### PR TITLE
docs: add Figma prototype links under ## Design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,16 @@ Fork → Branch → PR. See [CONTRIBUTING.md](CONTRIBUTING.md) (TBD).
 
 **Powered by Stellar – Decentralized health payments.**
 
+
+## Design
+
+Interactive Figma prototype flows for Health Watchers EMR.
+All links are view-only — no Figma account required.
+
+| # | Flow | Link |
+|---|------|------|
+| 1 | Login to Dashboard (success, error, MFA) | [View Prototype](https://www.figma.com/proto/fMSSNhPwYLewJWLDsA64DJ/Stellar?node-id=40-470&p=f&t=oXRhEZQ2VCN0s8YL-1&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1&starting-point-node-id=40%3A470&show-proto-sidebar=1) |
+| 2 | Register a Patient | [View Prototype](https://www.figma.com/proto/fMSSNhPwYLewJWLDsA64DJ/Stellar?node-id=13-1131&p=f&t=oXRhEZQ2VCN0s8YL-9&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1&starting-point-node-id=13%3A1131&show-proto-sidebar=1) |
+| 3 | Log an Encounter | [View Prototype](https://www.figma.com/proto/fMSSNhPwYLewJWLDsA64DJ/Stellar?node-id=13-1305&p=f&t=oXRhEZQ2VCN0s8YL-9&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1&starting-point-node-id=13%3A1305&show-proto-sidebar=1) |
+| 4 | Create and Confirm a Payment | [View Prototype](https://www.figma.com/proto/fMSSNhPwYLewJWLDsA64DJ/Stellar?node-id=5-844&p=f&t=oXRhEZQ2VCN0s8YL-9&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1&starting-point-node-id=5%3A844&show-proto-sidebar=1) |
+| 5 | Password Reset | [View Prototype](https://www.figma.com/proto/fMSSNhPwYLewJWLDsA64DJ/Stellar?node-id=40-470&p=f&t=oXRhEZQ2VCN0s8YL-1&scaling=min-zoom&content-scaling=fixed&page-id=0%3A1&starting-point-node-id=40%3A470&show-proto-sidebar=1) |


### PR DESCRIPTION
Closes #106

Uploading Screen Recording 2026-03-24 at 12.44.12 PM.mov…

## Summary
Built interactive Figma prototypes for all 5 UX flows as specified in the issue.

## Flows Completed
- [x] Flow 1 — Login to Dashboard (success, error state, MFA)
- [x] Flow 2 — Register a Patient (slide-over form)
- [x] Flow 3 — Log an Encounter (multi-step + AI summary)
- [x] Flow 4 — Create and Confirm a Payment (Stellar tx)
- [x] Flow 5 — Password Reset

## Prototype Links
All links are view-only, no Figma account needed.
See README.md → ## Design section.

## Transitions
- Slide-overs: Smart Animate, slide from right, 300ms ease-out
- Modals: Smart Animate, fade + scale, 200ms ease-out