### PR TITLE
fix: add robots.txt and noindex meta tag to block search engine indexing

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,10 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Health Watchers",
   description: "AI-assisted EMR powered by Stellar blockchain",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
fixes #49

Added robots.txt to block all search engine crawlers and a noindex, nofollow robots meta tag on all pages to prevent indexing of sensitive route patterns.

Changes:

robots.txt
 — disallows all crawlers via User-agent: * / Disallow: /
layout.tsx
 — adds robots: { index: false, follow: false } to the root metadata, which Next.js renders as <meta name="robots" content="noindex, nofollow"> on every page