### PR TITLE
fix: use network-aware Stellar explorer URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,11 @@ JWT_REFRESH_TOKEN_SECRET=dev-refresh-token-secret-change-in-production
 # WARNING: Mainnet transactions involve real money
 STELLAR_NETWORK=testnet
 
+# Stellar network for frontend (Next.js public variable)
+# Must match STELLAR_NETWORK value
+# Used to construct correct explorer URLs in the browser
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
 # Stellar secret key for blockchain transactions
 # This is a PRIVATE KEY - treat with extreme care
 # Format: Ed25519 private key starting with 'S'

--- a/apps/web/src/app/payments/PaymentsClient.tsx
+++ b/apps/web/src/app/payments/PaymentsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { ErrorMessage } from "@/components/ui";
+import { getStellarExplorerUrl } from "@/lib/stellar";
 
 interface Payment {
   id: string;
@@ -71,7 +72,7 @@ export default function PaymentsClient({ labels }: { labels: Labels }) {
               {p.txHash && (
                 <div className="mt-3 text-sm">
                   <a
-                    href={`https://stellar.expert/explorer/testnet/tx/${p.txHash}`}
+                    href={getStellarExplorerUrl(p.txHash, process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet')}
                     target="_blank"
                     rel="noreferrer"
                     aria-label={`${labels.view} transaction on Stellar Explorer (opens in new tab)`}

--- a/apps/web/src/app/payments/page.tsx
+++ b/apps/web/src/app/payments/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { PageWrapper, PageHeader, Card, CardContent } from '@/components/ui';
+import { getStellarExplorerUrl } from '@/lib/stellar';
 
 interface Payment {
   id: string;
@@ -55,7 +56,7 @@ export default function PaymentsPage() {
               {payment.txHash && (
                 <div className="pt-2">
                   <span className="font-medium text-secondary-900">Transaction:</span>{' '}
-                  <a href={`https://stellar.expert/explorer/testnet/tx/${payment.txHash}`} target="_blank" rel="noopener noreferrer"
+                  <a href={getStellarExplorerUrl(payment.txHash, process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet')} target="_blank" rel="noopener noreferrer"
                     className="text-primary-600 hover:text-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-md px-1 py-0.5 transition-colors">
                     View on Stellar Expert
                   </a>

--- a/apps/web/src/lib/stellar.ts
+++ b/apps/web/src/lib/stellar.ts
@@ -1,0 +1,6 @@
+export function getStellarExplorerUrl(txHash: string, network: string): string {
+  const baseUrl = network === 'mainnet'
+    ? 'https://stellar.expert/explorer/public/tx/'
+    : 'https://stellar.expert/explorer/testnet/tx/';
+  return `${baseUrl}${txHash}`;
+}


### PR DESCRIPTION
## Fix Stellar Explorer URL by Network

Resolves #45

### Changes
- Add `NEXT_PUBLIC_STELLAR_NETWORK` environment variable
- Create `getStellarExplorerUrl()` utility for dynamic explorer URLs
- Update payment components to use network-aware URLs

### Testing
- With `NEXT_PUBLIC_STELLAR_NETWORK=testnet`: links point to testnet explorer
- With `NEXT_PUBLIC_STELLAR_NETWORK=mainnet`: links point to mainnet explorer