### PR TITLE
Feat/patient search UI detail page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,11 @@ JWT_REFRESH_TOKEN_SECRET=dev-refresh-token-secret-change-in-production
 # WARNING: Mainnet transactions involve real money
 STELLAR_NETWORK=testnet
 
+# Stellar network for frontend (Next.js public variable)
+# Must match STELLAR_NETWORK value
+# Used to construct correct explorer URLs in the browser
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
 # Stellar secret key for blockchain transactions
 # This is a PRIVATE KEY - treat with extreme care
 # Format: Ed25519 private key starting with 'S'

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -16,7 +16,9 @@
     "name": "Full Name",
     "dob": "Date of Birth",
     "sex": "Sex",
-    "contact": "Contact"
+    "contact": "Contact",
+    "search": "Search patients by name...",
+    "view": "View"
   },
   "encounters": {
     "title": "Encounters",
@@ -36,5 +38,13 @@
     "amount": "Amount",
     "status": "Status",
     "view": "view"
+  },
+  "patientDetail": {
+    "back": "Back to Patients",
+    "loading": "Loading patient details...",
+    "error": "Failed to load patient details.",
+    "details": "Patient Details",
+    "encounters": "Encounter History",
+    "noEncounters": "No encounters recorded."
   }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -16,7 +16,9 @@
     "name": "Nom complet",
     "dob": "Date de naissance",
     "sex": "Sexe",
-    "contact": "Contact"
+    "contact": "Contact",
+    "search": "Rechercher des patients par nom...",
+    "view": "Voir"
   },
   "encounters": {
     "title": "Consultations",
@@ -36,5 +38,13 @@
     "amount": "Montant",
     "status": "Statut",
     "view": "voir"
+  },
+  "patientDetail": {
+    "back": "Retour aux Patients",
+    "loading": "Chargement des détails du patient...",
+    "error": "Impossible de charger les détails du patient.",
+    "details": "Détails du Patient",
+    "encounters": "Historique des Consultations",
+    "noEncounters": "Aucune consultation enregistrée."
   }
 }

--- a/apps/web/src/app/patients/PatientsClient.tsx
+++ b/apps/web/src/app/patients/PatientsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
 import { type Patient, formatDate } from "@health-watchers/types";
 import { ErrorMessage } from "@/components/ui";
 
@@ -13,17 +14,24 @@ interface Labels {
   dob: string;
   sex: string;
   contact: string;
+  search: string;
+  view: string;
 }
 
 export default function PatientsClient({ labels }: { labels: Labels }) {
   const [patients, setPatients] = useState<Patient[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const debounceTimer = useRef<NodeJS.Timeout>();
 
-  const fetchPatients = useCallback(() => {
+  const fetchPatients = useCallback((query?: string) => {
     setLoading(true);
     setError(null);
-    fetch("http://localhost:3001/api/v1/patients")
+    const url = query
+      ? `http://localhost:3001/api/v1/patients/search?q=${encodeURIComponent(query)}`
+      : "http://localhost:3001/api/v1/patients";
+    fetch(url)
       .then((res) => {
         if (!res.ok) throw new Error(`Request failed (${res.status})`);
         return res.json();
@@ -34,22 +42,34 @@ export default function PatientsClient({ labels }: { labels: Labels }) {
 
   useEffect(() => { fetchPatients(); }, [fetchPatients]);
 
-  if (loading) {
-    return (
-      <p role="status" aria-live="polite" className="px-4 py-8 text-gray-500">
-        {labels.loading}
-      </p>
-    );
-  }
-
-  if (error) {
-    return <ErrorMessage message={error} onRetry={fetchPatients} />;
-  }
+  const handleSearch = (value: string) => {
+    setSearchQuery(value);
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      fetchPatients(value || undefined);
+    }, 300);
+  };
 
   return (
     <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
       <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-6">{labels.title}</h1>
-      {patients.length === 0 ? (
+      <div className="mb-6">
+        <input
+          type="text"
+          placeholder={labels.search}
+          value={searchQuery}
+          onChange={(e) => handleSearch(e.target.value)}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          aria-label={labels.search}
+        />
+      </div>
+      {loading ? (
+        <p role="status" aria-live="polite" className="text-gray-500">
+          {labels.loading}
+        </p>
+      ) : error ? (
+        <ErrorMessage message={error} onRetry={() => fetchPatients(searchQuery || undefined)} />
+      ) : patients.length === 0 ? (
         <p role="status" className="text-gray-500">{labels.empty}</p>
       ) : (
         <>
@@ -67,6 +87,9 @@ export default function PatientsClient({ labels }: { labels: Labels }) {
                 <p className="text-gray-700">{p.sex}</p>
                 <p className="mt-2 text-xs text-gray-500 uppercase tracking-wide">{labels.contact}</p>
                 <p className="text-gray-700">{p.contactNumber || 'N/A'}</p>
+                <Link href={`/patients/${p._id}`} className="mt-3 inline-block px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">
+                  {labels.view}
+                </Link>
               </div>
             ))}
           </div>
@@ -81,6 +104,7 @@ export default function PatientsClient({ labels }: { labels: Labels }) {
                   <th scope="col" className="border border-gray-200 px-4 py-2 text-left">{labels.dob}</th>
                   <th scope="col" className="border border-gray-200 px-4 py-2 text-left">{labels.sex}</th>
                   <th scope="col" className="border border-gray-200 px-4 py-2 text-left">{labels.contact}</th>
+                  <th scope="col" className="border border-gray-200 px-4 py-2 text-left">{labels.view}</th>
                 </tr>
               </thead>
               <tbody>
@@ -91,6 +115,11 @@ export default function PatientsClient({ labels }: { labels: Labels }) {
                     <td className="border border-gray-200 px-4 py-2">{formatDate(p.dateOfBirth)}</td>
                     <td className="border border-gray-200 px-4 py-2">{p.sex}</td>
                     <td className="border border-gray-200 px-4 py-2">{p.contactNumber || 'N/A'}</td>
+                    <td className="border border-gray-200 px-4 py-2">
+                      <Link href={`/patients/${p._id}`} className="text-blue-600 hover:underline">
+                        {labels.view}
+                      </Link>
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
+++ b/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { type Patient, formatDate } from "@health-watchers/types";
+import { ErrorMessage } from "@/components/ui";
+
+interface Encounter {
+  _id: string;
+  chiefComplaint: string;
+  notes?: string;
+  createdAt: string;
+}
+
+interface Labels {
+  back: string;
+  loading: string;
+  error: string;
+  details: string;
+  encounters: string;
+  noEncounters: string;
+}
+
+export default function PatientDetailClient({ patientId, labels }: { patientId: string; labels: Labels }) {
+  const [patient, setPatient] = useState<Patient | null>(null);
+  const [encounters, setEncounters] = useState<Encounter[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      fetch(`http://localhost:3001/api/v1/patients/${patientId}`).then(r => r.json()),
+      fetch(`http://localhost:3001/api/v1/encounters/patient/${patientId}`).then(r => r.json()),
+    ])
+      .then(([patientRes, encountersRes]) => {
+        setPatient(patientRes.data);
+        setEncounters(encountersRes.data || []);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || "Failed to load patient details.");
+        setLoading(false);
+      });
+  }, [patientId]);
+
+  if (loading) {
+    return <p className="px-4 py-8 text-gray-500">{labels.loading}</p>;
+  }
+
+  if (error || !patient) {
+    return <ErrorMessage message={error || labels.error} onRetry={() => window.location.reload()} />;
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-8">
+      <Link href="/patients" className="text-blue-600 hover:underline mb-6 inline-block">
+        ← {labels.back}
+      </Link>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-6 mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">{patient.firstName} {patient.lastName}</h1>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+          <div>
+            <p className="text-xs text-gray-500 uppercase font-semibold">System ID</p>
+            <p className="text-gray-900">{patient.systemId}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 uppercase font-semibold">Date of Birth</p>
+            <p className="text-gray-900">{formatDate(patient.dateOfBirth)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 uppercase font-semibold">Sex</p>
+            <p className="text-gray-900">{patient.sex}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 uppercase font-semibold">Contact</p>
+            <p className="text-gray-900">{patient.contactNumber || 'N/A'}</p>
+          </div>
+          <div className="sm:col-span-2">
+            <p className="text-xs text-gray-500 uppercase font-semibold">Address</p>
+            <p className="text-gray-900">{patient.address || 'N/A'}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">{labels.encounters}</h2>
+        {encounters.length === 0 ? (
+          <p className="text-gray-500">{labels.noEncounters}</p>
+        ) : (
+          <div className="space-y-4">
+            {encounters.map((e) => (
+              <div key={e._id} className="bg-white rounded border border-gray-200 p-4">
+                <p className="text-xs text-gray-500 uppercase font-semibold">Chief Complaint</p>
+                <p className="text-gray-900 font-medium">{e.chiefComplaint}</p>
+                {e.notes && (
+                  <>
+                    <p className="text-xs text-gray-500 uppercase font-semibold mt-2">Notes</p>
+                    <p className="text-gray-700">{e.notes}</p>
+                  </>
+                )}
+                <p className="text-xs text-gray-500 mt-2">{formatDate(e.createdAt)}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/patients/[id]/page.tsx
+++ b/apps/web/src/app/patients/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { useTranslations } from "next-intl";
+import PatientDetailClient from "./PatientDetailClient";
+
+export default function PatientDetailPage({ params }: { params: { id: string } }) {
+  const t = useTranslations("patientDetail");
+  return (
+    <PatientDetailClient
+      patientId={params.id}
+      labels={{
+        back: t("back"),
+        loading: t("loading"),
+        error: t("error"),
+        details: t("details"),
+        encounters: t("encounters"),
+        noEncounters: t("noEncounters"),
+      }}
+    />
+  );
+}

--- a/apps/web/src/app/patients/page.tsx
+++ b/apps/web/src/app/patients/page.tsx
@@ -14,6 +14,8 @@ export default function PatientsPage() {
         dob: t("dob"),
         sex: t("sex"),
         contact: t("contact"),
+        search: t("search"),
+        view: t("view"),
       }}
     />
   );

--- a/apps/web/src/app/payments/PaymentsClient.tsx
+++ b/apps/web/src/app/payments/PaymentsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { ErrorMessage } from "@/components/ui";
+import { getStellarExplorerUrl } from "@/lib/stellar";
 
 interface Payment {
   id: string;
@@ -71,7 +72,7 @@ export default function PaymentsClient({ labels }: { labels: Labels }) {
               {p.txHash && (
                 <div className="mt-3 text-sm">
                   <a
-                    href={`https://stellar.expert/explorer/testnet/tx/${p.txHash}`}
+                    href={getStellarExplorerUrl(p.txHash, process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet')}
                     target="_blank"
                     rel="noreferrer"
                     aria-label={`${labels.view} transaction on Stellar Explorer (opens in new tab)`}

--- a/apps/web/src/app/payments/page.tsx
+++ b/apps/web/src/app/payments/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { PageWrapper, PageHeader, Card, CardContent } from '@/components/ui';
+import { getStellarExplorerUrl } from '@/lib/stellar';
 
 interface Payment {
   id: string;
@@ -55,7 +56,7 @@ export default function PaymentsPage() {
               {payment.txHash && (
                 <div className="pt-2">
                   <span className="font-medium text-secondary-900">Transaction:</span>{' '}
-                  <a href={`https://stellar.expert/explorer/testnet/tx/${payment.txHash}`} target="_blank" rel="noopener noreferrer"
+                  <a href={getStellarExplorerUrl(payment.txHash, process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet')} target="_blank" rel="noopener noreferrer"
                     className="text-primary-600 hover:text-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 rounded-md px-1 py-0.5 transition-colors">
                     View on Stellar Expert
                   </a>

--- a/apps/web/src/lib/stellar.ts
+++ b/apps/web/src/lib/stellar.ts
@@ -1,0 +1,6 @@
+export function getStellarExplorerUrl(txHash: string, network: string): string {
+  const baseUrl = network === 'mainnet'
+    ? 'https://stellar.expert/explorer/public/tx/'
+    : 'https://stellar.expert/explorer/testnet/tx/';
+  return `${baseUrl}${txHash}`;
+}


### PR DESCRIPTION
Add a debounced search input to patients/page.tsx that calls GET /patients/search?q= after 300ms
Create apps/web/src/app/patients/[id]/page.tsx as a patient detail page
Add a 'View' button/link in the patients table
The detail page should fetch patient, encounters, and payments in parallel

Closes #47