### PR TITLE
fix(rate-limit): add per-clinic AI/payment limiters, forgot-password,…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,14 @@ GEMINI_API_KEY=your-gemini-api-key-here
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 
 # ============================================================
+# Rate Limiting
+# ============================================================
+# Optional: Redis URL for distributed rate limiting across multiple API instances.
+# Falls back to in-memory store when not set (single-instance only).
+# Example: redis://localhost:6379
+REDIS_URL=
+
+# ============================================================
 # Request Body Size Limits
 # ============================================================
 MAX_REQUEST_BODY_SIZE=50kb

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,7 +18,7 @@ import aiRoutes from './modules/ai/ai.routes';
 import { setupSwagger } from './docs/swagger';
 import dashboardRoutes from './modules/dashboard/dashboard.routes';
 import { errorHandler } from './middlewares/error.middleware';
-import { authLimiter, generalLimiter } from './middlewares/rate-limit.middleware';
+import { authLimiter, forgotPasswordLimiter, aiLimiter, paymentLimiter, generalLimiter } from './middlewares/rate-limit.middleware';
 import { appointmentRoutes } from './modules/appointments/appointments.controller';
 import {
   startPaymentExpirationJob,
@@ -75,15 +75,16 @@ app.get('/health', (_req, res) =>
 
 // ── Routes ────────────────────────────────────────────────────────────────────
 app.use('/api/v1', generalLimiter);
+app.use('/api/v1/auth/forgot-password', forgotPasswordLimiter);
 app.use('/api/v1/auth', authLimiter, authRoutes);
 app.use('/api/v1/clinics', clinicRoutes);
 app.use('/api/v1/users', userRoutes);
 app.use('/api/v1/patients', patientRoutes);
 app.use('/api/v1/encounters', encounterRoutes);
-app.use('/api/v1/payments', paymentRoutes);
+app.use('/api/v1/payments', paymentLimiter, paymentRoutes);
 app.use('/api/v1/webhooks', webhookRoutes);
 app.use('/api/v1/audit-logs', auditLogRoutes);
-app.use('/api/v1/ai', express.json({ limit: aiLimit }), aiRoutes);
+app.use('/api/v1/ai', aiLimiter, express.json({ limit: aiLimit }), aiRoutes);
 app.use('/api/v1/dashboard', dashboardRoutes);
 app.use('/api/v1/appointments', appointmentRoutes);
 

--- a/apps/api/src/middlewares/rate-limit.middleware.ts
+++ b/apps/api/src/middlewares/rate-limit.middleware.ts
@@ -1,48 +1,111 @@
 import rateLimit, { type Options, type RateLimitRequestHandler } from 'express-rate-limit';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 
-const makeHandler = (windowMs: number, message: Options['message']) =>
-  (req: Request, res: Response, _next: NextFunction, options: Options): void => {
-    const retryAfter = Math.ceil(windowMs / 1000);
-    res.set('Retry-After', String(retryAfter));
+// ── Retry-After handler ───────────────────────────────────────────────────────
+const makeHandler =
+  (windowMs: number, message: Options['message']) =>
+  (_req: Request, res: Response, _next: unknown, _options: Options): void => {
+    res.set('Retry-After', String(Math.ceil(windowMs / 1000)));
     res.status(429).json(message);
   };
 
-/**
- * Strict limiter for auth endpoints (login, refresh).
- * 10 requests per 15 minutes per IP.
- * Returns 429 with Retry-After and X-RateLimit-* headers.
- */
-export const authLimiter: RateLimitRequestHandler = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
+// ── Optional Redis store ──────────────────────────────────────────────────────
+// Falls back to in-memory when REDIS_URL is not set.
+async function buildStore() {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) return undefined; // in-memory fallback
+
+  try {
+    const { createClient } = await import('redis');
+    const { RedisStore } = await import('rate-limit-redis');
+    const client = createClient({ url: redisUrl });
+    client.on('error', (err: Error) =>
+      console.error('[rate-limit] Redis error, falling back to in-memory:', err.message),
+    );
+    await client.connect();
+    return new RedisStore({ sendCommand: (...args: string[]) => client.sendCommand(args) });
+  } catch {
+    console.warn('[rate-limit] rate-limit-redis not installed, using in-memory store');
+    return undefined;
+  }
+}
+
+// Shared store promise — resolved once at startup
+const storePromise = buildStore();
+
+function make(windowMs: number, max: number, message: object): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message,
+    handler: makeHandler(windowMs, message),
+    // store is set lazily; in-memory is used until Redis resolves
+    store: undefined,
+  });
+}
+
+// Attach Redis store once it resolves (no-op if undefined)
+storePromise.then((store) => {
+  if (store) {
+    [authLimiter, forgotPasswordLimiter, aiLimiter, paymentLimiter, generalLimiter].forEach(
+      (limiter) => {
+        // express-rate-limit exposes the store on the handler object
+        (limiter as any).store = store;
+      },
+    );
+  }
+});
+
+// ── Auth: 10 req / 15 min per IP ──────────────────────────────────────────────
+export const authLimiter: RateLimitRequestHandler = make(
+  15 * 60 * 1000,
+  10,
+  { error: 'TooManyRequests', message: 'Too many login attempts. Try again in 15 minutes.' },
+);
+
+// ── Forgot-password: 5 req / 1 hour per IP ───────────────────────────────────
+export const forgotPasswordLimiter: RateLimitRequestHandler = make(
+  60 * 60 * 1000,
+  5,
+  { error: 'TooManyRequests', message: 'Too many password reset requests. Try again in 1 hour.' },
+);
+
+// ── AI endpoints: 10 req / 1 min per clinic ──────────────────────────────────
+export const aiLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: 60 * 1000,
   max: 10,
-  standardHeaders: true,  // sets X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+  standardHeaders: true,
   legacyHeaders: false,
-  message: {
+  keyGenerator: (req: Request) => req.user?.clinicId ?? req.ip ?? 'unknown',
+  message: { error: 'TooManyRequests', message: 'AI rate limit exceeded. Try again in 1 minute.' },
+  handler: makeHandler(60 * 1000, {
     error: 'TooManyRequests',
-    message: 'Too many requests from this IP, please try again after 15 minutes.',
-  },
-  handler: makeHandler(15 * 60 * 1000, {
-    error: 'TooManyRequests',
-    message: 'Too many requests from this IP, please try again after 15 minutes.',
+    message: 'AI rate limit exceeded. Try again in 1 minute.',
   }),
 });
 
-/**
- * General limiter for all API routes.
- * 100 requests per minute per IP.
- */
-export const generalLimiter: RateLimitRequestHandler = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 100,
+// ── Payment intent: 20 req / 1 min per clinic ────────────────────────────────
+export const paymentLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: (req: Request) => req.user?.clinicId ?? req.ip ?? 'unknown',
   message: {
     error: 'TooManyRequests',
-    message: 'Too many requests from this IP, please try again after 1 minute.',
+    message: 'Payment rate limit exceeded. Try again in 1 minute.',
   },
   handler: makeHandler(60 * 1000, {
     error: 'TooManyRequests',
-    message: 'Too many requests from this IP, please try again after 1 minute.',
+    message: 'Payment rate limit exceeded. Try again in 1 minute.',
   }),
 });
+
+// ── General: 300 req / 15 min per IP ─────────────────────────────────────────
+export const generalLimiter: RateLimitRequestHandler = make(
+  15 * 60 * 1000,
+  300,
+  { error: 'TooManyRequests', message: 'Too many requests. Try again in 15 minutes.' },
+);


### PR DESCRIPTION
              
  `fix/rate-limiting` → `main`                                                                                        
                                                                                                                      
  Title: fix(rate-limit): add per-clinic AI/payment limiters, forgot-password limiter, and Redis store                
                                                                                                                      
  Description:                                                                                                        
                                                                                                                      
  The API only had a basic auth limiter and a general limiter. High-value endpoints (AI summarize, payment intent,    
  forgot-password) had no dedicated limits, exposing the system to abuse and cost amplification attacks.              
                                                                                                                      
  Changes:                                                                                                            
                                                                                                                      
  `rate-limit.middleware.ts`:                                                                                         
                                                                                                                      
  - authLimiter — 10 req / 15 min per IP (unchanged)                                                                  
  - forgotPasswordLimiter — 5 req / 1 hr per IP                                                                       
  - aiLimiter — 10 req / 1 min per clinic (keyGenerator uses clinicId from JWT)                                       
  - paymentLimiter — 20 req / 1 min per clinic                                                                        
  - generalLimiter — 300 req / 15 min per IP (was 100/min)                                                            
  - Redis store: lazily attaches rate-limit-redis when REDIS_URL is set; silently falls back to in-memory if Redis is 
  unavailable or package not installed                                                                                
                                                                                                                      
  `app.ts`:                                                                                                           
                                                                                                                      
  - forgotPasswordLimiter registered at /api/v1/auth/forgot-password before authRoutes                                
  - aiLimiter applied to /api/v1/ai                                                                                   
  - paymentLimiter applied to /api/v1/payments                                                                        
                                                                                                                      
  `.env.example`:                                                                                                     
                                                                                                                      
  - Added REDIS_URL with documentation comment                                                                        
                                                                                                                      
  All limiters return:                                                                                                
                                                                                                                      
  - 429 Too Many Requests                                                                                             
  - Retry-After header                                                                                                
  - X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset headers (standardHeaders: true)    
  
  closes #317                   
                                                                             