### PR TITLE
fix(cors): add full CORS middleware with ALLOWED_ORIGINS config

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -52,6 +52,25 @@ app.use(
   }),
 );
 app.use(compression());
+
+// ── CORS ──────────────────────────────────────────────────────────────────────
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      // Allow server-to-server requests (no origin) and listed origins
+      if (!origin || allowedOrigins.includes(origin)) return callback(null, true);
+      return callback(new Error(`CORS: origin '${origin}' not allowed`));
+    },
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  }),
+);
 app.options('*', cors());
 
 // ── HTTP request logging ──────────────────────────────────────────────────────


### PR DESCRIPTION
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                      
  `fix/cors-configuration` → `main`                                                                                   
                                                                                                                      
  Title: fix(cors): configure CORS middleware with environment-based origin allowlist                                 
                                                                                                                      
  Description:                                                                                                        
                                                                                                                      
  The API had no CORS configuration, causing browsers to block all cross-origin requests from the frontend            
  (localhost:3000 → localhost:3001). Preflight OPTIONS requests were also failing.                                    
                                                                                                                      
  Changes:                                                                                                            
                                                                                                                      
  - Added full cors() middleware to app.ts before route handlers                                                      
  - Origins are controlled via ALLOWED_ORIGINS env var (comma-separated); defaults to http://localhost:3000           
  - credentials: true to support cookie/token-based auth                                                              
  - Allowed methods: GET, POST, PUT, DELETE, OPTIONS                                                                  
  - Allowed headers: Content-Type, Authorization                                                                      
  - Kept explicit app.options('*', cors()) preflight handler                                                          
                                                                                                                      
  Testing:                                                                                                            
                                                                                                                      
  - Cross-origin requests from localhost:3000 to localhost:3001 now succeed                                           
  - Requests from unlisted origins are rejected with a CORS error                                                     
  - Preflight OPTIONS returns 200 with correct headers                                                                
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
closes #318