### PR TITLE
feat(auth): refresh token rotation with JTI, logout, and logout-all

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -23,7 +23,9 @@ import {
   signTempToken,
   verifyRefreshToken,
   verifyTempToken,
+  REFRESH_TOKEN_EXPIRY_MS,
 } from './token.service';
+import { RefreshTokenModel } from './models/refresh-token.model';
 import { totpService } from './totp.service';
 
 const router = Router();
@@ -142,9 +144,17 @@ router.post(
     }
 
     const p = { userId: user.id, role: user.role, clinicId: String(user.clinicId) };
+    const { token: refreshToken, jti, family } = signRefreshToken(p);
+    await RefreshTokenModel.create({
+      jti,
+      userId: user.id,
+      family,
+      consumed: false,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS),
+    });
     return res.json({
       status: 'success',
-      data: { accessToken: signAccessToken(p), refreshToken: signRefreshToken(p) },
+      data: { accessToken: signAccessToken(p), refreshToken },
     });
   },
 );
@@ -164,19 +174,37 @@ router.post(
     if (!decoded)
       return res.status(401).json({ error: 'Unauthorized', message: 'Invalid refresh token' });
 
+    const existing = await RefreshTokenModel.findOne({ jti: decoded.jti });
+    if (!existing)
+      return res.status(401).json({ error: 'Unauthorized', message: 'Invalid refresh token' });
+
+    // Replay attack: token already consumed — revoke entire family
+    if (existing.consumed) {
+      await RefreshTokenModel.deleteMany({ family: existing.family });
+      return res.status(401).json({ error: 'Unauthorized', message: 'Token reuse detected — all sessions revoked' });
+    }
+
     const user = await UserModel.findById(decoded.userId);
     if (!user || !user.isActive)
       return res.status(401).json({ error: 'Unauthorized', message: 'Invalid refresh token' });
 
+    // Mark old token consumed and issue new one (rotation)
+    existing.consumed = true;
+    await existing.save();
+
+    const p = { userId: user.id, role: user.role, clinicId: String(user.clinicId) };
+    const { token: refreshToken, jti, family } = signRefreshToken(p, decoded.family);
+    await RefreshTokenModel.create({
+      jti,
+      userId: user.id,
+      family,
+      consumed: false,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS),
+    });
+
     return res.json({
       status: 'success',
-      data: {
-        accessToken: signAccessToken({
-          userId: user.id,
-          role: user.role,
-          clinicId: String(user.clinicId),
-        }),
-      },
+      data: { accessToken: signAccessToken(p), refreshToken },
     });
   },
 );
@@ -187,11 +215,30 @@ router.post(
  *   post:
  *     summary: Invalidate the current refresh token
  *     tags: [Auth]
+ */
+router.post(
+  '/logout',
+  validateRequest({ body: refreshSchema }),
+  async (req: RefreshReq, res: Response) => {
+    const decoded = verifyRefreshToken(req.body.refreshToken);
+    if (decoded) {
+      await RefreshTokenModel.deleteOne({ jti: decoded.jti });
+    }
+    return res.json({ status: 'success', data: { loggedOut: true } });
+  },
+);
+
+/**
+ * @swagger
+ * /auth/logout-all:
+ *   post:
+ *     summary: Revoke all refresh tokens for the authenticated user
+ *     tags: [Auth]
  *     security:
  *       - bearerAuth: []
  */
-router.post('/logout', authenticate, async (req: Request, res: Response) => {
-  await UserModel.findByIdAndUpdate(req.user!.userId, { refreshTokenHash: undefined });
+router.post('/logout-all', authenticate, async (req: Request, res: Response) => {
+  await RefreshTokenModel.deleteMany({ userId: req.user!.userId });
   return res.json({ status: 'success', data: { loggedOut: true } });
 });
 
@@ -268,9 +315,17 @@ router.post(
     if (!valid) return res.status(400).json({ error: 'InvalidCode', message: 'Invalid TOTP code' });
 
     const p = { userId: user.id, role: user.role, clinicId: String(user.clinicId) };
+    const { token: refreshToken, jti, family } = signRefreshToken(p);
+    await RefreshTokenModel.create({
+      jti,
+      userId: user.id,
+      family,
+      consumed: false,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS),
+    });
     return res.json({
       status: 'success',
-      data: { accessToken: signAccessToken(p), refreshToken: signRefreshToken(p) },
+      data: { accessToken: signAccessToken(p), refreshToken },
     });
   },
 );

--- a/apps/api/src/modules/auth/models/refresh-token.model.ts
+++ b/apps/api/src/modules/auth/models/refresh-token.model.ts
@@ -1,0 +1,26 @@
+import { Schema, model, models } from 'mongoose';
+
+export interface RefreshToken {
+  jti: string;
+  userId: string;
+  family: string;
+  consumed: boolean;
+  expiresAt: Date;
+}
+
+const refreshTokenSchema = new Schema<RefreshToken>(
+  {
+    jti:       { type: String, required: true, unique: true, index: true },
+    userId:    { type: String, required: true, index: true },
+    family:    { type: String, required: true, index: true },
+    consumed:  { type: Boolean, default: false },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: false, versionKey: false },
+);
+
+// TTL index — MongoDB auto-removes expired documents
+refreshTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const RefreshTokenModel =
+  models.RefreshToken || model<RefreshToken>('RefreshToken', refreshTokenSchema);

--- a/apps/api/src/modules/auth/refresh-token-rotation.test.ts
+++ b/apps/api/src/modules/auth/refresh-token-rotation.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for refresh token rotation, logout, and logout-all.
+ *
+ * Tests cover:
+ * - Normal rotation: old JTI consumed, new JTI issued
+ * - Replay attack: consumed JTI revokes entire family
+ * - Logout: deletes the specific JTI
+ * - Logout-all: deletes all tokens for the user
+ * - Invalid/missing token handling
+ */
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret',
+      refreshTokenSecret: 'test-refresh-secret',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+  },
+}));
+
+jest.mock('@api/modules/auth/models/user.model', () => ({
+  UserModel: { findById: jest.fn() },
+}));
+
+jest.mock('@api/modules/auth/models/refresh-token.model', () => ({
+  RefreshTokenModel: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    deleteOne: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import { UserModel } from '@api/modules/auth/models/user.model';
+import { RefreshTokenModel } from '@api/modules/auth/models/refresh-token.model';
+import {
+  signRefreshToken,
+  verifyRefreshToken,
+  signAccessToken,
+  REFRESH_TOKEN_EXPIRY_MS,
+} from './token.service';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRes() {
+  const res: Record<string, jest.Mock> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as unknown as { status: jest.Mock; json: jest.Mock };
+}
+
+const USER_ID = '507f1f77bcf86cd799439011';
+const CLINIC_ID = '507f1f77bcf86cd799439022';
+const mockUser = { id: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID, isActive: true };
+
+// ── Inline handler logic (mirrors auth.controller.ts) ─────────────────────────
+
+async function refreshHandler(body: { refreshToken: string }, res: ReturnType<typeof makeRes>) {
+  const decoded = verifyRefreshToken(body.refreshToken);
+  if (!decoded)
+    return res.status(401).json({ error: 'Unauthorized', message: 'Invalid refresh token' });
+
+  const existing = await (RefreshTokenModel as any).findOne({ jti: decoded.jti });
+  if (!existing)
+    return res.status(401).json({ error: 'Unauthorized', message: 'Invalid refresh token' });
+
+  if (existing.consumed) {
+    await (RefreshTokenModel as any).deleteMany({ family: existing.family });
+    return res.status(401).json({ error: 'Unauthorized', message: 'Token reuse detected — all sessions revoked' });
+  }
+
+  const user = await (UserModel as any).findById(decoded.userId);
+  if (!user || !user.isActive)
+    return res.status(401).json({ error: 'Unauthorized', message: 'Invalid refresh token' });
+
+  existing.consumed = true;
+  await existing.save();
+
+  const p = { userId: user.id, role: user.role, clinicId: String(user.clinicId) };
+  const { token: refreshToken, jti, family } = signRefreshToken(p, decoded.family);
+  await (RefreshTokenModel as any).create({
+    jti,
+    userId: user.id,
+    family,
+    consumed: false,
+    expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS),
+  });
+
+  return res.json({
+    status: 'success',
+    data: { accessToken: signAccessToken(p), refreshToken },
+  });
+}
+
+async function logoutHandler(body: { refreshToken: string }, res: ReturnType<typeof makeRes>) {
+  const decoded = verifyRefreshToken(body.refreshToken);
+  if (decoded) {
+    await (RefreshTokenModel as any).deleteOne({ jti: decoded.jti });
+  }
+  return res.json({ status: 'success', data: { loggedOut: true } });
+}
+
+async function logoutAllHandler(userId: string, res: ReturnType<typeof makeRes>) {
+  await (RefreshTokenModel as any).deleteMany({ userId });
+  return res.json({ status: 'success', data: { loggedOut: true } });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Refresh token rotation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('issues new access + refresh tokens and marks old JTI consumed', async () => {
+    const { token, jti, family } = signRefreshToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    const existing = { jti, family, consumed: false, save: saveMock };
+
+    (RefreshTokenModel.findOne as jest.Mock).mockResolvedValue(existing);
+    (UserModel.findById as jest.Mock).mockResolvedValue(mockUser);
+    (RefreshTokenModel.create as jest.Mock).mockResolvedValue({});
+    const res = makeRes();
+
+    await refreshHandler({ refreshToken: token }, res);
+
+    expect(existing.consumed).toBe(true);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(RefreshTokenModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({ family, consumed: false }),
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'success',
+        data: expect.objectContaining({ accessToken: expect.any(String), refreshToken: expect.any(String) }),
+      }),
+    );
+  });
+
+  it('new refresh token has a different JTI than the old one', async () => {
+    const { token, jti, family } = signRefreshToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    (RefreshTokenModel.findOne as jest.Mock).mockResolvedValue({ jti, family, consumed: false, save: saveMock });
+    (UserModel.findById as jest.Mock).mockResolvedValue(mockUser);
+    (RefreshTokenModel.create as jest.Mock).mockResolvedValue({});
+    const res = makeRes();
+
+    await refreshHandler({ refreshToken: token }, res);
+
+    const newJti = (RefreshTokenModel.create as jest.Mock).mock.calls[0][0].jti;
+    expect(newJti).not.toBe(jti);
+  });
+
+  it('preserves the token family across rotation', async () => {
+    const { token, jti, family } = signRefreshToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+    const saveMock = jest.fn().mockResolvedValue(undefined);
+    (RefreshTokenModel.findOne as jest.Mock).mockResolvedValue({ jti, family, consumed: false, save: saveMock });
+    (UserModel.findById as jest.Mock).mockResolvedValue(mockUser);
+    (RefreshTokenModel.create as jest.Mock).mockResolvedValue({});
+    const res = makeRes();
+
+    await refreshHandler({ refreshToken: token }, res);
+
+    const createdFamily = (RefreshTokenModel.create as jest.Mock).mock.calls[0][0].family;
+    expect(createdFamily).toBe(family);
+  });
+
+  it('detects replay attack: revokes entire family when consumed JTI is presented', async () => {
+    const { token, jti, family } = signRefreshToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+    (RefreshTokenModel.findOne as jest.Mock).mockResolvedValue({ jti, family, consumed: true });
+    const res = makeRes();
+
+    await refreshHandler({ refreshToken: token }, res);
+
+    expect(RefreshTokenModel.deleteMany).toHaveBeenCalledWith({ family });
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized' }));
+  });
+
+  it('returns 401 when JTI not found in DB (already deleted/expired)', async () => {
+    const { token } = signRefreshToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+    (RefreshTokenModel.findOne as jest.Mock).mockResolvedValue(null);
+    const res = makeRes();
+
+    await refreshHandler({ refreshToken: token }, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 401 for invalid JWT signature', async () => {
+    const res = makeRes();
+    await refreshHandler({ refreshToken: 'invalid.token.here' }, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(RefreshTokenModel.findOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/logout', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deletes the JTI from DB and returns loggedOut: true', async () => {
+    const { token, jti } = signRefreshToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+    (RefreshTokenModel.deleteOne as jest.Mock).mockResolvedValue({ deletedCount: 1 });
+    const res = makeRes();
+
+    await logoutHandler({ refreshToken: token }, res);
+
+    expect(RefreshTokenModel.deleteOne).toHaveBeenCalledWith({ jti });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: { loggedOut: true } }));
+  });
+
+  it('returns 200 even for an invalid token (graceful logout)', async () => {
+    const res = makeRes();
+    await logoutHandler({ refreshToken: 'bad.token' }, res);
+    expect(RefreshTokenModel.deleteOne).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }));
+  });
+});
+
+describe('POST /auth/logout-all', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deletes all tokens for the user', async () => {
+    (RefreshTokenModel.deleteMany as jest.Mock).mockResolvedValue({ deletedCount: 3 });
+    const res = makeRes();
+
+    await logoutAllHandler(USER_ID, res);
+
+    expect(RefreshTokenModel.deleteMany).toHaveBeenCalledWith({ userId: USER_ID });
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: { loggedOut: true } }));
+  });
+});

--- a/apps/api/src/modules/auth/token.service.test.ts
+++ b/apps/api/src/modules/auth/token.service.test.ts
@@ -45,8 +45,8 @@ describe('Token Service', () => {
   });
 
   describe('signRefreshToken', () => {
-    it('should sign a refresh token with issuer and audience claims', () => {
-      const token = signRefreshToken(mockPayload);
+    it('should sign a refresh token with issuer, audience, jti, and family claims', () => {
+      const { token, jti, family } = signRefreshToken(mockPayload);
       const decoded = jwt.decode(token, { complete: true });
 
       expect(decoded).toBeTruthy();
@@ -56,6 +56,8 @@ describe('Token Service', () => {
         clinicId: mockPayload.clinicId,
         iss: 'health-watchers-api',
         aud: 'health-watchers-client',
+        jti,
+        family,
       });
     });
   });
@@ -174,16 +176,18 @@ describe('Token Service', () => {
   });
 
   describe('verifyRefreshToken', () => {
-    it('should verify a valid refresh token', () => {
-      const token = signRefreshToken(mockPayload);
+    it('should verify a valid refresh token and return payload with jti and family', () => {
+      const { token } = signRefreshToken(mockPayload);
       const result = verifyRefreshToken(token);
 
-      expect(result).toEqual(mockPayload);
+      expect(result).toMatchObject(mockPayload);
+      expect(result?.jti).toBeDefined();
+      expect(result?.family).toBeDefined();
     });
 
     it('should reject a token with wrong issuer', () => {
       const tokenWithWrongIssuer = jwt.sign(
-        mockPayload,
+        { ...mockPayload, jti: 'test-jti', family: 'test-family' },
         'test-refresh-secret',
         {
           expiresIn: '7d',
@@ -198,7 +202,7 @@ describe('Token Service', () => {
 
     it('should reject a token with wrong audience', () => {
       const tokenWithWrongAudience = jwt.sign(
-        mockPayload,
+        { ...mockPayload, jti: 'test-jti', family: 'test-family' },
         'test-refresh-secret',
         {
           expiresIn: '7d',

--- a/apps/api/src/modules/auth/token.service.ts
+++ b/apps/api/src/modules/auth/token.service.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { config } from '@health-watchers/config';
 
@@ -10,12 +11,15 @@ export interface TokenPayload {
 interface JwtPayload extends TokenPayload {
   iss: string;
   aud: string;
+  jti?: string;
+  family?: string;
 }
 
 const JWT_ISSUER = config.jwt.issuer;
 const JWT_AUDIENCE = config.jwt.audience;
 const ACCESS_TOKEN_EXPIRY = '15m';
-const REFRESH_TOKEN_EXPIRY = '7d';
+export const REFRESH_TOKEN_EXPIRY = '7d';
+export const REFRESH_TOKEN_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 const TEMP_TOKEN_EXPIRY = '5m';
 
 export function signAccessToken(payload: TokenPayload): string {
@@ -30,9 +34,17 @@ export function signAccessToken(payload: TokenPayload): string {
   );
 }
 
-export function signRefreshToken(payload: TokenPayload): string {
-  return jwt.sign(
-    payload,
+export interface RefreshTokenMeta {
+  token: string;
+  jti: string;
+  family: string;
+}
+
+export function signRefreshToken(payload: TokenPayload, family?: string): RefreshTokenMeta {
+  const jti = crypto.randomUUID();
+  const tokenFamily = family ?? crypto.randomUUID();
+  const token = jwt.sign(
+    { ...payload, jti, family: tokenFamily },
     config.jwt.refreshTokenSecret,
     {
       expiresIn: REFRESH_TOKEN_EXPIRY,
@@ -40,6 +52,7 @@ export function signRefreshToken(payload: TokenPayload): string {
       audience: JWT_AUDIENCE,
     }
   );
+  return { token, jti, family: tokenFamily };
 }
 
 export function signTempToken(userId: string): string {
@@ -70,16 +83,24 @@ export function verifyAccessToken(token: string): TokenPayload | null {
   }
 }
 
-export function verifyRefreshToken(token: string): TokenPayload | null {
+export interface RefreshTokenPayload extends TokenPayload {
+  jti: string;
+  family: string;
+}
+
+export function verifyRefreshToken(token: string): RefreshTokenPayload | null {
   try {
     const decoded = jwt.verify(token, config.jwt.refreshTokenSecret, {
       issuer: JWT_ISSUER,
       audience: JWT_AUDIENCE,
     }) as JwtPayload;
+    if (!decoded.jti || !decoded.family) return null;
     return {
       userId: decoded.userId,
       role: decoded.role,
       clinicId: decoded.clinicId,
+      jti: decoded.jti,
+      family: decoded.family,
     };
   } catch (error) {
     return null;


### PR DESCRIPTION
                                                                                    closes #311
                                                                                                                      
  `feature/refresh-token-rotation` → main                                                                             
                                                                                                                      
  Title: feat(auth): refresh token rotation with JTI tracking and logout endpoints                                    
                                                                                                                      
  Description:                                                                                                        
                                                                                                                      
  Addresses the security vulnerability where stolen refresh tokens remained valid for 7 days with no revocation       
  mechanism.                                                                                                          
                                                                                                                      
  Changes:                                                                                                            
                                                                                                                      
  - New RefreshToken model (jti, userId, family, consumed, expiresAt) with a MongoDB TTL index for automatic cleanup. 
  - signRefreshToken now returns { token, jti, family } and embeds both claims in the JWT.                            
  - verifyRefreshToken now returns jti and family alongside the existing payload.                                     
  - POST /api/v1/auth/refresh — marks the presented JTI as consumed and issues a new token in the same family. If a   
  consumed JTI is presented (replay attack), the entire token family is revoked.                                      
  - POST /api/v1/auth/logout — accepts a refresh token and deletes its JTI from the DB.                               
  - POST /api/v1/auth/logout-all — deletes all refresh tokens for the authenticated user.                             
                                                                                                                      
  Files changed:                                                                                                      
                                                                                                                      
  - apps/api/src/modules/auth/models/refresh-token.model.ts (new)                                                     
  - apps/api/src/modules/auth/token.service.ts                                                                        
  - apps/api/src/modules/auth/auth.controller.ts                                                                      
  - apps/api/src/modules/auth/token.service.test.ts — updated for new signRefreshToken API                            
  - apps/api/src/modules/auth/refresh-token-rotation.test.ts (new — 9 tests)                                          
                                                                                                                      
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
               