### PR TITLE
feat(logging): replace console.* with structured pino logger (#322)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,9 +1,10 @@
 import './config/env'; // must be first — validates env vars
+import crypto from 'crypto';
 import express from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import compression from 'compression';
-import morgan from 'morgan';
+import pinoHttp from 'pino-http';
 import mongoSanitize from 'express-mongo-sanitize';
 import { connectDB } from './config/db';
 import { authRoutes } from './modules/auth/auth.controller';
@@ -54,13 +55,15 @@ app.use(
 app.use(compression());
 app.options('*', cors());
 
-// ── HTTP request logging ──────────────────────────────────────────────────────
+// ── HTTP request logging with correlation ID ──────────────────────────────────
 const isProd = process.env.NODE_ENV === 'production';
-const morganStream = { write: (msg: string) => logger.info(msg.trimEnd()) };
 app.use(
-  morgan(isProd ? 'combined' : 'dev', {
-    stream: morganStream,
-  skip: (req: express.Request) => isProd && req.path === '/health',
+  pinoHttp({
+    logger,
+    genReqId: (req) =>
+      (req.headers['x-request-id'] as string) ?? crypto.randomUUID(),
+    autoLogging: { ignore: (req) => isProd && req.url === '/health' },
+    redact: ['req.headers.authorization'],
   }),
 );
 

--- a/apps/api/src/config/db.ts
+++ b/apps/api/src/config/db.ts
@@ -1,11 +1,12 @@
 import mongoose from 'mongoose';
 import { config } from '@health-watchers/config';
+import logger from '../utils/logger';
 
 export async function connectDB(): Promise<void> {
   if (!config.mongoUri) {
-    console.error('❌ MONGO_URI is not set');
+    logger.error('MONGO_URI is not set');
     process.exit(1);
   }
   await mongoose.connect(config.mongoUri);
-  console.log('✅ MongoDB Connected');
+  logger.info('MongoDB connected');
 }

--- a/apps/api/src/middlewares/audit.middleware.ts
+++ b/apps/api/src/middlewares/audit.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { auditLog } from '../modules/audit/audit.service';
 import { AuditAction } from '../modules/audit/audit.model';
+import logger from '../utils/logger';
 
 /**
  * Middleware to automatically log audit events for specific routes
@@ -27,7 +28,7 @@ export function auditMiddleware(action: AuditAction, resourceType?: string) {
           },
           req
         ).catch((error) => {
-          console.error('Audit logging failed:', error);
+          logger.error({ err: error }, 'Audit logging failed');
         });
       }
 

--- a/apps/api/src/middlewares/error.middleware.ts
+++ b/apps/api/src/middlewares/error.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Error as MongooseError } from 'mongoose';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+import logger from '../utils/logger';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -29,7 +30,7 @@ export function errorHandler(err: unknown, _req: Request, res: Response, _next: 
   }
 
   if (isDev) {
-    console.error(err);
+    logger.error({ err }, 'Unhandled error');
   }
 
   const stack = isDev && err instanceof Error ? err.stack : undefined;

--- a/apps/api/src/modules/ai/ai.routes.ts
+++ b/apps/api/src/modules/ai/ai.routes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { isValidObjectId } from 'mongoose';
 import { generateClinicalSummary, isAIServiceAvailable } from './ai.service';
 import { authenticate } from '../../middlewares/auth.middleware';
+import logger from '../../utils/logger';
 
 const router = Router();
 
@@ -67,7 +68,7 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
       encounterId,
     });
   } catch (error: any) {
-    console.error('AI summarize error:', error);
+    logger.error({ err: error }, 'AI summarize error');
 
     // Handle Gemini API specific errors
     if (error.message.includes('Failed to generate AI summary')) {

--- a/apps/api/src/modules/audit/audit.controller.ts
+++ b/apps/api/src/modules/audit/audit.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, Router } from 'express';
 import { AuditLogModel } from './audit.model';
 import { authenticate } from '../../middlewares/auth.middleware';
+import logger from '../../utils/logger';
 
 const router = Router();
 
@@ -139,7 +140,7 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
       },
     });
   } catch (error) {
-    console.error('Error fetching audit logs:', error);
+    logger.error({ err: error }, 'Error fetching audit logs');
     return res.status(500).json({
       error: 'InternalServerError',
       message: 'Failed to retrieve audit logs',

--- a/apps/api/src/modules/audit/audit.service.ts
+++ b/apps/api/src/modules/audit/audit.service.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express';
 import { Types } from 'mongoose';
 import { AuditAction, AuditLogModel } from './audit.model';
+import logger from '../../utils/logger';
 
 interface AuditLogParams {
   action: AuditAction;
@@ -41,6 +42,6 @@ export async function auditLog(params: AuditLogParams, req?: Request): Promise<v
     });
   } catch (error) {
     // Log the error but don't throw - audit logging should not break the main flow
-    console.error('Failed to create audit log:', error);
+    logger.error({ err: error }, 'Failed to create audit log');
   }
 }

--- a/apps/api/src/modules/export/export.routes.ts
+++ b/apps/api/src/modules/export/export.routes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { Types } from 'mongoose';
 import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
 import { auditLog } from '@api/modules/audit/audit.service';
+import logger from '@api/utils/logger';
 import {
   buildPatientRecord,
   sendPatientJson,
@@ -52,12 +53,12 @@ router.get('/patients/:id/export', authenticate, async (req: Request, res: Respo
     auditLog(
       { action: 'EXPORT_PATIENT_DATA', resourceType: 'Patient', resourceId: id, userId, clinicId },
       req,
-    ).catch(console.error);
+    ).catch((err) => logger.error({ err }, 'Audit log failed for patient export'));
 
     if (format === 'json') return sendPatientJson(res, record);
     return sendPatientPdf(res, record);
   } catch (err: any) {
-    console.error('[export] patient export error:', err);
+    logger.error({ err }, 'Patient export error');
     return res.status(500).json({ error: 'InternalError', message: 'Export failed' });
   }
 });
@@ -90,11 +91,11 @@ router.get(
       auditLog(
         { action: 'EXPORT_PATIENT_DATA', resourceType: 'Clinic', resourceId: id, userId: req.user!.userId, clinicId: req.user!.clinicId },
         req,
-      ).catch(console.error);
+      ).catch((err) => logger.error({ err }, 'Audit log failed for clinic export'));
 
       return sendClinicZip(res, id, record);
     } catch (err: any) {
-      console.error('[export] clinic export error:', err);
+      logger.error({ err }, 'Clinic export error');
       return res.status(500).json({ error: 'InternalError', message: 'Export failed' });
     }
   },

--- a/apps/api/src/modules/export/export.service.ts
+++ b/apps/api/src/modules/export/export.service.ts
@@ -6,6 +6,7 @@ import { EncounterModel } from '@api/modules/encounters/encounter.model';
 import { PaymentRecordModel } from '@api/modules/payments/models/payment-record.model';
 import { UserModel } from '@api/modules/auth/models/user.model';
 import { Types } from 'mongoose';
+import logger from '@api/utils/logger';
 
 // ─── Sanitization ──────────────────────────────────────────────────────────
 
@@ -153,7 +154,7 @@ export function sendClinicZip(
   const archive = archiver('zip', { zlib: { level: 9 } });
 
   archive.on('error', (err: Error) => {
-    console.error('[export] archiver error:', err);
+    logger.error({ err }, 'Archiver error during clinic export');
     res.destroy(err);
   });
 

--- a/apps/stellar-service/package.json
+++ b/apps/stellar-service/package.json
@@ -15,7 +15,9 @@
     "@health-watchers/config": "*",
     "@stellar/stellar-sdk": "^12.0.0",
     "dotenv": "^16.0.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "pino": "^9.0.0",
+    "pino-pretty": "^11.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/apps/stellar-service/src/guards.ts
+++ b/apps/stellar-service/src/guards.ts
@@ -1,4 +1,5 @@
 import { stellarConfig } from "./config";
+import logger from "./logger";
 
 /**
  * Run at startup. Exits with code 1 if mainnet is configured without
@@ -8,22 +9,19 @@ export function assertMainnetSafety(): void {
   const { network, mainnetConfirmed, dryRun } = stellarConfig;
 
   if (network === "mainnet") {
-    // Prominent warning regardless
-    console.warn("⚠️  ============================================================");
-    console.warn("⚠️  STELLAR_NETWORK=mainnet — REAL XLM WILL BE USED");
-    console.warn("⚠️  ============================================================");
+    logger.warn("STELLAR_NETWORK=mainnet — REAL XLM WILL BE USED");
 
     if (!mainnetConfirmed) {
-      console.error(
-        "❌  STELLAR_MAINNET_CONFIRMED is not set to 'true'.\n" +
-        "    Set STELLAR_MAINNET_CONFIRMED=true to acknowledge mainnet operation.\n" +
-        "    Exiting to prevent accidental real-funds usage."
+      logger.error(
+        "STELLAR_MAINNET_CONFIRMED is not set to 'true'. " +
+        "Set STELLAR_MAINNET_CONFIRMED=true to acknowledge mainnet operation. " +
+        "Exiting to prevent accidental real-funds usage."
       );
       process.exit(1);
     }
 
     if (dryRun) {
-      console.warn("⚠️  STELLAR_DRY_RUN=true — transactions will be simulated, not submitted.");
+      logger.warn("STELLAR_DRY_RUN=true — transactions will be simulated, not submitted.");
     }
   }
 }

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -1,9 +1,12 @@
 // apps/stellar-service/src/index.ts
 
+import crypto from 'crypto';
 import express from 'express';
 import { Server } from 'http';
+import pinoHttp from 'pino-http';
 import { fundAccount, createIntent, verifyIntent } from './stellar.js'; // your existing imports
 import dotenv from 'dotenv';
+import logger from './logger.js';
 
 dotenv.config();
 
@@ -12,7 +15,7 @@ const PORT = process.env.STELLAR_PORT || 3002;
 const SHARED_SECRET = process.env.STELLAR_SERVICE_SECRET;
 
 if (!SHARED_SECRET) {
-  console.error('❌ STELLAR_SERVICE_SECRET required!');
+  logger.error('STELLAR_SERVICE_SECRET required');
   process.exit(1);
 }
 
@@ -34,6 +37,11 @@ const requireSecret = (req: express.Request, res: express.Response, next: expres
 };
 
 app.use(express.json());
+app.use(pinoHttp({
+  logger,
+  genReqId: (req) => (req.headers['x-request-id'] as string) ?? crypto.randomUUID(),
+  redact: ['req.headers.authorization'],
+}));
 
 // ✅ PROTECTED: POST /fund (requires secret)
 app.post('/fund', requireSecret, async (req, res) => {
@@ -68,8 +76,7 @@ app.get('/verify/:hash', async (req, res) => {
 });
 
 const server: Server = app.listen(PORT, () => {
-  console.log(`🚀 Stellar Service running on port ${PORT}`);
-  console.log(`🔒 Protected by secret: ${SHARED_SECRET ? 'SET' : 'MISSING'}`);
+  logger.info({ port: PORT, secret: SHARED_SECRET ? 'SET' : 'MISSING' }, 'Stellar Service running');
 });
 
 export default server;

--- a/apps/stellar-service/src/logger.ts
+++ b/apps/stellar-service/src/logger.ts
@@ -1,0 +1,10 @@
+import pino from 'pino';
+
+const logger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+  ...(process.env.NODE_ENV !== 'production'
+    ? { transport: { target: 'pino-pretty', options: { colorize: true } } }
+    : {}),
+});
+
+export default logger;

--- a/apps/stellar-service/src/payment-stream.ts
+++ b/apps/stellar-service/src/payment-stream.ts
@@ -1,5 +1,6 @@
 import StellarSdk from "stellar-sdk";
 import { stellarConfig } from "./config";
+import logger from "./logger";
 
 export type PaymentStreamHandler = (payment: {
   memo: string;
@@ -15,7 +16,7 @@ export type PaymentStreamHandler = (payment: {
  */
 export function startPaymentStream(onPayment: PaymentStreamHandler): () => void {
   if (!stellarConfig.platformPublicKey) {
-    console.warn("[stellar-stream] STELLAR_PLATFORM_PUBLIC_KEY not set — stream disabled");
+    logger.warn("STELLAR_PLATFORM_PUBLIC_KEY not set — stream disabled");
     return () => {};
   }
 
@@ -25,8 +26,9 @@ export function startPaymentStream(onPayment: PaymentStreamHandler): () => void 
       : "https://horizon-testnet.stellar.org",
   );
 
-  console.log(
-    `[stellar-stream] Listening for payments on ${stellarConfig.platformPublicKey} (${stellarConfig.network})`,
+  logger.info(
+    { publicKey: stellarConfig.platformPublicKey, network: stellarConfig.network },
+    "Listening for Stellar payments",
   );
 
   const close = server
@@ -35,7 +37,6 @@ export function startPaymentStream(onPayment: PaymentStreamHandler): () => void 
     .cursor("now")
     .stream({
       onmessage: async (record: any) => {
-        // Only process incoming payment_operations
         if (record.type !== "payment" || record.to !== stellarConfig.platformPublicKey) return;
 
         try {
@@ -48,11 +49,11 @@ export function startPaymentStream(onPayment: PaymentStreamHandler): () => void 
             from:   record.from,
           });
         } catch (err) {
-          console.error("[stellar-stream] Failed to fetch transaction for payment", err);
+          logger.error({ err }, "Failed to fetch transaction for payment");
         }
       },
       onerror: (err: unknown) => {
-        console.error("[stellar-stream] Stream error", err);
+        logger.error({ err }, "Payment stream error");
       },
     });
 


### PR DESCRIPTION
- Add pino logger to stellar-service (logger.ts)
- Install pino + pino-pretty in stellar-service/package.json
- Replace morgan with pino-http in API for structured HTTP request logging
- Add pino-http to stellar-service for HTTP request logging
- Generate correlation/request ID per request via genReqId (honours x-request-id header, falls back to crypto.randomUUID())
- Redact req.headers.authorization from HTTP logs
- Replace all console.* in stellar-service: index.ts, guards.ts, payment-stream.ts
- Replace all console.* in API: db.ts, error.middleware.ts, audit.middleware.ts, audit.service.ts, audit.controller.ts, export.routes.ts, export.service.ts, ai.routes.ts
- All loggers use structured JSON in production, pino-pretty in development
- LOG_LEVEL configurable via env var (already in .env.example)
- Sensitive fields redacted via pino redact config

Closes #322