### PR TITLE
feat(encounters): add GET list, compound index, 409 guard, status:cancelled soft-delete

### DIFF
--- a/apps/api/src/modules/encounters/encounter.model.ts
+++ b/apps/api/src/modules/encounters/encounter.model.ts
@@ -29,8 +29,9 @@ export interface Encounter {
   patientId: Schema.Types.ObjectId;
   clinicId: Schema.Types.ObjectId;
   attendingDoctorId: Schema.Types.ObjectId;
+  encounteredBy?: Schema.Types.ObjectId; // alias for attendingDoctorId (spec compat)
   chiefComplaint: string;
-  status: "open" | "closed" | "follow-up";
+  status: "open" | "closed" | "follow-up" | "cancelled";
   notes?: string;
   diagnosis?: Diagnosis[];
   treatmentPlan?: string;
@@ -78,8 +79,9 @@ const encounterSchema = new Schema<Encounter>(
     patientId:         { type: Schema.Types.ObjectId, ref: "Patient",  required: true, index: true },
     clinicId:          { type: Schema.Types.ObjectId, ref: "Clinic",   required: true, index: true },
     attendingDoctorId: { type: Schema.Types.ObjectId, ref: "User",     required: true, index: true },
+    encounteredBy:     { type: Schema.Types.ObjectId, ref: "User" },
     chiefComplaint:    { type: String, required: true },
-    status:            { type: String, enum: ["open", "closed", "follow-up"], default: "open", index: true },
+    status:            { type: String, enum: ["open", "closed", "follow-up", "cancelled"], default: "open", index: true },
     notes:             { type: String },
     treatmentPlan:     { type: String },
     diagnosis:         { type: [diagnosisSchema], default: undefined },
@@ -91,6 +93,9 @@ const encounterSchema = new Schema<Encounter>(
   },
   { timestamps: true, versionKey: false }
 );
+
+// Compound index for paginated clinic-scoped queries
+encounterSchema.index({ clinicId: 1, patientId: 1, createdAt: -1 });
 
 const FREE_TEXT_FIELDS = ["chiefComplaint", "notes", "treatmentPlan", "aiSummary"] as const;
 

--- a/apps/api/src/modules/encounters/encounter.validation.ts
+++ b/apps/api/src/modules/encounters/encounter.validation.ts
@@ -34,7 +34,7 @@ export const createEncounterSchema = z.object({
   clinicId:          z.string().regex(objectIdRegex, 'Invalid clinicId'),
   attendingDoctorId: z.string().regex(objectIdRegex, 'Invalid attendingDoctorId'),
   chiefComplaint:    z.string().min(3, 'chiefComplaint must be at least 3 characters'),
-  status:            z.enum(['open', 'closed', 'follow-up']).optional(),
+  status:            z.enum(['open', 'closed', 'follow-up', 'cancelled']).optional(),
   notes:             z.string().max(5000).optional(),
   treatmentPlan:     z.string().max(5000).optional(),
   diagnosis:         z.array(diagnosisSchema).optional(),
@@ -70,6 +70,10 @@ export const patchEncounterSchema = z.object({
   aiSummary: z.string().max(5000).optional(),
   diagnosis: z.array(diagnosisSchema).optional(),
   treatmentPlan: z.string().max(5000).optional(),
+  vitalSigns: vitalSignsSchema,
+  prescriptions: z.array(prescriptionSchema).optional(),
+  followUpDate: z.string().datetime({ offset: true }).optional(),
+  status: z.enum(['open', 'closed', 'follow-up']).optional(), // 'cancelled' only via DELETE
 }).refine(
   (d) => Object.keys(d).length > 0,
   'At least one field is required',
@@ -78,7 +82,7 @@ export const patchEncounterSchema = z.object({
 export const listEncountersQuerySchema = z.object({
   patientId: objectId.optional(),
   doctorId: objectId.optional(),
-  status: z.enum(['open', 'closed', 'follow-up']).optional(),
+  status: z.enum(['open', 'closed', 'follow-up', 'cancelled']).optional(),
   date: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD')

--- a/apps/api/src/modules/encounters/encounters.controller.ts
+++ b/apps/api/src/modules/encounters/encounters.controller.ts
@@ -9,14 +9,53 @@ import {
   patchEncounterSchema,
   encounterIdParamSchema,
   patientIdParamSchema,
+  listEncountersQuerySchema,
+  ListEncountersQuery,
 } from './encounter.validation';
 
 const router = Router();
 router.use(authenticate);
 
+// GET /encounters — paginated list scoped to the authenticated clinic
+router.get(
+  '/',
+  validateRequest({ query: listEncountersQuerySchema }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { patientId, doctorId, status, date, page, limit } =
+      req.query as unknown as ListEncountersQuery;
+
+    const filter: Record<string, unknown> = {
+      clinicId: req.user!.clinicId,
+      isActive: true,
+    };
+    if (patientId) filter.patientId = patientId;
+    if (doctorId) filter.attendingDoctorId = doctorId;
+    if (status) filter.status = status;
+    if (date) {
+      const start = new Date(date);
+      const end = new Date(date);
+      end.setDate(end.getDate() + 1);
+      filter.createdAt = { $gte: start, $lt: end };
+    }
+
+    const skip = (page - 1) * limit;
+    const [docs, total] = await Promise.all([
+      EncounterModel.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+      EncounterModel.countDocuments(filter),
+    ]);
+
+    return res.json({
+      status: 'success',
+      data: docs.map(toEncounterResponse),
+      meta: { total, page, limit },
+    });
+  }),
+);
+
 // POST /encounters
 router.post(
   '/',
+  requireRoles('DOCTOR', 'CLINIC_ADMIN', 'NURSE'),
   validateRequest({ body: createEncounterSchema }),
   asyncHandler(async (req: Request, res: Response) => {
     const doc = await EncounterModel.create(req.body);
@@ -29,38 +68,49 @@ router.get(
   '/:id',
   validateRequest({ params: encounterIdParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const doc = await EncounterModel.findOne({ 
-      _id: req.params.id, 
-      isActive: true 
+    const doc = await EncounterModel.findOne({
+      _id: req.params.id,
+      clinicId: req.user!.clinicId,
+      isActive: true,
     });
     if (!doc) return res.status(404).json({ error: 'NotFound', message: 'Encounter not found' });
     return res.json({ status: 'success', data: toEncounterResponse(doc) });
   }),
 );
 
-// PATCH /encounters/:id
-// Restricted to DOCTOR and CLINIC_ADMIN roles
-// Only allows updating: chiefComplaint, notes, aiSummary, diagnosis, treatmentPlan
+// PATCH /encounters/:id — only DOCTOR (own) or CLINIC_ADMIN; closed encounters → 409
 router.patch(
   '/:id',
   requireRoles('DOCTOR', 'CLINIC_ADMIN'),
   validateRequest({ params: encounterIdParamSchema, body: patchEncounterSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    // Ensure caller can only update encounters in their clinic
     const encounter = await EncounterModel.findOne({
       _id: req.params.id,
       clinicId: req.user!.clinicId,
       isActive: true,
     });
-    
+
     if (!encounter) {
       return res.status(404).json({ error: 'NotFound', message: 'Encounter not found' });
     }
 
-    // Update only allowed fields
-    const allowedFields = ['chiefComplaint', 'notes', 'aiSummary', 'diagnosis', 'treatmentPlan'] as const;
-    const updateData: Record<string, any> = {};
-    
+    if (encounter.status === 'closed' || encounter.status === 'cancelled') {
+      return res.status(409).json({
+        error: 'Conflict',
+        message: `Cannot edit a ${encounter.status} encounter`,
+      });
+    }
+
+    // DOCTOR can only edit their own encounters
+    if (
+      req.user!.role === 'DOCTOR' &&
+      String(encounter.attendingDoctorId) !== req.user!.userId
+    ) {
+      return res.status(403).json({ error: 'Forbidden', message: 'You can only edit your own encounters' });
+    }
+
+    const allowedFields = ['chiefComplaint', 'notes', 'aiSummary', 'diagnosis', 'treatmentPlan', 'vitalSigns', 'prescriptions', 'followUpDate', 'status'] as const;
+    const updateData: Record<string, unknown> = {};
     for (const field of allowedFields) {
       if (field in req.body && req.body[field] !== undefined) {
         updateData[field] = req.body[field];
@@ -71,42 +121,34 @@ router.patch(
       new: true,
       runValidators: true,
     });
-    
-    if (!doc) {
-      return res.status(404).json({ error: 'NotFound', message: 'Encounter not found' });
-    }
-    
-    return res.json({ status: 'success', data: toEncounterResponse(doc) });
+
+    return res.json({ status: 'success', data: toEncounterResponse(doc!) });
   }),
 );
 
-// DELETE /encounters/:id
-// Soft-delete: marks encounter as inactive
-// Restricted to CLINIC_ADMIN role only
+// DELETE /encounters/:id — soft-delete via status:'cancelled'; CLINIC_ADMIN or SUPER_ADMIN only
 router.delete(
   '/:id',
-  requireRoles('CLINIC_ADMIN'),
+  requireRoles('CLINIC_ADMIN', 'SUPER_ADMIN'),
   validateRequest({ params: encounterIdParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    // Ensure caller can only delete encounters in their clinic
     const encounter = await EncounterModel.findOne({
       _id: req.params.id,
       clinicId: req.user!.clinicId,
       isActive: true,
     });
-    
+
     if (!encounter) {
       return res.status(404).json({ error: 'NotFound', message: 'Encounter not found' });
     }
 
-    // Soft-delete by setting isActive to false
     const doc = await EncounterModel.findByIdAndUpdate(
       req.params.id,
-      { isActive: false },
-      { new: true }
+      { status: 'cancelled', isActive: false },
+      { new: true },
     );
-    
-    return res.json({ status: 'success', message: 'Encounter deleted', data: toEncounterResponse(doc!) });
+
+    return res.json({ status: 'success', message: 'Encounter cancelled', data: toEncounterResponse(doc!) });
   }),
 );
 
@@ -115,9 +157,10 @@ router.get(
   '/patient/:patientId',
   validateRequest({ params: patientIdParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const docs = await EncounterModel.find({ 
+    const docs = await EncounterModel.find({
       patientId: req.params.patientId,
-      isActive: true 
+      clinicId: req.user!.clinicId,
+      isActive: true,
     }).sort({ createdAt: -1 });
     return res.json({ status: 'success', data: docs.map(toEncounterResponse) });
   }),

--- a/apps/web/src/app/encounters/page.tsx
+++ b/apps/web/src/app/encounters/page.tsx
@@ -1,103 +1,161 @@
-// apps/web/src/app/encounters/page.tsx
-
 'use client';
-import { useState, useEffect } from 'react';
 
-interface Encounter {
-  _id: string;
-  patientId: {
-    firstName: string;
-    lastName: string;
-    systemId: string;
-  };
-  status: string;
-  createdAt: string;
-  // ... other fields
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ErrorMessage, Toast, TableSkeleton, Button } from '@/components/ui';
+import {
+  CreateEncounterForm,
+  type CreateEncounterData,
+} from '@/components/forms/CreateEncounterForm';
+import { queryKeys } from '@/lib/queryKeys';
+import { useEncounters } from '@/lib/queries/useEncounters';
+import { API_URL } from '@/lib/api';
+
+const API = `${API_URL}/api/v1`;
+
+function getEncounterErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return 'Unable to load encounters right now.';
+  if (error.message.includes('Failed to fetch')) {
+    return 'Unable to reach the server. Please check your connection and try again.';
+  }
+  return error.message;
 }
 
-interface ApiResponse {
-  status: string;
-  data: Encounter[];
-  meta: {
-    total: number;
-    page: number;
-    limit: number;
-  };
-}
+const STATUS_COLORS: Record<string, string> = {
+  open: 'bg-green-100 text-green-800',
+  closed: 'bg-gray-100 text-gray-700',
+  'follow-up': 'bg-blue-100 text-blue-800',
+  cancelled: 'bg-red-100 text-red-700',
+};
 
 export default function EncountersPage() {
-  const [encounters, setEncounters] = useState<Encounter[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
   const [page, setPage] = useState(1);
-  const [limit] = useState(10);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
-  useEffect(() => {
-    fetchEncounters();
-  }, [page]);
+  const { data, isLoading, error } = useEncounters(page);
+  const encounters = data?.data ?? [];
+  const total = data?.meta?.total ?? 0;
+  const limit = data?.meta?.limit ?? 20;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
 
-  const fetchEncounters = async () => {
-    try {
-      const params = new URLSearchParams({
-        page: page.toString(),
-        limit: limit.toString(),
-      });
-      
-      const response = await fetch(`/api/v1/encounters?${params}`);
-      const data: ApiResponse = await response.json();
-      
-      if (data.status === 'success') {
-        setEncounters(data.data);
-      }
-    } catch (error) {
-      console.error('Failed to fetch encounters:', error);
-    } finally {
-      setLoading(false);
+  const handleCreate = async (formData: CreateEncounterData) => {
+    const res = await fetch(`${API}/encounters`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formData),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.message || `Error ${res.status}`);
     }
+    setShowForm(false);
+    setToast({ message: 'Encounter created successfully.', type: 'success' });
+    queryClient.invalidateQueries({ queryKey: queryKeys.encounters.list() });
   };
 
-  if (loading) return <div>Loading encounters...</div>;
+  if (isLoading) return <TableSkeleton columns={5} rows={8} />;
+  if (error)
+    return (
+      <ErrorMessage
+        message={getEncounterErrorMessage(error)}
+        onRetry={() => queryClient.invalidateQueries({ queryKey: queryKeys.encounters.list() })}
+      />
+    );
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-6">Encounters</h1>
-      <div className="grid gap-4">
-        {encounters.map((encounter) => (
-          <div key={encounter._id} className="p-4 border rounded-lg">
-            <div className="font-medium">
-              {encounter.patientId?.firstName} {encounter.patientId?.lastName}
-              <span className="text-sm text-gray-500 ml-2">
-                ({encounter.patientId?.systemId})
-              </span>
-            </div>
-            <div className="text-sm text-gray-600">
-              Status: <span className="font-semibold">{encounter.status}</span>
-            </div>
-            <div className="text-xs text-gray-500">
-              {new Date(encounter.createdAt).toLocaleDateString()}
+    <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Encounters</h1>
+        <button
+          onClick={() => setShowForm(true)}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + New Encounter
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="mb-8 rounded-lg border border-gray-200 p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">New Encounter</h2>
+          <CreateEncounterForm onSubmit={handleCreate} onCancel={() => setShowForm(false)} />
+        </div>
+      )}
+
+      {encounters.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
+          <h2 className="text-lg font-semibold text-gray-900">No encounters found</h2>
+          <p className="mt-2 text-sm text-gray-600">Create your first encounter to get started.</p>
+          <Button variant="primary" size="md" className="mt-5" onClick={() => setShowForm(true)}>
+            Create Encounter
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="overflow-x-auto rounded-lg border border-gray-200 shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  {['Patient', 'Chief Complaint', 'Status', 'Doctor', 'Date'].map((h) => (
+                    <th
+                      key={h}
+                      scope="col"
+                      className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {encounters.map((e) => (
+                  <tr key={e.id} className="hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3 font-mono text-xs text-gray-600">{e.patientId}</td>
+                    <td className="px-4 py-3 text-gray-900 max-w-xs truncate">{e.chiefComplaint}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[e.status] ?? 'bg-gray-100 text-gray-700'}`}
+                      >
+                        {e.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-600">{e.attendingDoctorId}</td>
+                    <td className="px-4 py-3 text-gray-500 text-xs whitespace-nowrap">
+                      {e.createdAt ? new Date(e.createdAt).toLocaleDateString() : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          <div className="mt-4 flex items-center justify-between text-sm text-gray-600">
+            <span>
+              Page {page} of {totalPages} ({total} total)
+            </span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="px-3 py-1.5 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+              >
+                Previous
+              </button>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="px-3 py-1.5 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+              >
+                Next
+              </button>
             </div>
           </div>
-        ))}
-      </div>
-      
-      {/* Pagination */}
-      <div className="mt-6 flex justify-between">
-        <button
-          onClick={() => setPage(p => Math.max(1, p - 1))}
-          disabled={page === 1}
-          className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
-        >
-          Previous
-        </button>
-        <span>
-          Page {page} of {Math.ceil(100 / limit)} {/* Replace 100 with meta.total */}
-        </span>
-        <button
-          onClick={() => setPage(p => p + 1)}
-          className="px-4 py-2 bg-blue-500 text-white rounded"
-        >
-          Next
-        </button>
-      </div>
-    </div>
+        </>
+      )}
+    </main>
   );
 }

--- a/apps/web/src/lib/queries/useEncounters.ts
+++ b/apps/web/src/lib/queries/useEncounters.ts
@@ -1,26 +1,32 @@
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
-
 import { API_V1 } from '@/lib/api';
 
 export interface Encounter {
   id: string;
   patientId: string;
-  date: string;
-  notes: string;
+  clinicId: string;
+  attendingDoctorId: string;
+  chiefComplaint: string;
+  status: 'open' | 'closed' | 'follow-up' | 'cancelled' | string;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
-export function useEncounters() {
-  return useQuery<Encounter[]>({
-    queryKey: queryKeys.encounters.list(),
-    queryFn: async () => {
-      const res = await fetch(`${API_V1}/encounters`);
-      if (!res.ok) {
-        throw new Error(`Request failed (${res.status})`);
-      }
+export interface EncountersPage {
+  data: Encounter[];
+  meta: { total: number; page: number; limit: number };
+}
 
-      const data = await res.json();
-      return data.data || data || [];
+export function useEncounters(page = 1, limit = 20) {
+  return useQuery<EncountersPage>({
+    queryKey: [...queryKeys.encounters.list(), page, limit],
+    queryFn: async () => {
+      const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+      const res = await fetch(`${API_V1}/encounters?${params}`);
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      return res.json();
     },
   });
 }


### PR DESCRIPTION


- Add GET /encounters paginated list endpoint with filters (patientId, doctorId, status, date)
- Add compound index { clinicId, patientId, createdAt } to encounter model
- Add 'cancelled' to status enum; soft-delete sets status:'cancelled' + isActive:false
- Guard PATCH on closed/cancelled encounters with 409 Conflict
- DOCTOR can only edit own encounters; CLINIC_ADMIN/SUPER_ADMIN can delete
- Extend patchEncounterSchema with vitalSigns, prescriptions, followUpDate, status
- Update web encounters page to use paginated list with status badges
closes #313