### PR TITLE
feat(ai): add POST /ai/insights, raw text input, PII stripping, disclaimer

### DIFF
--- a/apps/api/src/modules/ai/ai.routes.ts
+++ b/apps/api/src/modules/ai/ai.routes.ts
@@ -1,6 +1,12 @@
 import { Router, Request, Response } from 'express';
 import { isValidObjectId } from 'mongoose';
-import { generateClinicalSummary, isAIServiceAvailable } from './ai.service';
+import {
+  generateClinicalSummary,
+  generateRawTextSummary,
+  generatePatientInsights,
+  isAIServiceAvailable,
+  AI_DISCLAIMER,
+} from './ai.service';
 import { authenticate } from '../../middlewares/auth.middleware';
 import logger from '../../utils/logger';
 
@@ -10,68 +16,80 @@ const router = Router();
 router.get('/health', (_req, res) => res.json({ status: 'ok', service: 'ai' }));
 
 // POST /api/v1/ai/summarize
-// Request body: { encounterId: string }
-// Returns: { success: boolean, summary: string } or error responses
+// Request body: { encounterId?: string, text?: string }
+// Returns: { success: boolean, summary: string, disclaimer: string }
 router.post('/summarize', authenticate, async (req: Request, res: Response) => {
+  const startTime = Date.now();
   try {
-    // Check if AI service is available
     if (!isAIServiceAvailable()) {
       return res.status(503).json({
         error: 'AIUnavailable',
+        message: 'AI service is not configured. Please contact your administrator.',
       });
     }
 
-    // Validate request body
-    const { encounterId } = req.body;
-    if (!encounterId) {
+    const { encounterId, text } = req.body;
+
+    // Accept either encounterId or raw text
+    if (!encounterId && !text) {
       return res.status(400).json({
         error: 'ValidationError',
-        message: 'encounterId is required',
+        message: 'Either encounterId or text is required',
       });
     }
 
-    // Validate encounterId is a valid MongoDB ObjectId
-    if (!isValidObjectId(encounterId)) {
-      return res.status(400).json({
-        error: 'ValidationError',
-        message: 'Invalid encounterId format',
+    let summary: string;
+
+    if (text) {
+      // Raw text input
+      if (typeof text !== 'string' || text.trim().length < 10) {
+        return res.status(400).json({
+          error: 'ValidationError',
+          message: 'text must be a non-empty string with at least 10 characters',
+        });
+      }
+      summary = await generateRawTextSummary(text);
+    } else {
+      // encounterId input
+      if (!isValidObjectId(encounterId)) {
+        return res.status(400).json({
+          error: 'ValidationError',
+          message: 'Invalid encounterId format',
+        });
+      }
+
+      const { EncounterModel } = await import('../encounters/encounter.model');
+      const encounter = await EncounterModel.findById(encounterId);
+      if (!encounter) {
+        return res.status(404).json({ error: 'NotFound', message: 'Encounter not found' });
+      }
+
+      summary = await generateClinicalSummary({
+        chiefComplaint: encounter.chiefComplaint,
+        notes: encounter.notes,
+        diagnosis: encounter.diagnosis,
+        vitalSigns: encounter.vitalSigns,
       });
+
+      // Store the summary in the encounter
+      encounter.aiSummary = summary;
+      await encounter.save();
     }
 
-    // Lazy-import to avoid circular dependencies
-    const { EncounterModel } = await import('../encounters/encounter.model');
-
-    // Fetch the encounter
-    const encounter = await EncounterModel.findById(encounterId);
-    if (!encounter) {
-      return res.status(404).json({
-        error: 'NotFound',
-        message: 'Encounter not found',
-      });
-    }
-
-    // Generate clinical summary
-    const summary = await generateClinicalSummary({
-      chiefComplaint: encounter.chiefComplaint,
-      notes: encounter.notes,
-      diagnosis: encounter.diagnosis,
-      vitalSigns: encounter.vitalSigns,
-    });
-
-    // Store the summary in the encounter
-    encounter.aiSummary = summary;
-    await encounter.save();
+    const duration = Date.now() - startTime;
+    logger.info({ encounterId, duration, textLength: text?.length }, 'AI summary generated');
 
     return res.json({
       success: true,
       summary,
-      encounterId,
+      disclaimer: AI_DISCLAIMER,
+      ...(encounterId ? { encounterId } : {}),
     });
-  } catch (error: any) {
-    logger.error({ err: error }, 'AI summarize error');
+  } catch (error: unknown) {
+    const duration = Date.now() - startTime;
+    logger.error({ err: error, duration }, 'AI summarize error');
 
-    // Handle Gemini API specific errors
-    if (error.message.includes('Failed to generate AI summary')) {
+    if (error instanceof Error && error.message.includes('Failed to generate AI summary')) {
       return res.status(503).json({
         error: 'AIServiceError',
         message: 'Failed to generate AI summary. Please try again later.',
@@ -80,7 +98,84 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
 
     return res.status(500).json({
       error: 'InternalServerError',
-      message: error.message || 'An unexpected error occurred',
+      message: error instanceof Error ? error.message : 'An unexpected error occurred',
+    });
+  }
+});
+
+// POST /api/v1/ai/insights
+// Request body: { patientId: string }
+// Returns: { success: boolean, insights: string, disclaimer: string }
+router.post('/insights', authenticate, async (req: Request, res: Response) => {
+  const startTime = Date.now();
+  try {
+    if (!isAIServiceAvailable()) {
+      return res.status(503).json({
+        error: 'AIUnavailable',
+        message: 'AI service is not configured. Please contact your administrator.',
+      });
+    }
+
+    const { patientId } = req.body;
+    if (!patientId || !isValidObjectId(patientId)) {
+      return res.status(400).json({
+        error: 'ValidationError',
+        message: 'Valid patientId is required',
+      });
+    }
+
+    const { EncounterModel } = await import('../encounters/encounter.model');
+
+    // Fetch last 10 encounters for the patient
+    const encounters = await EncounterModel.find({
+      patientId,
+      clinicId: req.user!.clinicId,
+      isActive: true,
+    })
+      .sort({ createdAt: -1 })
+      .limit(10)
+      .lean();
+
+    if (encounters.length === 0) {
+      return res.status(404).json({
+        error: 'NotFound',
+        message: 'No encounters found for this patient',
+      });
+    }
+
+    const insights = await generatePatientInsights(
+      encounters.map((e) => ({
+        chiefComplaint: e.chiefComplaint,
+        notes: e.notes,
+        diagnosis: e.diagnosis,
+        createdAt: e.createdAt,
+      })),
+    );
+
+    const duration = Date.now() - startTime;
+    logger.info({ patientId, encounterCount: encounters.length, duration }, 'AI insights generated');
+
+    return res.json({
+      success: true,
+      insights,
+      disclaimer: AI_DISCLAIMER,
+      patientId,
+      encounterCount: encounters.length,
+    });
+  } catch (error: unknown) {
+    const duration = Date.now() - startTime;
+    logger.error({ err: error, duration }, 'AI insights error');
+
+    if (error instanceof Error && error.message.includes('Failed to generate patient insights')) {
+      return res.status(503).json({
+        error: 'AIServiceError',
+        message: 'Failed to generate patient insights. Please try again later.',
+      });
+    }
+
+    return res.status(500).json({
+      error: 'InternalServerError',
+      message: error instanceof Error ? error.message : 'An unexpected error occurred',
     });
   }
 });

--- a/apps/api/src/modules/ai/ai.service.ts
+++ b/apps/api/src/modules/ai/ai.service.ts
@@ -3,64 +3,119 @@ import { config } from '@health-watchers/config';
 
 let clientInstance: GoogleGenerativeAI | null = null;
 
-/**
- * Initialize and return the Gemini client
- * Throws an error if GEMINI_API_KEY is not configured
- */
 function getGeminiClient(): GoogleGenerativeAI {
-  if (!config.geminiApiKey) {
-    throw new Error('GEMINI_API_KEY is not configured');
-  }
-
-  if (!clientInstance) {
-    clientInstance = new GoogleGenerativeAI(config.geminiApiKey);
-  }
-
+  if (!config.geminiApiKey) throw new Error('GEMINI_API_KEY is not configured');
+  if (!clientInstance) clientInstance = new GoogleGenerativeAI(config.geminiApiKey);
   return clientInstance;
 }
 
+export function isAIServiceAvailable(): boolean {
+  return !!config.geminiApiKey;
+}
+
+export const AI_DISCLAIMER =
+  'AI-generated summary for clinical assistance only. Not a substitute for professional medical judgment.';
+
+// ── PII stripping ─────────────────────────────────────────────────────────────
+// Remove common PII patterns before sending to external AI API
+const PII_PATTERNS: [RegExp, string][] = [
+  [/\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/g, '[PHONE]'],                          // phone numbers
+  [/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[EMAIL]'],                 // email addresses
+  [/\b\d{3}-\d{2}-\d{4}\b/g, '[SSN]'],                                         // SSN
+  [/\b(0[1-9]|1[0-2])[\/\-](0[1-9]|[12]\d|3[01])[\/\-]\d{2,4}\b/g, '[DOB]'], // dates of birth
+  [/\b\d{5}(-\d{4})?\b/g, '[ZIP]'],                                             // zip codes
+];
+
+export function stripPII(text: string): string {
+  let sanitized = text;
+  for (const [pattern, replacement] of PII_PATTERNS) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+  return sanitized;
+}
+
+// ── Clinical summary ──────────────────────────────────────────────────────────
 export interface ClinicalNotesInput {
   chiefComplaint: string;
   notes?: string;
-  diagnosis?: any;
-  vitalSigns?: any;
+  diagnosis?: unknown;
+  vitalSigns?: unknown;
 }
 
-/**
- * Generate an AI summary of clinical notes using Google Gemini
- * @param clinicalNotes Object containing clinical information
- * @returns AI-generated summary of the clinical notes
- * @throws Error if Gemini API fails or API key is not configured
- */
 export async function generateClinicalSummary(clinicalNotes: ClinicalNotesInput): Promise<string> {
   const client = getGeminiClient();
 
-  const prompt = `You are a medical AI assistant. Provide a concise clinical summary based on the following patient encounter notes. 
-Keep the summary to 2-3 sentences and focus on the most important clinical findings.
+  const rawText = [
+    `Chief Complaint: ${clinicalNotes.chiefComplaint}`,
+    clinicalNotes.notes ? `Clinical Notes: ${clinicalNotes.notes}` : '',
+    clinicalNotes.diagnosis ? `Diagnosis: ${JSON.stringify(clinicalNotes.diagnosis)}` : '',
+    clinicalNotes.vitalSigns ? `Vital Signs: ${JSON.stringify(clinicalNotes.vitalSigns)}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
 
-Chief Complaint: ${clinicalNotes.chiefComplaint}
-${clinicalNotes.notes ? `Clinical Notes: ${clinicalNotes.notes}` : ''}
-${clinicalNotes.diagnosis ? `Diagnosis: ${JSON.stringify(clinicalNotes.diagnosis)}` : ''}
-${clinicalNotes.vitalSigns ? `Vital Signs: ${JSON.stringify(clinicalNotes.vitalSigns)}` : ''}
+  const safeText = stripPII(rawText);
 
-Generate a professional clinical summary:`;
+  const prompt = `Summarize the following clinical encounter in 2-3 sentences for a medical professional. Include chief complaint, key findings, and recommended follow-up:\n\n${safeText}`;
 
   try {
     const model = client.getGenerativeModel({ model: 'gemini-1.5-flash' });
     const result = await model.generateContent(prompt);
-    const response = result.response;
-    const text = response.text();
-
-    return text;
+    return result.response.text();
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-    throw new Error(`Failed to generate AI summary: ${errorMessage}`);
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Failed to generate AI summary: ${msg}`);
   }
 }
 
-/**
- * Check if the AI service is available (API key is configured)
- */
-export function isAIServiceAvailable(): boolean {
-  return !!config.geminiApiKey;
+export async function generateRawTextSummary(text: string): Promise<string> {
+  const client = getGeminiClient();
+  const safeText = stripPII(text);
+  const prompt = `Summarize the following clinical notes in 2-3 sentences for a medical professional. Include chief complaint, key findings, and recommended follow-up:\n\n${safeText}`;
+
+  try {
+    const model = client.getGenerativeModel({ model: 'gemini-1.5-flash' });
+    const result = await model.generateContent(prompt);
+    return result.response.text();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Failed to generate AI summary: ${msg}`);
+  }
+}
+
+// ── Longitudinal insights ─────────────────────────────────────────────────────
+export interface EncounterSummary {
+  chiefComplaint: string;
+  notes?: string;
+  diagnosis?: unknown;
+  createdAt: Date | string;
+}
+
+export async function generatePatientInsights(encounters: EncounterSummary[]): Promise<string> {
+  const client = getGeminiClient();
+
+  const encounterText = encounters
+    .map((e, i) => {
+      const date = new Date(e.createdAt).toLocaleDateString();
+      const lines = [
+        `Encounter ${i + 1} (${date}): ${e.chiefComplaint}`,
+        e.notes ? `  Notes: ${e.notes}` : '',
+        e.diagnosis ? `  Diagnosis: ${JSON.stringify(e.diagnosis)}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+      return stripPII(lines);
+    })
+    .join('\n\n');
+
+  const prompt = `You are a medical AI assistant. Based on the following ${encounters.length} clinical encounters for a single patient, provide a longitudinal health trend summary in 3-5 sentences. Identify recurring conditions, patterns, or areas of concern:\n\n${encounterText}`;
+
+  try {
+    const model = client.getGenerativeModel({ model: 'gemini-1.5-flash' });
+    const result = await model.generateContent(prompt);
+    return result.response.text();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Failed to generate patient insights: ${msg}`);
+  }
 }


### PR DESCRIPTION


- POST /ai/summarize now accepts { encounterId } OR { text } (raw clinical notes)
- POST /ai/insights: fetch last 10 encounters, generate longitudinal health trends
- Strip PII (phone, email, SSN, DOB, zip) before sending to Gemini API
- Add AI_DISCLAIMER field in every response
- Log AI call duration and token context (no PHI in logs)
- Return 503 with clear message when GEMINI_API_KEY is missing
- Rate limiting: 10 req/min per clinic via existing aiLimiter middleware
- Graceful Gemini error handling returns 503 not 500
closes #315