### PR TITLE
feat(payments): add status polling with visual indicators and fix confirm method

### DIFF
--- a/apps/web/src/app/payments/PaymentsClient.tsx
+++ b/apps/web/src/app/payments/PaymentsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ErrorMessage,
@@ -20,16 +20,61 @@ import { API_URL } from "@/lib/api";
 
 const API = `${API_URL}/api/v1`;
 const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "testnet";
+const POLL_INTERVAL_MS = 5000;
+
+function getPaymentsErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return 'Unable to load payments right now.';
+  if (error.message.includes('Failed to fetch')) {
+    return 'Unable to reach the server. Please check your connection and try again.';
+  }
+  if (error.message.startsWith('Request failed')) {
+    return 'Unable to load payments right now. Please try again.';
+  }
+  return error.message;
+}
+
+function usePayments(pollingEnabled: boolean) {
+  return useQuery<Payment[]>({
+    queryKey: queryKeys.payments.list(),
+    queryFn: async () => {
+      const res = await fetch(`${API}/payments`);
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      const data = await res.json();
+      return data.data ?? data ?? [];
+    },
+    refetchInterval: pollingEnabled ? POLL_INTERVAL_MS : false,
+  });
+}
+
+/** Returns true if any payment in the list is still pending */
+function hasPendingPayments(payments: Payment[]): boolean {
+  return payments.some((p) => p.status === 'pending');
+}
 
 export default function PaymentsClient() {
   const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(false);
-  const [toast, setToast] = useState<{
-    message: string;
-    type: 'success' | 'error';
-  } | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
-  const { data: payments = [], isLoading, error } = usePayments();
+  const { data: payments = [], isLoading, error } = usePayments(hasPendingPayments([]));
+
+  // Enable polling whenever there are pending payments
+  const polling = hasPendingPayments(payments);
+  const { data: polledPayments = payments, isLoading: pollingLoading } = usePayments(polling);
+
+  // Track previous statuses to show toast on transition
+  const prevStatuses = useRef<Record<string, string>>({});
+  useEffect(() => {
+    polledPayments.forEach((p) => {
+      const prev = prevStatuses.current[p.id];
+      if (prev === 'pending' && p.status === 'confirmed') {
+        setToast({ message: `Payment confirmed.`, type: 'success' });
+      } else if (prev === 'pending' && p.status === 'failed') {
+        setToast({ message: `Payment failed.`, type: 'error' });
+      }
+      prevStatuses.current[p.id] = p.status;
+    });
+  }, [polledPayments]);
 
   const handleCreate = async (data: PaymentIntentData) => {
     const res = await fetch(`${API}/payments/intent`, {
@@ -46,9 +91,9 @@ export default function PaymentsClient() {
     queryClient.invalidateQueries({ queryKey: queryKeys.payments.list() });
   };
 
-  const handleConfirm = async (paymentId: string, txHash: string) => {
-    const res = await fetch(`${API}/payments/${paymentId}/confirm`, {
-      method: 'POST',
+  const handleConfirm = async (intentId: string, txHash: string) => {
+    const res = await fetch(`${API}/payments/${intentId}/confirm`, {
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ txHash }),
     });
@@ -60,16 +105,26 @@ export default function PaymentsClient() {
     queryClient.invalidateQueries({ queryKey: queryKeys.payments.list() });
   };
 
+  const displayPayments = polling ? polledPayments : payments;
+
   return (
     <PageWrapper className="py-8">
       {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
 
       <div className="flex items-center justify-between mb-6">
         <PageHeader title="Payments" />
-        <Button onClick={() => setShowForm(true)}>+ New Payment</Button>
+        <div className="flex items-center gap-3">
+          {polling && (
+            <span className="flex items-center gap-1.5 text-xs text-yellow-700 bg-yellow-50 border border-yellow-200 rounded-full px-3 py-1">
+              <span className="h-2 w-2 rounded-full bg-yellow-400 animate-pulse" aria-hidden="true" />
+              Polling for updates…
+            </span>
+          )}
+          <Button onClick={() => setShowForm(true)}>+ New Payment</Button>
+        </div>
       </div>
 
-      {isLoading && (
+      {(isLoading || pollingLoading) && !displayPayments.length && (
         <div
           role="status"
           aria-live="polite"
@@ -87,18 +142,15 @@ export default function PaymentsClient() {
         <ErrorMessage
           message={getPaymentsErrorMessage(error)}
           onRetry={() =>
-            queryClient.invalidateQueries({
-              queryKey: queryKeys.payments.list(),
-            })
+            queryClient.invalidateQueries({ queryKey: queryKeys.payments.list() })
           }
         />
       )}
 
       {!isLoading && !error && (
-        <PaymentTable payments={payments} network={NETWORK} onConfirm={handleConfirm} />
+        <PaymentTable payments={displayPayments} network={NETWORK} onConfirm={handleConfirm} />
       )}
 
-      {/* Create Payment Intent slide-over */}
       <SlideOver isOpen={showForm} onClose={() => setShowForm(false)} title="New Payment Intent">
         <PaymentIntentForm onSubmit={handleCreate} onCancel={() => setShowForm(false)} />
       </SlideOver>

--- a/apps/web/src/components/payments/PaymentTable.tsx
+++ b/apps/web/src/components/payments/PaymentTable.tsx
@@ -9,28 +9,60 @@ import { ConfirmPaymentModal } from "@/components/payments/ConfirmPaymentModal";
 
 export interface Payment {
   id: string;
+  intentId?: string;
   patientId: string;
   amount: string;
   asset?: string;
-  status: "pending" | "completed" | "failed" | string;
+  assetCode?: string;
+  status: "pending" | "confirmed" | "completed" | "failed" | string;
   txHash?: string;
+  confirmedAt?: string;
   createdAt?: string;
 }
 
-type StatusFilter = "all" | "pending" | "completed" | "failed";
+type StatusFilter = "all" | "pending" | "confirmed" | "failed";
 
 const STATUS_TABS: { value: StatusFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "pending", label: "Pending" },
-  { value: "completed", label: "Completed" },
+  { value: "confirmed", label: "Confirmed" },
   { value: "failed", label: "Failed" },
 ];
 
 function statusBadgeVariant(status: string) {
-  if (status === "completed") return "success";
+  if (status === "confirmed" || status === "completed") return "success";
   if (status === "pending") return "warning";
   if (status === "failed") return "danger";
   return "default";
+}
+
+/** Animated dot indicator for real-time status feedback */
+function StatusIndicator({ status }: { status: string }) {
+  if (status === "pending") {
+    return (
+      <span className="flex items-center gap-1.5">
+        <span className="h-2 w-2 rounded-full bg-yellow-400 animate-pulse" aria-hidden="true" />
+        <Badge variant="warning">pending</Badge>
+      </span>
+    );
+  }
+  if (status === "confirmed" || status === "completed") {
+    return (
+      <span className="flex items-center gap-1.5">
+        <span className="h-2 w-2 rounded-full bg-green-500" aria-hidden="true" />
+        <Badge variant="success">{status}</Badge>
+      </span>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <span className="flex items-center gap-1.5">
+        <span className="h-2 w-2 rounded-full bg-red-500" aria-hidden="true" />
+        <Badge variant="danger">failed</Badge>
+      </span>
+    );
+  }
+  return <Badge variant="default">{status}</Badge>;
 }
 
 interface Props {
@@ -181,9 +213,7 @@ export function PaymentTable({
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    <Badge variant={statusBadgeVariant(p.status)}>
-                      {p.status}
-                    </Badge>
+                    <StatusIndicator status={p.status} />
                   </td>
                   <td className="px-4 py-3">
                     {p.txHash ? (

--- a/apps/web/src/lib/queries/usePayments.ts
+++ b/apps/web/src/lib/queries/usePayments.ts
@@ -1,29 +1,47 @@
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queryKeys';
-
 import { API_V1 } from '@/lib/api';
 
 export interface Payment {
   id: string;
+  intentId?: string;
   patientId: string;
   amount: string;
   asset?: string;
-  status: 'pending' | 'completed' | 'failed' | string;
+  assetCode?: string;
+  status: 'pending' | 'confirmed' | 'failed' | string;
   txHash?: string;
+  confirmedAt?: string;
   createdAt?: string;
 }
 
-export function usePayments() {
+export function usePayments(refetchInterval?: number | false) {
   return useQuery<Payment[]>({
     queryKey: queryKeys.payments.list(),
     queryFn: async () => {
       const res = await fetch(`${API_V1}/payments`);
-      if (!res.ok) {
-        throw new Error(`Request failed (${res.status})`);
-      }
-
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
       const data = await res.json();
       return data.data ?? data ?? [];
+    },
+    refetchInterval: refetchInterval ?? false,
+  });
+}
+
+/** Poll a single payment's status every 5 s until it leaves 'pending' */
+export function usePaymentStatus(intentId: string | null) {
+  return useQuery<Payment>({
+    queryKey: [...queryKeys.payments.all, 'status', intentId],
+    queryFn: async () => {
+      const res = await fetch(`${API_V1}/payments/status/${intentId}`);
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      const data = await res.json();
+      return data.data ?? data;
+    },
+    enabled: !!intentId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === 'pending' ? 5000 : false;
     },
   });
 }


### PR DESCRIPTION


- Poll GET /payments every 5s when any payment is pending
- Show animated yellow dot for pending, green for confirmed, red for failed
- Fix confirm call from POST to PATCH to match API route
- Add usePaymentStatus hook for single-payment polling
- Add getPaymentsErrorMessage helper
- Handle 'confirmed' status (API) alongside legacy 'completed'
- closes #314