### PR TITLE
feat(wallet): implement Stellar testnet account funding UI and wallet management page (#328)

### DIFF
--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -23,6 +23,49 @@ function canReadPayments(role: string): boolean {
   return ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE', 'ASSISTANT', 'READ_ONLY'].includes(role);
 }
 
+// GET /payments/balance — fetch clinic's Stellar account balance from stellar-service
+router.get(
+  '/balance',
+  asyncHandler(async (req: Request, res: Response) => {
+    const clinicId = req.user!.clinicId;
+    const { ClinicModel } = await import('../clinics/clinic.model');
+    const clinic = await ClinicModel.findById(clinicId).lean();
+
+    if (!clinic?.stellarPublicKey) {
+      return res.status(404).json({ error: 'NotFound', message: 'No Stellar public key configured for this clinic' });
+    }
+
+    try {
+      const data = await stellarClient.getBalance(clinic.stellarPublicKey);
+      return res.json({ status: 'success', data: { publicKey: clinic.stellarPublicKey, ...data } });
+    } catch (err: any) {
+      return res.status(502).json({ error: 'StellarServiceError', message: err.message });
+    }
+  }),
+);
+
+// POST /payments/fund — fund clinic's testnet account via Friendbot
+router.post(
+  '/fund',
+  asyncHandler(async (req: Request, res: Response) => {
+    const clinicId = req.user!.clinicId;
+    const { ClinicModel } = await import('../clinics/clinic.model');
+    const clinic = await ClinicModel.findById(clinicId).lean();
+
+    if (!clinic?.stellarPublicKey) {
+      return res.status(404).json({ error: 'NotFound', message: 'No Stellar public key configured for this clinic' });
+    }
+
+    try {
+      const data = await stellarClient.fundAccount(clinic.stellarPublicKey);
+      logger.info({ clinicId, publicKey: clinic.stellarPublicKey }, 'Testnet account funded via Friendbot');
+      return res.json({ status: 'success', data });
+    } catch (err: any) {
+      return res.status(502).json({ error: 'StellarServiceError', message: err.message });
+    }
+  }),
+);
+
 // GET /payments — paginated list scoped to the authenticated clinic
 router.get(
   '/',

--- a/apps/api/src/modules/payments/services/stellar-client.ts
+++ b/apps/api/src/modules/payments/services/stellar-client.ts
@@ -67,6 +67,32 @@ class StellarClient {
   }
 
   /**
+   * Get XLM balance and recent transactions for a public key
+   * Calls the stellar-service GET /balance/:publicKey endpoint
+   */
+  async getBalance(publicKey: string): Promise<{ balance: string; transactions: unknown[] }> {
+    const secret = process.env.STELLAR_SERVICE_SECRET;
+    const response = await this.client.get(`/balance/${publicKey}`, {
+      headers: { Authorization: `Bearer ${secret}` },
+    });
+    return response.data;
+  }
+
+  /**
+   * Fund a testnet account via Friendbot
+   * Calls the stellar-service POST /fund endpoint
+   */
+  async fundAccount(publicKey: string): Promise<{ funded: boolean; hash?: string }> {
+    const secret = process.env.STELLAR_SERVICE_SECRET;
+    const response = await this.client.post(
+      '/fund',
+      { publicKey },
+      { headers: { Authorization: `Bearer ${secret}` } },
+    );
+    return response.data;
+  }
+
+  /**
    * Check if the stellar-service is healthy
    */
   async healthCheck(): Promise<{ status: string; network: string; dryRun: boolean }> {

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import express from 'express';
 import { Server } from 'http';
 import pinoHttp from 'pino-http';
-import { fundAccount, createIntent, verifyIntent } from './stellar.js'; // your existing imports
+import { fundAccount, createIntent, verifyIntent, getAccountBalance } from './stellar.js';
 import dotenv from 'dotenv';
 import logger from './logger.js';
 
@@ -70,6 +70,17 @@ app.get('/verify/:hash', async (req, res) => {
   try {
     const { hash } = req.params;
     const result = await verifyIntent(hash);
+    res.json({ success: true, ...result });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ✅ PROTECTED: GET /balance/:publicKey (requires secret)
+app.get('/balance/:publicKey', requireSecret, async (req, res) => {
+  try {
+    const { publicKey } = req.params;
+    const result = await getAccountBalance(publicKey);
     res.json({ success: true, ...result });
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/apps/stellar-service/src/stellar.ts
+++ b/apps/stellar-service/src/stellar.ts
@@ -1,0 +1,92 @@
+import StellarSdk from 'stellar-sdk';
+import { stellarConfig } from './config.js';
+import logger from './logger.js';
+
+function getServer() {
+  return new StellarSdk.Horizon.Server(stellarConfig.network === 'mainnet'
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org');
+}
+
+/** Fund a testnet account via Friendbot */
+export async function fundAccount(publicKey: string, _amount?: string) {
+  if (stellarConfig.network !== 'testnet') {
+    throw new Error('Friendbot is only available on testnet');
+  }
+  const res = await fetch(`https://friendbot.stellar.org?addr=${encodeURIComponent(publicKey)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail ?? `Friendbot error: ${res.status}`);
+  }
+  const data = await res.json();
+  logger.info({ publicKey }, 'Account funded via Friendbot');
+  return { funded: true, hash: data.hash };
+}
+
+/** Get XLM balance and recent transactions for an account */
+export async function getAccountBalance(publicKey: string) {
+  const server = getServer();
+  const account = await server.loadAccount(publicKey);
+  const xlmBalance = account.balances.find((b: any) => b.asset_type === 'native');
+  const balance = xlmBalance ? xlmBalance.balance : '0';
+
+  const payments = await server.payments().forAccount(publicKey).limit(10).order('desc').call();
+  const transactions = payments.records
+    .filter((r: any) => r.type === 'payment' || r.type === 'create_account')
+    .map((r: any) => ({
+      id: r.id,
+      type: r.type,
+      amount: r.amount ?? r.starting_balance ?? '0',
+      asset: r.asset_type === 'native' ? 'XLM' : `${r.asset_code}:${r.asset_issuer}`,
+      from: r.from ?? r.funder,
+      to: r.to ?? r.account,
+      hash: r.transaction_hash,
+      createdAt: r.created_at,
+    }));
+
+  return { balance, transactions };
+}
+
+/** Create a payment intent (build + sign + submit) */
+export async function createIntent(fromPublicKey: string, toPublicKey: string, amount: string) {
+  const server = getServer();
+  const sourceAccount = await server.loadAccount(fromPublicKey);
+  const fee = await server.fetchBaseFee();
+
+  const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+    fee: String(fee),
+    networkPassphrase: stellarConfig.network === 'mainnet'
+      ? StellarSdk.Networks.PUBLIC
+      : StellarSdk.Networks.TESTNET,
+  })
+    .addOperation(StellarSdk.Operation.payment({
+      destination: toPublicKey,
+      asset: StellarSdk.Asset.native(),
+      amount,
+    }))
+    .setTimeout(30)
+    .build();
+
+  if (stellarConfig.stellarSecretKey) {
+    const keypair = StellarSdk.Keypair.fromSecret(stellarConfig.stellarSecretKey);
+    transaction.sign(keypair);
+    if (!stellarConfig.dryRun) {
+      const result = await server.submitTransaction(transaction);
+      return { hash: result.hash, envelope: transaction.toEnvelope().toXDR('base64') };
+    }
+  }
+
+  return { envelope: transaction.toEnvelope().toXDR('base64'), dryRun: true };
+}
+
+/** Verify a transaction by hash */
+export async function verifyIntent(hash: string) {
+  const server = getServer();
+  const tx = await server.transactions().transaction(hash).call();
+  return {
+    found: true,
+    hash: tx.hash,
+    successful: tx.successful,
+    createdAt: tx.created_at,
+  };
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2,7 +2,8 @@
   "nav": {
     "patients": "Patients",
     "encounters": "Encounters",
-    "payments": "Payments"
+    "payments": "Payments",
+    "wallet": "Wallet"
   },
   "login": {
     "title": "Sign in to Health Watchers",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -2,7 +2,8 @@
   "nav": {
     "patients": "Patients",
     "encounters": "Consultations",
-    "payments": "Paiements"
+    "payments": "Paiements",
+    "wallet": "Portefeuille"
   },
   "login": {
     "title": "Connectez-vous à Health Watchers",

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { locales, defaultLocale } from "./i18n.config";
 
-const protectedRoutes = ["/patients", "/encounters", "/payments", "/settings"];
+const protectedRoutes = ["/patients", "/encounters", "/payments", "/settings", "/wallet"];
 const publicRoutes = ["/login"];
 
 export function middleware(request: NextRequest) {

--- a/apps/web/src/app/api/payments/balance/route.ts
+++ b/apps/web/src/app/api/payments/balance/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/api';
+
+export async function GET(request: NextRequest) {
+  const accessToken = request.cookies.get('accessToken')?.value;
+  if (!accessToken) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const res = await fetch(`${API_URL}/api/v1/payments/balance`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/src/app/api/payments/fund/route.ts
+++ b/apps/web/src/app/api/payments/fund/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/api';
+
+export async function POST(request: NextRequest) {
+  const accessToken = request.cookies.get('accessToken')?.value;
+  if (!accessToken) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const res = await fetch(`${API_URL}/api/v1/payments/fund`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/src/app/wallet/WalletClient.tsx
+++ b/apps/web/src/app/wallet/WalletClient.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+import { getStellarExplorerUrl } from '@/lib/stellar';
+import {
+  PageWrapper,
+  PageHeader,
+  Card,
+  CardHeader,
+  CardTitle,
+  Badge,
+  Button,
+  Input,
+  Modal,
+  Toast,
+  Spinner,
+  ErrorMessage,
+  StellarAddressDisplay,
+} from '@/components/ui';
+
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
+const IS_TESTNET = NETWORK === 'testnet';
+
+interface Transaction {
+  id: string;
+  type: string;
+  amount: string;
+  asset: string;
+  from: string;
+  to: string;
+  hash: string;
+  createdAt: string;
+}
+
+interface WalletBalance {
+  publicKey: string;
+  balance: string;
+  transactions: Transaction[];
+}
+
+function useWalletBalance() {
+  return useQuery<WalletBalance>({
+    queryKey: queryKeys.wallet.balance(),
+    queryFn: async () => {
+      const res = await fetch('/api/payments/balance');
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? `Error ${res.status}`);
+      }
+      const body = await res.json();
+      return body.data;
+    },
+    retry: 1,
+  });
+}
+
+interface SendPaymentFormProps {
+  balance: string;
+  onSubmit: (data: { destination: string; amount: string; memo?: string }) => void;
+  onCancel: () => void;
+  loading: boolean;
+}
+
+function SendPaymentForm({ balance, onSubmit, onCancel, loading }: SendPaymentFormProps) {
+  const [destination, setDestination] = useState('');
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validate = () => {
+    const e: Record<string, string> = {};
+    if (!destination.trim()) e.destination = 'Destination is required';
+    if (!amount || isNaN(Number(amount)) || Number(amount) <= 0) e.amount = 'Enter a valid amount';
+    else if (Number(amount) > Number(balance)) e.amount = `Insufficient balance (${balance} XLM available)`;
+    return e;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs = validate();
+    if (Object.keys(errs).length) { setErrors(errs); return; }
+    onSubmit({ destination: destination.trim(), amount, memo: memo.trim() || undefined });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Input
+        label="Destination Public Key"
+        value={destination}
+        onChange={(e) => setDestination(e.target.value)}
+        placeholder="G..."
+        error={errors.destination}
+      />
+      <Input
+        label="Amount (XLM)"
+        type="number"
+        min="0.0000001"
+        step="any"
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+        helperText={`Available: ${balance} XLM`}
+        error={errors.amount}
+      />
+      <Input
+        label="Memo (optional)"
+        value={memo}
+        onChange={(e) => setMemo(e.target.value)}
+        placeholder="Payment reference"
+      />
+      <div className="flex justify-end gap-3 pt-2">
+        <Button type="button" variant="secondary" onClick={onCancel} disabled={loading}>Cancel</Button>
+        <Button type="submit" loading={loading}>Review Payment</Button>
+      </div>
+    </form>
+  );
+}
+
+interface ConfirmPaymentModalProps {
+  open: boolean;
+  data: { destination: string; amount: string; memo?: string } | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading: boolean;
+}
+
+function ConfirmPaymentModal({ open, data, onConfirm, onCancel, loading }: ConfirmPaymentModalProps) {
+  if (!data) return null;
+  return (
+    <Modal open={open} onClose={onCancel} title="Confirm Payment" size="sm">
+      <div className="flex flex-col gap-3 text-sm text-neutral-700">
+        <div className="flex justify-between">
+          <span className="text-neutral-500">To</span>
+          <StellarAddressDisplay value={data.destination} />
+        </div>
+        <div className="flex justify-between">
+          <span className="text-neutral-500">Amount</span>
+          <span className="font-semibold">{data.amount} XLM</span>
+        </div>
+        {data.memo && (
+          <div className="flex justify-between">
+            <span className="text-neutral-500">Memo</span>
+            <span>{data.memo}</span>
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end gap-3 mt-6">
+        <Button variant="secondary" onClick={onCancel} disabled={loading}>Cancel</Button>
+        <Button onClick={onConfirm} loading={loading}>Send Payment</Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default function WalletClient() {
+  const queryClient = useQueryClient();
+  const { data: wallet, isLoading, error, refetch } = useWalletBalance();
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [showSendForm, setShowSendForm] = useState(false);
+  const [pendingPayment, setPendingPayment] = useState<{ destination: string; amount: string; memo?: string } | null>(null);
+
+  const fundMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch('/api/payments/fund', { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? `Error ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setToast({ message: 'Account funded successfully! Balance will update shortly.', type: 'success' });
+      // Delay refetch to allow Horizon to index the transaction
+      setTimeout(() => queryClient.invalidateQueries({ queryKey: queryKeys.wallet.balance() }), 3000);
+    },
+    onError: (err: Error) => {
+      setToast({ message: err.message, type: 'error' });
+    },
+  });
+
+  const sendMutation = useMutation({
+    mutationFn: async (data: { destination: string; amount: string; memo?: string }) => {
+      const res = await fetch('/api/v1/payments/intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...data, assetCode: 'XLM' }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? `Error ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setPendingPayment(null);
+      setShowSendForm(false);
+      setToast({ message: 'Payment initiated successfully.', type: 'success' });
+      queryClient.invalidateQueries({ queryKey: queryKeys.wallet.balance() });
+    },
+    onError: (err: Error) => {
+      setPendingPayment(null);
+      setToast({ message: err.message, type: 'error' });
+    },
+  });
+
+  return (
+    <PageWrapper className="py-8 space-y-6">
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+
+      <PageHeader
+        title="Wallet"
+        subtitle="Manage your clinic's Stellar account"
+      />
+
+      {isLoading && (
+        <div role="status" aria-live="polite" className="flex items-center gap-3 py-12 text-neutral-500">
+          <Spinner />
+          <span>Loading wallet...</span>
+        </div>
+      )}
+
+      {error && (
+        <ErrorMessage
+          message={(error as Error).message}
+          onRetry={() => refetch()}
+        />
+      )}
+
+      {wallet && (
+        <>
+          {/* Account Overview */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Account Overview</CardTitle>
+              <Badge variant={IS_TESTNET ? 'warning' : 'success'}>
+                {IS_TESTNET ? 'Testnet' : 'Mainnet'}
+              </Badge>
+            </CardHeader>
+
+            <div className="space-y-4">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
+                <span className="text-sm text-neutral-500 shrink-0">Public Key</span>
+                <StellarAddressDisplay value={wallet.publicKey} className="text-sm" />
+                <span className="font-mono text-xs text-neutral-400 hidden sm:block truncate">{wallet.publicKey}</span>
+              </div>
+
+              <div className="flex items-end gap-2">
+                <span className="text-4xl font-bold text-neutral-900 tabular-nums">
+                  {parseFloat(wallet.balance).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 })}
+                </span>
+                <span className="text-lg text-neutral-500 mb-1">XLM</span>
+              </div>
+
+              <div className="flex flex-wrap gap-3 pt-2">
+                <Button onClick={() => setShowSendForm(true)} disabled={parseFloat(wallet.balance) <= 0}>
+                  Send Payment
+                </Button>
+                {IS_TESTNET && (
+                  <Button
+                    variant="outline"
+                    onClick={() => fundMutation.mutate()}
+                    loading={fundMutation.isPending}
+                    disabled={fundMutation.isSuccess}
+                    title={fundMutation.isSuccess ? 'Already funded this session' : 'Fund with Friendbot (testnet only)'}
+                  >
+                    {fundMutation.isSuccess ? '✓ Funded' : 'Fund with Friendbot'}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </Card>
+
+          {/* Send Payment Form */}
+          {showSendForm && !pendingPayment && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Send Payment</CardTitle>
+              </CardHeader>
+              <SendPaymentForm
+                balance={wallet.balance}
+                onSubmit={(data) => { setPendingPayment(data); setShowSendForm(false); }}
+                onCancel={() => setShowSendForm(false)}
+                loading={false}
+              />
+            </Card>
+          )}
+
+          {/* Recent Transactions */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent Transactions</CardTitle>
+              <span className="text-xs text-neutral-400">Last 10</span>
+            </CardHeader>
+
+            {wallet.transactions.length === 0 ? (
+              <p className="text-sm text-neutral-500 py-4 text-center">No transactions yet.</p>
+            ) : (
+              <div className="overflow-x-auto -mx-6">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-neutral-100">
+                      <th className="px-6 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wide">Type</th>
+                      <th className="px-6 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wide">Amount</th>
+                      <th className="px-6 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wide">From / To</th>
+                      <th className="px-6 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wide">Date</th>
+                      <th className="px-6 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wide">Tx</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-neutral-50">
+                    {wallet.transactions.map((tx) => {
+                      const isIncoming = tx.to === wallet.publicKey;
+                      return (
+                        <tr key={tx.id} className="hover:bg-neutral-50">
+                          <td className="px-6 py-3">
+                            <Badge variant={isIncoming ? 'success' : 'default'}>
+                              {isIncoming ? '↓ In' : '↑ Out'}
+                            </Badge>
+                          </td>
+                          <td className="px-6 py-3 font-mono font-medium">
+                            {parseFloat(tx.amount).toFixed(2)} {tx.asset}
+                          </td>
+                          <td className="px-6 py-3">
+                            <StellarAddressDisplay value={isIncoming ? tx.from : tx.to} />
+                          </td>
+                          <td className="px-6 py-3 text-neutral-500 whitespace-nowrap">
+                            {new Date(tx.createdAt).toLocaleDateString()}
+                          </td>
+                          <td className="px-6 py-3">
+                            <a
+                              href={getStellarExplorerUrl(tx.hash, NETWORK)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-primary-500 hover:underline text-xs font-mono"
+                              aria-label={`View transaction ${tx.hash} on Stellar Explorer`}
+                            >
+                              {tx.hash.slice(0, 8)}…
+                            </a>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </Card>
+        </>
+      )}
+
+      {/* Confirm Payment Modal */}
+      <ConfirmPaymentModal
+        open={!!pendingPayment}
+        data={pendingPayment}
+        onConfirm={() => pendingPayment && sendMutation.mutate(pendingPayment)}
+        onCancel={() => { setPendingPayment(null); setShowSendForm(true); }}
+        loading={sendMutation.isPending}
+      />
+    </PageWrapper>
+  );
+}

--- a/apps/web/src/app/wallet/page.tsx
+++ b/apps/web/src/app/wallet/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import WalletClient from './WalletClient';
+
+export const metadata: Metadata = {
+  title: 'Wallet',
+  description: "Manage your clinic's Stellar wallet, view XLM balance, and send payments.",
+};
+
+export default function WalletPage() {
+  return <WalletClient />;
+}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -12,6 +12,7 @@ export default async function Navbar() {
     { href: "/patients", label: t("patients") },
     { href: "/encounters", label: t("encounters") },
     { href: "/payments", label: t("payments") },
+    { href: "/wallet", label: t("wallet") },
     { href: "/settings", label: "Settings" },
   ];
 

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -1,7 +1,45 @@
 'use client';
 
-export function Toast({ children }: { children?: React.ReactNode }) {
-  return <>{children}</>;
+import { useEffect } from 'react';
+
+interface ToastProps {
+  message: string;
+  type?: 'success' | 'error' | 'info';
+  onClose?: () => void;
+  duration?: number;
+}
+
+export function Toast({ message, type = 'info', onClose, duration = 4000 }: ToastProps) {
+  useEffect(() => {
+    if (!onClose) return;
+    const t = setTimeout(onClose, duration);
+    return () => clearTimeout(t);
+  }, [onClose, duration]);
+
+  const colors = {
+    success: 'bg-green-600',
+    error: 'bg-red-600',
+    info: 'bg-neutral-800',
+  };
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={`fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-white shadow-lg ${colors[type]}`}
+    >
+      <span>{message}</span>
+      {onClose && (
+        <button
+          onClick={onClose}
+          aria-label="Dismiss notification"
+          className="ml-2 opacity-70 hover:opacity-100 focus:outline-none"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
 }
 
 export function Toaster() {

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -13,4 +13,8 @@ export const queryKeys = {
     all: ['payments'] as const,
     list: () => [...queryKeys.payments.all, 'list'] as const,
   },
+  wallet: {
+    all: ['wallet'] as const,
+    balance: () => [...queryKeys.wallet.all, 'balance'] as const,
+  },
 } as const;


### PR DESCRIPTION
closes #328 

## Summary

Implements the wallet management page and all supporting backend/frontend plumbing for clinic administrators to manage their Stellar account, fund testnet accounts, and initiate payments.

## Changes

**Backend (API)**
- `GET /api/v1/payments/balance` — fetches clinic's XLM balance and last 10 transactions from Horizon using the clinic's configured `stellarPublicKey`
- `POST /api/v1/payments/fund` — proxies Friendbot to fund the clinic's testnet account; both endpoints are auth-protected

**Stellar Service**
- Added `/balance/:publicKey` and `/fund` endpoints with shared-secret authorization
- `getAccountBalance()` returns XLM balance + recent payment records mapped to a clean transaction shape

**Frontend (Next.js)**
- `/wallet` page with:
  - Account overview: public key display, live XLM balance, testnet/mainnet badge
  - "Fund with Friendbot" button — visible only when `STELLAR_NETWORK=testnet`, disabled after first use
  - Send payment form with balance validation
  - Confirmation dialog before submitting
  - Recent transactions table (last 10) with Stellar Explorer links
- Next.js proxy routes at `/api/payments/balance` and `/api/payments/fund`
- `/wallet` added to protected routes in middleware
- Wallet nav link added with i18n support (EN: "Wallet" / FR: "Portefeuille")
- Fixed `Toast` component to support `message`, `type`, and `onClose` props with auto-dismiss

## Acceptance Criteria

- [x] Wallet page at `/wallet` shows clinic's Stellar public key and XLM balance
- [x] Balance fetched from Horizon API in real-time
- [x] Testnet funding button visible only when `STELLAR_NETWORK=testnet`
- [x] Friendbot funding shows success/error feedback
- [x] Payment form validates amount against available balance
- [x] Confirmation dialog shown before submitting payment
- [x] Recent transactions list shows last 10 with Stellar Explorer links
- [x] `POST /api/v1/payments/fund` proxy endpoint added
- [x] `GET /api/v1/payments/balance` endpoint returns current XLM balance
- [x] Wallet page is protected (requires authentication)

## Testing

1. Set `STELLAR_NETWORK=testnet` in `.env`
2. Ensure clinic has a `stellarPublicKey` configured in settings
3. Navigate to `/wallet` — balance and transactions should load
4. Click "Fund with Friendbot" — should show success toast and refresh balance after ~3s
5. Click "Send Payment", fill the form, confirm in the dialog