### PR TITLE
feat(web): add accessibility (WCAG 2.1 AA) compliance

### DIFF
--- a/apps/web/src/app/encounters/new/page.tsx
+++ b/apps/web/src/app/encounters/new/page.tsx
@@ -326,7 +326,7 @@ export default function NewEncounterPage() {
                   className="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto rounded-md border border-neutral-200 bg-white shadow-lg"
                 >
                   {patientSearching && (
-                    <li className="px-4 py-2 text-sm text-neutral-400">Searching…</li>
+                    <li className="px-4 py-2 text-sm text-neutral-500">Searching…</li>
                   )}
                   {patientHits.map((p) => (
                     <li
@@ -348,7 +348,7 @@ export default function NewEncounterPage() {
                       <span className="font-medium">
                         {p.firstName} {p.lastName}
                       </span>
-                      <span className="ml-2 text-xs text-neutral-400">
+                      <span className="ml-2 text-xs text-neutral-500">
                         {p.systemId} · {formatDate(p.dateOfBirth)}
                       </span>
                     </li>
@@ -377,7 +377,7 @@ export default function NewEncounterPage() {
               placeholder="Describe the primary reason for this visit…"
               error={errors.chiefComplaint}
             />
-            <span className="absolute right-3 bottom-2 text-xs text-neutral-400" aria-live="polite">
+            <span className="absolute right-3 bottom-2 text-xs text-neutral-500" aria-live="polite">
               {chiefComplaint.length}/500
             </span>
           </div>
@@ -395,7 +395,7 @@ export default function NewEncounterPage() {
           >
             <span>
               Vital Signs{' '}
-              <span className="font-normal text-neutral-400 normal-case">(optional)</span>
+              <span className="font-normal text-neutral-500 normal-case">(optional)</span>
             </span>
             <span aria-hidden="true">{vitalsOpen ? '▲' : '▼'}</span>
           </button>
@@ -520,7 +520,7 @@ export default function NewEncounterPage() {
               placeholder="Clinical observations, history, examination findings…"
               error={errors.notes}
             />
-            <span className="absolute right-3 bottom-2 text-xs text-neutral-400" aria-live="polite">
+            <span className="absolute right-3 bottom-2 text-xs text-neutral-500" aria-live="polite">
               {notes.length}/10,000
             </span>
           </div>
@@ -533,7 +533,7 @@ export default function NewEncounterPage() {
             className="mb-3 text-sm font-semibold tracking-wide text-neutral-500 uppercase"
           >
             Diagnosis (ICD-10){' '}
-            <span className="font-normal text-neutral-400 normal-case">— up to 10</span>
+            <span className="font-normal text-neutral-500 normal-case">— up to 10</span>
           </h2>
 
           {diagnoses.length > 0 && (
@@ -546,13 +546,13 @@ export default function NewEncounterPage() {
                   <span>
                     <span className="text-primary-700 font-mono font-medium">{d.code}</span>
                     <span className="ml-2 text-neutral-700">{d.description}</span>
-                    {i === 0 && <span className="ml-2 text-xs text-neutral-400">(primary)</span>}
+                    {i === 0 && <span className="ml-2 text-xs text-neutral-500">(primary)</span>}
                   </span>
                   <button
                     type="button"
                     onClick={() => removeDiagnosis(d.code)}
                     aria-label={`Remove ${d.code}`}
-                    className="hover:text-danger-500 focus-visible:ring-primary-500 ml-3 rounded text-neutral-400 focus:outline-none focus-visible:ring-2"
+                    className="hover:text-danger-500 focus-visible:ring-primary-500 ml-3 rounded text-neutral-500 focus:outline-none focus-visible:ring-2"
                   >
                     ✕
                   </button>

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -66,7 +66,7 @@ function NotificationRow({ n }: { n: Notification }) {
           <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${TYPE_COLORS[n.type]}`}>
             {TYPE_LABELS[n.type]}
           </span>
-          <span className="text-xs text-neutral-400">{formatDate(n.createdAt)}</span>
+          <span className="text-xs text-neutral-500">{formatDate(n.createdAt)}</span>
         </div>
         <button
           type="button"
@@ -93,7 +93,7 @@ function NotificationRow({ n }: { n: Notification }) {
         <button
           type="button"
           onClick={() => deleteNotif.mutate(n._id)}
-          className="text-xs text-neutral-400 hover:text-red-500 focus:outline-none"
+          className="text-xs text-neutral-500 hover:text-red-500 focus:outline-none"
           aria-label="Delete notification"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
+++ b/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
@@ -300,7 +300,7 @@ export default function PatientDetailClient({
               <Badge variant={patient.gender === 'inactive' ? 'danger' : 'success'}>
                 {labels.active}
               </Badge>
-              <span className="text-xs text-neutral-400">
+              <span className="text-xs text-neutral-500">
                 {labels.registeredOn}: {formatDate((patient as any).createdAt)}
               </span>
             </div>
@@ -318,37 +318,37 @@ export default function PatientDetailClient({
 
         <dl className="grid grid-cols-2 gap-x-6 gap-y-4 text-sm sm:grid-cols-3">
           <div>
-            <dt className="text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <dt className="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
               {labels.systemId}
             </dt>
             <dd className="mt-0.5 font-mono text-neutral-900">{patient.systemId}</dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <dt className="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
               {labels.dob}
             </dt>
             <dd className="mt-0.5 text-neutral-900">{formatDate(patient.dateOfBirth)}</dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <dt className="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
               {labels.age}
             </dt>
             <dd className="mt-0.5 text-neutral-900">{calcAge(patient.dateOfBirth)}</dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <dt className="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
               {labels.sex}
             </dt>
             <dd className="mt-0.5 text-neutral-900">{patient.sex}</dd>
           </div>
           <div>
-            <dt className="text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <dt className="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
               {labels.contact}
             </dt>
             <dd className="mt-0.5 text-neutral-900">{patient.contactNumber || 'N/A'}</dd>
           </div>
           <div className="sm:col-span-2">
-            <dt className="text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+            <dt className="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
               {labels.address}
             </dt>
             <dd className="mt-0.5 text-neutral-900">{patient.address || 'N/A'}</dd>
@@ -406,7 +406,7 @@ export default function PatientDetailClient({
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div>
                       <p className="font-medium text-neutral-900">{enc.chiefComplaint}</p>
-                      <p className="mt-0.5 text-xs text-neutral-400">{formatDate(enc.createdAt)}</p>
+                      <p className="mt-0.5 text-xs text-neutral-500">{formatDate(enc.createdAt)}</p>
                     </div>
                     <Badge variant={statusVariant(enc.status)}>{enc.status}</Badge>
                   </div>
@@ -467,9 +467,9 @@ export default function PatientDetailClient({
                     <div>
                       <p className="font-medium text-neutral-900">
                         {p.amount}{' '}
-                        <span className="font-normal text-neutral-400">{p.assetCode ?? 'XLM'}</span>
+                        <span className="font-normal text-neutral-500">{p.assetCode ?? 'XLM'}</span>
                       </p>
-                      <p className="mt-0.5 text-xs text-neutral-400">
+                      <p className="mt-0.5 text-xs text-neutral-500">
                         {p.createdAt ? new Date(p.createdAt).toLocaleDateString() : '—'}
                       </p>
                     </div>
@@ -538,13 +538,13 @@ export default function PatientDetailClient({
               <>
                 <p className="text-sm leading-relaxed text-neutral-600">{aiSummary}</p>
                 {aiLastRun && (
-                  <p className="mt-3 text-xs text-neutral-400">
+                  <p className="mt-3 text-xs text-neutral-500">
                     {labels.lastAnalysis}: {aiLastRun.toLocaleString()}
                   </p>
                 )}
               </>
             ) : (
-              <p className="text-sm text-neutral-400">{labels.aiSummaryPlaceholder}</p>
+              <p className="text-sm text-neutral-500">{labels.aiSummaryPlaceholder}</p>
             )}
           </div>
         </TabsContent>

--- a/apps/web/src/app/wallet/WalletClient.tsx
+++ b/apps/web/src/app/wallet/WalletClient.tsx
@@ -290,7 +290,7 @@ export default function WalletClient() {
               <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-4">
                 <span className="shrink-0 text-sm text-neutral-500">Public Key</span>
                 <StellarAddressDisplay value={wallet.publicKey} className="text-sm" />
-                <span className="hidden truncate font-mono text-xs text-neutral-400 sm:block">
+                <span className="hidden truncate font-mono text-xs text-neutral-500 sm:block">
                   {wallet.publicKey}
                 </span>
               </div>
@@ -316,7 +316,7 @@ export default function WalletClient() {
                   <span className="mb-0.5 text-base text-neutral-500">USDC</span>
                 </div>
               ) : (
-                <p className="text-sm text-neutral-400">
+                <p className="text-sm text-neutral-500">
                   No USDC trustline — create one to receive USDC payments.
                 </p>
               )}
@@ -379,7 +379,7 @@ export default function WalletClient() {
           <Card>
             <CardHeader>
               <CardTitle>Recent Transactions</CardTitle>
-              <span className="text-xs text-neutral-400">Last 10</span>
+              <span className="text-xs text-neutral-500">Last 10</span>
             </CardHeader>
 
             {wallet.transactions.length === 0 ? (

--- a/apps/web/src/components/dashboard/RecentTable.tsx
+++ b/apps/web/src/components/dashboard/RecentTable.tsx
@@ -25,7 +25,7 @@ export function RecentTable<T extends Record<string, unknown>>({
         <h2 className="text-base font-semibold text-neutral-900">{title}</h2>
       </div>
       {rows.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-12 text-neutral-400">
+        <div className="flex flex-col items-center justify-center py-12 text-neutral-500">
           <span className="mb-2 text-4xl" aria-hidden="true">
             📭
           </span>
@@ -33,6 +33,7 @@ export function RecentTable<T extends Record<string, unknown>>({
         </div>
       ) : (
         <Table>
+          <caption className="sr-only">{title}</caption>
           <TableHead>
             <TableRow>
               {columns.map((col) => (

--- a/apps/web/src/components/forms/PaymentIntentForm.tsx
+++ b/apps/web/src/components/forms/PaymentIntentForm.tsx
@@ -100,7 +100,7 @@ export function PaymentIntentForm({ onSubmit, onCancel }: Props) {
               {amount} {asset}
             </span>
           </div>
-          <p className="pt-1 text-xs text-neutral-400">
+          <p className="pt-1 text-xs text-neutral-500">
             Review carefully — Stellar transactions cannot be reversed.
           </p>
         </div>

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -49,6 +49,7 @@ export default function TopBar({ onMenuClick }: TopBarProps) {
       <div className="flex items-center gap-3">
         <NotificationBell />
         <div
+          role="img"
           className="bg-primary-500 flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold text-white select-none"
           aria-label={user ? `Logged in as ${user.name}` : 'Not logged in'}
           title={user?.name}

--- a/apps/web/src/components/notifications/NotificationBell.tsx
+++ b/apps/web/src/components/notifications/NotificationBell.tsx
@@ -40,7 +40,7 @@ function NotificationItem({ n, onRead }: { n: Notification; onRead: (id: string)
           <div className={!n.isRead ? '' : 'pl-4'}>
             <p className="text-sm font-medium text-neutral-900 leading-snug">{n.title}</p>
             <p className="text-xs text-neutral-500 mt-0.5 line-clamp-2">{n.message}</p>
-            <p className="text-xs text-neutral-400 mt-1">{timeAgo(n.createdAt)}</p>
+            <p className="text-xs text-neutral-500 mt-1">{timeAgo(n.createdAt)}</p>
           </div>
         </div>
       </button>

--- a/apps/web/src/components/patients/LabResultsTab.tsx
+++ b/apps/web/src/components/patients/LabResultsTab.tsx
@@ -206,10 +206,10 @@ export default function LabResultsTab({ patientId }: { patientId: string }) {
                     <p className="font-medium text-neutral-900">
                       {lab.testName}
                       {lab.testCode && (
-                        <span className="ml-2 text-xs text-neutral-400 font-mono">{lab.testCode}</span>
+                        <span className="ml-2 text-xs text-neutral-500 font-mono">{lab.testCode}</span>
                       )}
                     </p>
-                    <p className="text-xs text-neutral-400 mt-0.5">
+                    <p className="text-xs text-neutral-500 mt-0.5">
                       Ordered: {new Date(lab.orderedAt).toLocaleDateString()}
                       {lab.resultedAt && ` · Resulted: ${new Date(lab.resultedAt).toLocaleDateString()}`}
                     </p>

--- a/apps/web/src/components/payments/PaymentTable.tsx
+++ b/apps/web/src/components/payments/PaymentTable.tsx
@@ -176,7 +176,7 @@ export function PaymentTable({ payments, network = 'testnet', onConfirm }: Props
           <tbody className="divide-y divide-neutral-100 bg-white">
             {filtered.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-4 py-8 text-center text-neutral-400">
+                <td colSpan={7} className="px-4 py-8 text-center text-neutral-500">
                   No payments match the current filters.
                 </td>
               </tr>
@@ -192,7 +192,7 @@ export function PaymentTable({ payments, network = 'testnet', onConfirm }: Props
                   <td className="px-4 py-3 text-neutral-700">{p.patientId}</td>
                   <td className="px-4 py-3 font-medium text-neutral-900">
                     {p.amount}{' '}
-                    <span className="font-normal text-neutral-400">{p.asset ?? 'XLM'}</span>
+                    <span className="font-normal text-neutral-500">{p.asset ?? 'XLM'}</span>
                   </td>
                   <td className="px-4 py-3">
                     <StatusIndicator status={p.status} />

--- a/apps/web/src/components/ui/Input.tsx
+++ b/apps/web/src/components/ui/Input.tsx
@@ -26,7 +26,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         <div className="relative flex items-center">
           {leftIcon && (
-            <span className="pointer-events-none absolute left-3 text-neutral-400">{leftIcon}</span>
+            <span className="pointer-events-none absolute left-3 text-neutral-500">{leftIcon}</span>
           )}
           <input
             ref={ref}
@@ -36,7 +36,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               hasError ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
             }
             className={[
-              'bg-neutral-0 w-full rounded-md border px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400',
+              'bg-neutral-0 w-full rounded-md border px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-500',
               'focus:ring-primary-500 focus:border-primary-500 transition-colors focus:ring-2 focus:outline-none',
               'disabled:cursor-not-allowed disabled:opacity-50',
               hasError ? 'border-danger-500' : 'border-neutral-200',
@@ -46,7 +46,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             ].join(' ')}
             {...props}
           />
-          {rightIcon && <span className="absolute right-3 text-neutral-400">{rightIcon}</span>}
+          {rightIcon && <span className="absolute right-3 text-neutral-500">{rightIcon}</span>}
         </div>
         {hasError && (
           <p id={`${inputId}-error`} role={errorRole} className="text-danger-500 text-xs">

--- a/apps/web/src/components/ui/Modal.tsx
+++ b/apps/web/src/components/ui/Modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 
 export interface ModalProps {
   open: boolean;
@@ -27,6 +27,44 @@ export function Modal({
   className,
   size = 'md',
 }: ModalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Focus management
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      if (containerRef.current) containerRef.current.focus();
+
+      const handleTab = (e: KeyboardEvent) => {
+        if (e.key !== 'Tab' || !containerRef.current) return;
+        const focusable = containerRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0] as HTMLElement;
+        const last = focusable[focusable.length - 1] as HTMLElement;
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last?.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first?.focus();
+          }
+        }
+      };
+
+      document.addEventListener('keydown', handleTab);
+      return () => {
+        document.removeEventListener('keydown', handleTab);
+        previousFocusRef.current?.focus();
+      };
+    }
+  }, [open]);
+
   // Close on Escape key
   useEffect(() => {
     if (!open) return;
@@ -58,8 +96,10 @@ export function Modal({
 
       {/* Panel */}
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
         aria-labelledby={title ? 'modal-title' : undefined}
         aria-describedby={description ? 'modal-description' : undefined}
         className={[
@@ -90,7 +130,7 @@ export function Modal({
         {/* Close button */}
         <button
           onClick={onClose}
-          className="focus:ring-primary-500 absolute top-4 right-4 rounded-md p-1 text-neutral-400 hover:text-neutral-700 focus:ring-2 focus:outline-none"
+          className="focus:ring-primary-500 absolute top-4 right-4 rounded-md p-1 text-neutral-500 hover:text-neutral-700 focus:ring-2 focus:outline-none"
           aria-label="Close"
         >
           <svg

--- a/apps/web/src/components/ui/PasswordInput.tsx
+++ b/apps/web/src/components/ui/PasswordInput.tsx
@@ -56,7 +56,7 @@ export function PasswordInput({ error, ...props }: PasswordInputProps) {
       type="button"
       aria-label={visible ? 'Hide password' : 'Show password'}
       onClick={() => setVisible((v) => !v)}
-      className="text-neutral-400 hover:text-neutral-600 focus:text-neutral-600 focus:outline-none"
+      className="text-neutral-500 hover:text-neutral-600 focus:text-neutral-600 focus:outline-none"
     >
       {visible ? <EyeOffIcon /> : <EyeIcon />}
     </button>

--- a/apps/web/src/components/ui/PasswordStrengthIndicator.tsx
+++ b/apps/web/src/components/ui/PasswordStrengthIndicator.tsx
@@ -52,7 +52,7 @@ export function PasswordStrengthIndicator({ password }: { password: string }) {
           return (
             <li
               key={r.label}
-              className={`flex items-center gap-1.5 text-xs ${ok ? 'text-success-600' : 'text-neutral-400'}`}
+              className={`flex items-center gap-1.5 text-xs ${ok ? 'text-success-600' : 'text-neutral-500'}`}
             >
               <span aria-hidden="true">{ok ? '✓' : '○'}</span>
               {r.label}

--- a/apps/web/src/components/ui/SearchInput.tsx
+++ b/apps/web/src/components/ui/SearchInput.tsx
@@ -8,7 +8,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ className, value, onClear, ...props }, ref) => (
     <div className="relative flex items-center">
       {/* Search icon */}
-      <span className="pointer-events-none absolute left-3 text-neutral-400">
+      <span className="pointer-events-none absolute left-3 text-neutral-500">
         <svg
           className="h-4 w-4"
           fill="none"
@@ -31,7 +31,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
         role="searchbox"
         value={value}
         className={[
-          'bg-neutral-0 w-full rounded-md border border-neutral-200 py-2 pr-9 pl-9 text-sm text-neutral-900 placeholder:text-neutral-400',
+          'bg-neutral-0 w-full rounded-md border border-neutral-200 py-2 pr-9 pl-9 text-sm text-neutral-900 placeholder:text-neutral-500',
           'focus:ring-primary-500 focus:border-primary-500 transition-colors focus:ring-2 focus:outline-none',
           'disabled:cursor-not-allowed disabled:opacity-50',
           className ?? '',
@@ -45,7 +45,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           type="button"
           onClick={onClear}
           aria-label="Clear search"
-          className="absolute right-2.5 text-neutral-400 hover:text-neutral-700 focus:outline-none"
+          className="absolute right-2.5 text-neutral-500 hover:text-neutral-700 focus:outline-none"
         >
           <svg
             className="h-4 w-4"

--- a/apps/web/src/components/ui/Select.tsx
+++ b/apps/web/src/components/ui/Select.tsx
@@ -50,7 +50,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             ))}
           </select>
           {/* Chevron icon */}
-          <span className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 text-neutral-400">
+          <span className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 text-neutral-500">
             <svg
               className="h-4 w-4"
               fill="none"

--- a/apps/web/src/components/ui/SlideOver.tsx
+++ b/apps/web/src/components/ui/SlideOver.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 
 interface SlideOverProps {
   isOpen: boolean;
@@ -19,6 +19,50 @@ export function SlideOver({
   children,
   width = 'w-full sm:w-96',
 }: SlideOverProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Focus management
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      if (containerRef.current) containerRef.current.focus();
+
+      const handleTab = (e: KeyboardEvent) => {
+        if (e.key !== 'Tab' || !containerRef.current) return;
+        const focusable = containerRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const first = focusable[0] as HTMLElement;
+        const last = focusable[focusable.length - 1] as HTMLElement;
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last?.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first?.focus();
+          }
+        }
+      };
+
+      const handleEscape = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') onClose();
+      };
+
+      document.addEventListener('keydown', handleTab);
+      document.addEventListener('keydown', handleEscape);
+      return () => {
+        document.removeEventListener('keydown', handleTab);
+        document.removeEventListener('keydown', handleEscape);
+        previousFocusRef.current?.focus();
+      };
+    }
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   return (
@@ -27,19 +71,26 @@ export function SlideOver({
       <div className="fixed inset-0 z-40 bg-black/40" onClick={onClose} aria-hidden="true" />
       {/* Panel */}
       <div
-        className={`fixed inset-y-0 right-0 z-50 flex flex-col bg-white shadow-xl ${width}`}
+        ref={containerRef}
+        className={`fixed inset-y-0 right-0 z-50 flex flex-col bg-white shadow-xl focus:outline-none ${width}`}
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
+        aria-labelledby={title ? 'slide-over-title' : undefined}
       >
         <div className="flex items-center justify-between border-b border-neutral-200 px-6 py-4">
           <div>
-            {title && <h2 className="text-lg font-semibold text-neutral-900">{title}</h2>}
+            {title && (
+              <h2 id="slide-over-title" className="text-lg font-semibold text-neutral-900">
+                {title}
+              </h2>
+            )}
             {subtitle && <p className="text-sm text-neutral-500">{subtitle}</p>}
           </div>
           <button
             onClick={onClose}
             aria-label="Close"
-            className="focus:ring-primary-500 rounded-md p-1 text-neutral-400 hover:text-neutral-700 focus:ring-2 focus:outline-none"
+            className="focus:ring-primary-500 rounded-md p-1 text-neutral-500 hover:text-neutral-700 focus:ring-2 focus:outline-none"
           >
             <svg
               className="h-5 w-5"

--- a/apps/web/src/components/ui/StellarAddressDisplay.tsx
+++ b/apps/web/src/components/ui/StellarAddressDisplay.tsx
@@ -37,7 +37,7 @@ export function StellarAddressDisplay({
         </a>
         {/* external link icon */}
         <svg
-          className="h-3 w-3 text-neutral-400"
+          className="h-3 w-3 text-neutral-500"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/apps/web/src/components/ui/Tabs.tsx
+++ b/apps/web/src/components/ui/Tabs.tsx
@@ -31,9 +31,30 @@ export function Tabs({ value, onValueChange, children, className }: TabsProps) {
 }
 
 export function TabsList({ children, className }: { children: ReactNode; className?: string }) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.role !== 'tab') return;
+
+    const tabs = Array.from(e.currentTarget.querySelectorAll('[role="tab"]')) as HTMLElement[];
+    const index = tabs.indexOf(target);
+
+    let nextIndex: number | null = null;
+    if (e.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length;
+    if (e.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length;
+    if (e.key === 'Home') nextIndex = 0;
+    if (e.key === 'End') nextIndex = tabs.length - 1;
+
+    if (nextIndex !== null) {
+      e.preventDefault();
+      tabs[nextIndex].focus();
+      tabs[nextIndex].click();
+    }
+  };
+
   return (
     <div
       role="tablist"
+      onKeyDown={handleKeyDown}
       className={['flex gap-1 border-b border-neutral-200', className ?? ''].join(' ')}
     >
       {children}
@@ -54,7 +75,10 @@ export function TabsTrigger({ value, children, className }: TabsTriggerProps) {
   return (
     <button
       role="tab"
+      id={`tab-trigger-${value}`}
       aria-selected={isActive}
+      aria-controls={`tab-panel-${value}`}
+      tabIndex={isActive ? 0 : -1}
       onClick={() => onChange(value)}
       className={[
         'focus-visible:ring-primary-500 -mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2',
@@ -79,7 +103,13 @@ export function TabsContent({ value, children, className }: TabsContentProps) {
   const { active } = useTabsContext();
   if (active !== value) return null;
   return (
-    <div role="tabpanel" className={['pt-4', className ?? ''].join(' ')}>
+    <div
+      role="tabpanel"
+      id={`tab-panel-${value}`}
+      aria-labelledby={`tab-trigger-${value}`}
+      tabIndex={0}
+      className={['focus:outline-none pt-4', className ?? ''].join(' ')}
+    >
       {children}
     </div>
   );

--- a/apps/web/src/components/ui/Textarea.tsx
+++ b/apps/web/src/components/ui/Textarea.tsx
@@ -26,7 +26,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             hasError ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
           }
           className={[
-            'bg-neutral-0 w-full rounded-md border px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-400',
+            'bg-neutral-0 w-full rounded-md border px-3 py-2 text-sm text-neutral-900 placeholder:text-neutral-500',
             'focus:ring-primary-500 focus:border-primary-500 transition-colors focus:ring-2 focus:outline-none',
             'min-h-[80px] resize-y disabled:cursor-not-allowed disabled:opacity-50',
             hasError ? 'border-danger-500' : 'border-neutral-200',

--- a/apps/web/tests/accessibility.spec.ts
+++ b/apps/web/tests/accessibility.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('accessibility', () => {
+  test('should not have any automatically detectable WCAG AA violations on dashboard', async ({ page }) => {
+    // Navigate to dashboard
+    await page.goto('/');
+
+    // Wait for content to load
+    await expect(page.getByRole('heading', { name: /Dashboard/i })).toBeVisible();
+
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(accessibilityScanResults.violations).toEqual([]);
+  });
+
+  test('should focus trap in modals', async ({ page }) => {
+    await page.goto('/');
+    
+    // Click "New Patient" to open modal
+    await page.getByLabel('Register a new patient').click();
+    
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    const focusedElement = await page.evaluate(() => document.activeElement?.tagName);
+    expect(['DIV', 'BUTTON', 'INPUT']).toContain(focusedElement);
+    
+    await page.keyboard.press('Tab');
+  });
+});


### PR DESCRIPTION
closes #380 
Summary of Completed Work
Focus Management & Keyboard Navigation:

Implemented focus trapping and focus restoration for Modal and SlideOver components.
Added Arrow key navigation (Left/Right/Home/End) to the Tabs component.
Ensured the Escape key closes all overlays (Modals, SlideOvers, and the Notification menu).
Set tabIndex={0} on tabpanel elements to allow keyboard access to tab content.
Color Contrast:

Performed a codebase-wide replacement of text-neutral-400 with text-neutral-500 for text elements, ensuring a minimum contrast ratio of at least 4.5:1 against white backgrounds.
Semantic Structure & ARIA:

Added visually hidden <caption> elements to dashboard tables for screen reader context.
Assigned role="img" and descriptive aria-label to the user avatar in the TopBar.
Verified existing ARIA labels on navigation buttons, links, and form inputs.
Automated Verification:

Added a Playwright test suite (apps/web/tests/accessibility.spec.ts) utilizing @axe-core/playwright to detect and prevent regression of WCAG violations.