### PR TITLE
feat: implement Stellar account monitoring and balance alerts (#388)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -49,6 +49,10 @@ import {
   startReconciliationJob,
   stopReconciliationJob,
 } from './modules/payments/services/reconciliation-job';
+import {
+  startBalanceMonitoringJob,
+  stopBalanceMonitoringJob,
+} from './modules/payments/services/balance-monitoring-job';
 import { getCacheMetrics } from './services/cache.service';
 import { carePlanRoutes } from './modules/care-plans/care-plans.controller';
 import { portalRoutes } from './modules/portal/portal.controller';
@@ -220,6 +224,7 @@ async function startServer() {
 
   startPaymentExpirationJob();
   startReconciliationJob();
+  startBalanceMonitoringJob();
 
   // Graceful shutdown handler
   const shutdown = async (signal: string) => {
@@ -233,6 +238,7 @@ async function startServer() {
         // Stop payment expiration job
         stopPaymentExpirationJob();
         stopReconciliationJob();
+        stopBalanceMonitoringJob();
         logger.info('Payment expiration job stopped');
 
         // Close database connection

--- a/apps/api/src/lib/email.service.ts
+++ b/apps/api/src/lib/email.service.ts
@@ -16,6 +16,8 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+
 /**
  * Enqueue an email to be sent.
  * Currently sends synchronously, but could be moved to a background job queue (e.g. BullMQ).
@@ -37,22 +39,27 @@ export async function enqueue(to: string, subject: string, text: string, html?: 
   }
 }
 
-export function sendWelcomeEmail(to: string, name: string) {
+export function sendWelcomeEmail(to: string, name: string): void {
   const subject = 'Welcome to Health Watchers';
   const text = `Hi ${name},\n\nWelcome to Health Watchers! Your account has been successfully created.`;
   const html = `<h3>Welcome to Health Watchers</h3><p>Hi <strong>${name}</strong>,</p><p>Your account has been successfully created. You can now log in to the portal.</p>`;
   enqueue(to, subject, text, html);
 }
 
-export function sendPasswordResetEmail(to: string, token: string) {
-  const resetUrl = `${config.portalUrl}/reset-password?token=${token}`;
+export function sendPasswordResetEmail(to: string, token: string): void {
+  const resetUrl = `${APP_BASE_URL}/reset-password?token=${token}`;
   const subject = 'Password Reset Request';
   const text = `You requested a password reset. Please use the following link: ${resetUrl}`;
   const html = `<h3>Password Reset</h3><p>You requested a password reset. Please click the link below to set a new password:</p><p><a href="${resetUrl}">Reset Password</a></p><p>If you didn't request this, you can safely ignore this email.</p>`;
   enqueue(to, subject, text, html);
 }
 
-export function sendAppointmentReminderEmail(to: string, patientName: string, date: Date, doctorName: string) {
+export function sendAppointmentReminderEmail(
+  to: string,
+  patientName: string,
+  date: Date,
+  doctorName: string
+): void {
   const dateStr = date.toLocaleString('en-US', { dateStyle: 'full', timeStyle: 'short' });
   const subject = 'Appointment Reminder';
   const text = `This is a reminder for your appointment with Dr. ${doctorName} on ${dateStr} for patient ${patientName}.`;
@@ -60,15 +67,6 @@ export function sendAppointmentReminderEmail(to: string, patientName: string, da
   enqueue(to, subject, text, html);
 }
 
-export function sendPaymentConfirmationEmail(to: string, amount: string, assetCode: string, txHash: string) {
-  const subject = 'Payment Confirmation';
-  const text = `Your payment of ${amount} ${assetCode} has been confirmed.\n\nTransaction Hash: ${txHash}`;
-  const html = `<h3>Payment Confirmed</h3><p>Your payment has been successfully processed.</p><ul><li><strong>Amount:</strong> ${amount} ${assetCode}</li><li><strong>Transaction Hash:</strong> <code style="word-break: break-all;">${txHash}</code></li></ul><p>Thank you for using Health Watchers.</p>`;
-  enqueue(to, subject, text, html);
-}
-
-export function sendAISummaryNotification(to: string, patientName: string, encounterId: string) {
-  const APP_BASE_URL = config.portalUrl || 'http://localhost:3000';
 /** Payment confirmation email sent when Stellar transaction confirms */
 export function sendPaymentConfirmationEmail(
   to: string,
@@ -97,9 +95,13 @@ export function sendInvoiceEmail(
     dueDate: Date;
     stellarPayURI: string;
     qrCodeDataUrl: string;
-  },
+  }
 ): void {
-  const dueDateStr = invoice.dueDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  const dueDateStr = invoice.dueDate.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
   const text = `Invoice ${invoice.invoiceNumber}\n\nAmount due: ${invoice.total} ${invoice.currency}\nDue date: ${dueDateStr}\n\nPay via Stellar: ${invoice.stellarPayURI}`;
   const html = `
     <h2>Invoice ${invoice.invoiceNumber}</h2>
@@ -116,7 +118,7 @@ export function sendInvoiceEmail(
 export function sendReferralNotificationEmail(
   to: string,
   adminName: string,
-  referral: { patientName: string; urgency: string; reason: string; referralId: string },
+  referral: { patientName: string; urgency: string; reason: string; referralId: string }
 ): void {
   const referralUrl = `${APP_BASE_URL}/referrals/incoming`;
   const urgencyLabel = referral.urgency.toUpperCase();
@@ -145,4 +147,105 @@ export function sendAiSummaryReadyEmail(
     <p><a href="${encounterUrl}">View Encounter Summary</a></p>
   `;
   enqueue(to, 'AI Clinical Summary Ready — Health Watchers', text, html);
+}
+
+/** Low balance warning sent when XLM balance drops below the warning threshold */
+export function sendLowBalanceWarningEmail(
+  to: string,
+  clinicName: string,
+  xlmBalance: string,
+  threshold: number
+): void {
+  const walletUrl = `${APP_BASE_URL}/wallet`;
+  const text = `Warning: Your clinic's Stellar account balance (${xlmBalance} XLM) has dropped below the warning threshold of ${threshold} XLM.\n\nPlease top up your account to avoid payment failures.\n\nManage wallet: ${walletUrl}`;
+  const html = `
+    <h3>⚠️ Low Balance Warning — ${clinicName}</h3>
+    <p>Your clinic's Stellar account balance has dropped below the warning threshold.</p>
+    <table style="border-collapse:collapse;width:100%;margin:16px 0">
+      <tr><td style="padding:8px;font-weight:bold">Current Balance</td><td style="padding:8px;color:#d97706">${xlmBalance} XLM</td></tr>
+      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Warning Threshold</td><td style="padding:8px">${threshold} XLM</td></tr>
+    </table>
+    <p>Please top up your account to avoid payment failures.</p>
+    <p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Manage Wallet</a></p>
+    <hr style="margin-top:32px">
+    <small style="color:#6b7280">Health Watchers</small>
+  `;
+  enqueue(to, `⚠️ Low Balance Warning — ${clinicName}`, text, html);
+}
+
+/** Critical balance alert sent when XLM balance drops below the critical threshold */
+export function sendCriticalBalanceEmail(
+  to: string,
+  clinicName: string,
+  xlmBalance: string,
+  threshold: number
+): void {
+  const walletUrl = `${APP_BASE_URL}/wallet`;
+  const text = `CRITICAL: Your clinic's Stellar account balance (${xlmBalance} XLM) is critically low (below ${threshold} XLM). Payments may fail immediately.\n\nManage wallet: ${walletUrl}`;
+  const html = `
+    <h3>🚨 Critical Balance Alert — ${clinicName}</h3>
+    <p><strong>Your clinic's Stellar account balance is critically low. Payments may fail immediately.</strong></p>
+    <table style="border-collapse:collapse;width:100%;margin:16px 0">
+      <tr><td style="padding:8px;font-weight:bold">Current Balance</td><td style="padding:8px;color:#dc2626">${xlmBalance} XLM</td></tr>
+      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Critical Threshold</td><td style="padding:8px">${threshold} XLM</td></tr>
+    </table>
+    <p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px">Top Up Now</a></p>
+    <hr style="margin-top:32px">
+    <small style="color:#6b7280">Health Watchers</small>
+  `;
+  enqueue(to, `🚨 Critical Balance Alert — ${clinicName}`, text, html);
+}
+
+/** Large transaction alert sent when a transaction exceeds the configured threshold */
+export function sendLargeTransactionEmail(
+  to: string,
+  clinicName: string,
+  amount: string,
+  txHash: string,
+  direction: 'incoming' | 'outgoing',
+  threshold: number
+): void {
+  const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+  const walletUrl = `${APP_BASE_URL}/wallet`;
+  const text = `A large ${direction} transaction of ${amount} XLM (threshold: ${threshold} XLM) was detected on your clinic's Stellar account.\n\nTransaction: ${txHash}\nView: ${explorerUrl}`;
+  const html = `
+    <h3>💸 Large Transaction Detected — ${clinicName}</h3>
+    <p>A large <strong>${direction}</strong> transaction was detected on your clinic's Stellar account.</p>
+    <table style="border-collapse:collapse;width:100%;margin:16px 0">
+      <tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr>
+      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Direction</td><td style="padding:8px;text-transform:capitalize">${direction}</td></tr>
+      <tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr>
+    </table>
+    <p><a href="${explorerUrl}">View on Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">View Wallet</a></p>
+    <hr style="margin-top:32px">
+    <small style="color:#6b7280">Health Watchers</small>
+  `;
+  enqueue(to, `💸 Large Transaction Detected — ${clinicName}`, text, html);
+}
+
+/** Unrecognized transaction alert sent when a transaction is not matched to a known payment intent */
+export function sendUnrecognizedTransactionEmail(
+  to: string,
+  clinicName: string,
+  amount: string,
+  txHash: string,
+  from: string
+): void {
+  const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+  const walletUrl = `${APP_BASE_URL}/wallet`;
+  const text = `An unrecognized transaction of ${amount} XLM from ${from} was detected on your clinic's Stellar account. This transaction was not initiated through Health Watchers.\n\nTransaction: ${txHash}\nView: ${explorerUrl}`;
+  const html = `
+    <h3>🔍 Unrecognized Transaction — ${clinicName}</h3>
+    <p>An unrecognized transaction was detected on your clinic's Stellar account. This transaction was <strong>not initiated through Health Watchers</strong>.</p>
+    <table style="border-collapse:collapse;width:100%;margin:16px 0">
+      <tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr>
+      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">From</td><td style="padding:8px;font-family:monospace;font-size:12px">${from}</td></tr>
+      <tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr>
+    </table>
+    <p>Please review this transaction and contact support if you did not authorize it.</p>
+    <p><a href="${explorerUrl}">View on Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">View Wallet</a></p>
+    <hr style="margin-top:32px">
+    <small style="color:#6b7280">Health Watchers</small>
+  `;
+  enqueue(to, `🔍 Unrecognized Transaction Detected — ${clinicName}`, text, html);
 }

--- a/apps/api/src/migrations/20260424_add_balance_snapshot_index.ts
+++ b/apps/api/src/migrations/20260424_add_balance_snapshot_index.ts
@@ -1,0 +1,16 @@
+import { Db } from 'mongodb';
+
+/**
+ * Add compound unique index on BalanceSnapshot { clinicId, date }
+ * for efficient per-clinic daily snapshot queries and deduplication.
+ */
+export async function up(db: Db): Promise<void> {
+  await db.collection('balancesnapshots').createIndex(
+    { clinicId: 1, date: -1 },
+    { unique: true, background: true, name: 'clinicId_1_date_-1' }
+  );
+}
+
+export async function down(db: Db): Promise<void> {
+  await db.collection('balancesnapshots').dropIndex('clinicId_1_date_-1').catch(() => {});
+}

--- a/apps/api/src/modules/auth/models/user.model.ts
+++ b/apps/api/src/modules/auth/models/user.model.ts
@@ -23,6 +23,10 @@ export interface UserPreferences {
     ai_summary_ready: boolean;
     lab_result_ready: boolean;
     system: boolean;
+    balance_low_warning: boolean;
+    balance_critical: boolean;
+    large_transaction: boolean;
+    unrecognized_transaction: boolean;
   };
 }
 
@@ -116,6 +120,10 @@ const userSchema = new Schema(
         ai_summary_ready:     { type: Boolean, default: true },
         lab_result_ready:     { type: Boolean, default: true },
         system:               { type: Boolean, default: true },
+        balance_low_warning:      { type: Boolean, default: true },
+        balance_critical:         { type: Boolean, default: true },
+        large_transaction:        { type: Boolean, default: true },
+        unrecognized_transaction: { type: Boolean, default: true },
       },
     },
   },

--- a/apps/api/src/modules/clinics/clinic-settings.model.ts
+++ b/apps/api/src/modules/clinics/clinic-settings.model.ts
@@ -45,6 +45,12 @@ export interface IClinicSettings {
     logoUrl?: string;
     primaryColor?: string;
   };
+  balanceAlerts: {
+    lowBalanceWarningXlm: number;
+    criticalBalanceXlm: number;
+    largeTransactionXlm: number;
+    alertsEnabled: boolean;
+  };
 }
 
 const clinicSettingsSchema = new Schema<IClinicSettings>(
@@ -71,6 +77,12 @@ const clinicSettingsSchema = new Schema<IClinicSettings>(
       clinicName: { type: String, default: '' },
       logoUrl: { type: String },
       primaryColor: { type: String },
+    },
+    balanceAlerts: {
+      lowBalanceWarningXlm: { type: Number, default: 100 },
+      criticalBalanceXlm: { type: Number, default: 10 },
+      largeTransactionXlm: { type: Number, default: 1000 },
+      alertsEnabled: { type: Boolean, default: true },
     },
   },
   { timestamps: true, versionKey: false }

--- a/apps/api/src/modules/notifications/notification.model.ts
+++ b/apps/api/src/modules/notifications/notification.model.ts
@@ -7,6 +7,10 @@ export const NOTIFICATION_TYPES = [
   'ai_summary_ready',
   'lab_result_ready',
   'system',
+  'balance_low_warning',
+  'balance_critical',
+  'large_transaction',
+  'unrecognized_transaction',
 ] as const;
 
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number];

--- a/apps/api/src/modules/payments/models/balance-snapshot.model.ts
+++ b/apps/api/src/modules/payments/models/balance-snapshot.model.ts
@@ -1,0 +1,25 @@
+import { Schema, Types, model, models } from 'mongoose';
+
+export interface IBalanceSnapshot {
+  clinicId: Types.ObjectId;
+  date: Date;
+  xlmBalance: string;
+  usdcBalance: string | null;
+  createdAt: Date;
+}
+
+const balanceSnapshotSchema = new Schema<IBalanceSnapshot>(
+  {
+    clinicId: { type: Schema.Types.ObjectId, ref: 'Clinic', required: true, index: true },
+    date: { type: Date, required: true },
+    xlmBalance: { type: String, required: true },
+    usdcBalance: { type: String, default: null },
+  },
+  { timestamps: true, versionKey: false }
+);
+
+// One snapshot per clinic per day
+balanceSnapshotSchema.index({ clinicId: 1, date: -1 }, { unique: true });
+
+export const BalanceSnapshotModel =
+  models.BalanceSnapshot || model<IBalanceSnapshot>('BalanceSnapshot', balanceSnapshotSchema);

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -573,4 +573,22 @@ router.get(
   }),
 );
 
+// GET /payments/balance-snapshots — fetch daily balance history for the clinic
+router.get(
+  '/balance-snapshots',
+  asyncHandler(async (req: Request, res: Response) => {
+    if (!canReadPayments(req.user!.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    const clinicId = req.user!.clinicId;
+    const limit = Math.min(parseInt((req.query.limit as string) ?? '30', 10), 90);
+    const { BalanceSnapshotModel } = await import('./models/balance-snapshot.model');
+    const snapshots = await BalanceSnapshotModel.find({ clinicId })
+      .sort({ date: -1 })
+      .limit(limit)
+      .lean();
+    return res.json({ status: 'success', data: snapshots.reverse() });
+  })
+);
+
 export const paymentRoutes = router;

--- a/apps/api/src/modules/payments/services/balance-monitoring-job.ts
+++ b/apps/api/src/modules/payments/services/balance-monitoring-job.ts
@@ -1,0 +1,221 @@
+import { ClinicModel } from '../clinics/clinic.model';
+import { ClinicSettingsModel } from '../clinics/clinic-settings.model';
+import { BalanceSnapshotModel } from './models/balance-snapshot.model';
+import { PaymentRecordModel } from './models/payment-record.model';
+import { UserModel } from '../auth/models/user.model';
+import { createNotification } from '../notifications/notification.service';
+import {
+  sendLowBalanceWarningEmail,
+  sendCriticalBalanceEmail,
+  sendLargeTransactionEmail,
+  sendUnrecognizedTransactionEmail,
+} from '@api/lib/email.service';
+import { stellarClient } from './services/stellar-client';
+import logger from '@api/utils/logger';
+
+const CHECK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+
+let monitoringJobInterval: NodeJS.Timeout | null = null;
+
+/** Midnight UTC date for daily snapshot deduplication */
+function todayUtc(): Date {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Check if a transaction hash is known (exists in PaymentRecordModel).
+ */
+async function isKnownTransaction(txHash: string, clinicId: string): Promise<boolean> {
+  const record = await PaymentRecordModel.findOne({ txHash, clinicId }).lean();
+  return record !== null;
+}
+
+/**
+ * Get the CLINIC_ADMIN user for a clinic to send alerts to.
+ */
+async function getClinicAdmin(clinicId: string) {
+  return UserModel.findOne({ clinicId, role: 'CLINIC_ADMIN', isActive: true }).lean();
+}
+
+/**
+ * Run balance checks for a single clinic.
+ */
+async function checkClinic(clinicId: string, publicKey: string, clinicName: string): Promise<void> {
+  const settings = await ClinicSettingsModel.findOne({ clinicId }).lean();
+  const alerts = settings?.balanceAlerts ?? {
+    lowBalanceWarningXlm: 100,
+    criticalBalanceXlm: 10,
+    largeTransactionXlm: 1000,
+    alertsEnabled: true,
+  };
+
+  if (!alerts.alertsEnabled) return;
+
+  let balanceData: { balance: string; usdcBalance: string | null; transactions: unknown[] };
+  try {
+    balanceData = await stellarClient.getBalance(publicKey);
+  } catch (err) {
+    logger.warn({ err, clinicId, publicKey }, 'Failed to fetch balance for monitoring');
+    return;
+  }
+
+  const xlmBalance = parseFloat(balanceData.balance);
+  const admin = await getClinicAdmin(clinicId);
+
+  // ── Daily balance snapshot ────────────────────────────────────────────────
+  await BalanceSnapshotModel.findOneAndUpdate(
+    { clinicId, date: todayUtc() },
+    { xlmBalance: balanceData.balance, usdcBalance: balanceData.usdcBalance },
+    { upsert: true, new: true }
+  );
+
+  if (!admin) return;
+
+  // ── Balance threshold alerts ──────────────────────────────────────────────
+  if (xlmBalance < alerts.criticalBalanceXlm) {
+    await createNotification({
+      userId: admin._id,
+      clinicId,
+      type: 'balance_critical',
+      title: 'Critical Balance Alert',
+      message: `Your Stellar account balance (${balanceData.balance} XLM) is critically low. Payments may fail.`,
+      link: '/wallet',
+      metadata: { xlmBalance: balanceData.balance, threshold: alerts.criticalBalanceXlm },
+    });
+    sendCriticalBalanceEmail(
+      admin.email,
+      clinicName,
+      balanceData.balance,
+      alerts.criticalBalanceXlm
+    );
+  } else if (xlmBalance < alerts.lowBalanceWarningXlm) {
+    await createNotification({
+      userId: admin._id,
+      clinicId,
+      type: 'balance_low_warning',
+      title: 'Low Balance Warning',
+      message: `Your Stellar account balance (${balanceData.balance} XLM) is below the warning threshold.`,
+      link: '/wallet',
+      metadata: { xlmBalance: balanceData.balance, threshold: alerts.lowBalanceWarningXlm },
+    });
+    sendLowBalanceWarningEmail(
+      admin.email,
+      clinicName,
+      balanceData.balance,
+      alerts.lowBalanceWarningXlm
+    );
+  }
+
+  // ── Transaction alerts ────────────────────────────────────────────────────
+  const transactions = balanceData.transactions as Array<{
+    hash: string;
+    amount: string;
+    from: string;
+    to: string;
+    asset: string;
+  }>;
+
+  for (const tx of transactions) {
+    if (tx.asset !== 'XLM') continue;
+    const amount = parseFloat(tx.amount);
+
+    // Large transaction check
+    if (amount >= alerts.largeTransactionXlm) {
+      const direction = tx.to === publicKey ? 'incoming' : 'outgoing';
+      await createNotification({
+        userId: admin._id,
+        clinicId,
+        type: 'large_transaction',
+        title: 'Large Transaction Detected',
+        message: `A large ${direction} transaction of ${tx.amount} XLM was detected.`,
+        link: '/wallet',
+        metadata: { txHash: tx.hash, amount: tx.amount, direction, threshold: alerts.largeTransactionXlm },
+      });
+      sendLargeTransactionEmail(
+        admin.email,
+        clinicName,
+        tx.amount,
+        tx.hash,
+        direction,
+        alerts.largeTransactionXlm
+      );
+    }
+
+    // Unrecognized transaction check (only for incoming)
+    if (tx.to === publicKey) {
+      const known = await isKnownTransaction(tx.hash, clinicId);
+      if (!known) {
+        await createNotification({
+          userId: admin._id,
+          clinicId,
+          type: 'unrecognized_transaction',
+          title: 'Unrecognized Transaction',
+          message: `An unrecognized incoming transaction of ${tx.amount} XLM from ${tx.from} was detected.`,
+          link: '/wallet',
+          metadata: { txHash: tx.hash, amount: tx.amount, from: tx.from },
+        });
+        sendUnrecognizedTransactionEmail(
+          admin.email,
+          clinicName,
+          tx.amount,
+          tx.hash,
+          tx.from
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Run balance monitoring for all active clinics with a Stellar public key.
+ */
+export async function runBalanceMonitoring(): Promise<void> {
+  const clinics = await ClinicModel.find({
+    isActive: true,
+    stellarPublicKey: { $exists: true, $ne: null },
+  }).lean();
+
+  logger.info({ count: clinics.length }, 'Running balance monitoring check');
+
+  await Promise.allSettled(
+    clinics.map((clinic) =>
+      checkClinic(String(clinic._id), clinic.stellarPublicKey!, clinic.name).catch((err) =>
+        logger.error({ err, clinicId: clinic._id }, 'Balance check failed for clinic')
+      )
+    )
+  );
+}
+
+export function startBalanceMonitoringJob(): void {
+  if (monitoringJobInterval) {
+    logger.warn('Balance monitoring job is already running');
+    return;
+  }
+
+  logger.info(`Starting balance monitoring job (every ${CHECK_INTERVAL_MS / 60000}m)`);
+
+  // Run immediately on startup
+  runBalanceMonitoring().catch((err) =>
+    logger.error({ err }, 'Initial balance monitoring check failed')
+  );
+
+  monitoringJobInterval = setInterval(() => {
+    runBalanceMonitoring().catch((err) =>
+      logger.error({ err }, 'Balance monitoring job failed')
+    );
+  }, CHECK_INTERVAL_MS);
+}
+
+export function stopBalanceMonitoringJob(): void {
+  if (monitoringJobInterval) {
+    clearInterval(monitoringJobInterval);
+    monitoringJobInterval = null;
+    logger.info('Balance monitoring job stopped');
+  }
+}
+
+export function isBalanceMonitoringJobRunning(): boolean {
+  return monitoringJobInterval !== null;
+}

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -15,6 +15,7 @@ import {
   getOrderbook,
   checkHorizon,
   getFeeStats,
+  streamAccountTransactions,
 } from './stellar.js';
 import dotenv from 'dotenv';
 import logger from './logger.js';
@@ -210,6 +211,35 @@ app.get('/orderbook', async (req, res) => {
   } catch (error: any) {
     return res.status(500).json({ error: error.message });
   }
+});
+
+// ✅ PROTECTED: GET /monitor/stream?publicKey=G... — SSE stream of account transactions
+app.get('/monitor/stream', requireSecret, (req, res) => {
+  const { publicKey } = req.query;
+
+  if (!publicKey || typeof publicKey !== 'string') {
+    return res.status(400).json({ error: 'publicKey query parameter is required' });
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  const close = streamAccountTransactions(
+    publicKey,
+    (tx) => {
+      res.write(`data: ${JSON.stringify(tx)}\n\n`);
+    },
+    (err) => {
+      res.write(`event: error\ndata: ${JSON.stringify({ error: String(err) })}\n\n`);
+    }
+  );
+
+  req.on('close', () => {
+    close();
+    logger.info({ publicKey }, 'SSE client disconnected, stream closed');
+  });
 });
 
 const server: Server = app.listen(PORT, () => {

--- a/apps/stellar-service/src/stellar.ts
+++ b/apps/stellar-service/src/stellar.ts
@@ -295,7 +295,7 @@ function stroopsToXlm(stroops: string): string {
 
 /** Fetch fee statistics from Horizon */
 export async function getFeeStats() {
-  const server = getServer();
+  const server = getHorizonServer();
   const stats = await server.feeStats();
   const { fee_charged } = stats;
   return {
@@ -312,4 +312,66 @@ export async function getFeeStats() {
       p99:  fee_charged.p99,
     },
   };
+}
+
+/** Check Horizon connectivity and latency */
+export async function checkHorizon(): Promise<{ status: 'healthy' | 'unhealthy'; latency?: number }> {
+  const server = getHorizonServer();
+  const start = Date.now();
+  try {
+    await server.feeStats();
+    return { status: 'healthy', latency: Date.now() - start };
+  } catch {
+    return { status: 'unhealthy', latency: Date.now() - start };
+  }
+}
+
+export interface StreamedTransaction {
+  hash: string;
+  amount: string;
+  asset: string;
+  from: string;
+  to: string;
+  type: string;
+  createdAt: string;
+}
+
+/**
+ * Stream real-time transactions for an account via Horizon SSE.
+ * Calls onTransaction for each new payment/create_account record.
+ * Returns a close() function to stop the stream.
+ */
+export function streamAccountTransactions(
+  publicKey: string,
+  onTransaction: (tx: StreamedTransaction) => void,
+  onError?: (err: unknown) => void
+): () => void {
+  const server = getHorizonServer();
+
+  logger.info({ publicKey }, 'Starting account transaction stream');
+
+  const close = server
+    .payments()
+    .forAccount(publicKey)
+    .cursor('now')
+    .stream({
+      onmessage: (record: any) => {
+        if (record.type !== 'payment' && record.type !== 'create_account') return;
+        onTransaction({
+          hash: record.transaction_hash,
+          amount: record.amount ?? record.starting_balance ?? '0',
+          asset: record.asset_type === 'native' ? 'XLM' : `${record.asset_code}:${record.asset_issuer}`,
+          from: record.from ?? record.funder ?? '',
+          to: record.to ?? record.account ?? '',
+          type: record.type,
+          createdAt: record.created_at,
+        });
+      },
+      onerror: (err: unknown) => {
+        logger.error({ err, publicKey }, 'Account transaction stream error');
+        onError?.(err);
+      },
+    });
+
+  return close as () => void;
 }

--- a/apps/web/src/app/api/payments/balance-snapshots/route.ts
+++ b/apps/web/src/app/api/payments/balance-snapshots/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/api';
+
+export async function GET(request: NextRequest) {
+  const accessToken = request.cookies.get('accessToken')?.value;
+  if (!accessToken) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const limit = searchParams.get('limit') ?? '30';
+
+  const res = await fetch(`${API_URL}/api/v1/payments/balance-snapshots?limit=${limit}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/src/app/wallet/WalletClient.tsx
+++ b/apps/web/src/app/wallet/WalletClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { queryKeys } from '@/lib/queryKeys';
 import { getStellarExplorerUrl } from '@/lib/stellar';
 import {
@@ -22,6 +23,7 @@ import {
 
 const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
 const IS_TESTNET = NETWORK === 'testnet';
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
 interface Transaction {
   id: string;
@@ -43,6 +45,19 @@ interface WalletBalance {
   transactions: Transaction[];
 }
 
+interface BalanceSnapshot {
+  date: string;
+  xlmBalance: string;
+  usdcBalance: string | null;
+}
+
+interface BalanceAlerts {
+  lowBalanceWarningXlm: number;
+  criticalBalanceXlm: number;
+  largeTransactionXlm: number;
+  alertsEnabled: boolean;
+}
+
 function useWalletBalance() {
   return useQuery<WalletBalance>({
     queryKey: queryKeys.wallet.balance(),
@@ -56,6 +71,36 @@ function useWalletBalance() {
       return body.data;
     },
     retry: 1,
+  });
+}
+
+function useBalanceSnapshots() {
+  return useQuery<BalanceSnapshot[]>({
+    queryKey: queryKeys.wallet.snapshots(),
+    queryFn: async () => {
+      const res = await fetch('/api/payments/balance-snapshots');
+      if (!res.ok) return [];
+      const body = await res.json();
+      return body.data ?? [];
+    },
+    retry: 1,
+  });
+}
+
+function useBalanceAlerts() {
+  return useQuery<BalanceAlerts>({
+    queryKey: ['wallet', 'alert-settings'],
+    queryFn: async () => {
+      const res = await fetch(`${API}/api/v1/settings`, { credentials: 'include' });
+      if (!res.ok) throw new Error('Failed to load settings');
+      const body = await res.json();
+      return body.data?.balanceAlerts ?? {
+        lowBalanceWarningXlm: 100,
+        criticalBalanceXlm: 10,
+        largeTransactionXlm: 1000,
+        alertsEnabled: true,
+      };
+    },
   });
 }
 
@@ -174,9 +219,123 @@ function ConfirmPaymentModal({
   );
 }
 
+function BalanceTrendChart({ snapshots }: { snapshots: BalanceSnapshot[] }) {
+  if (!snapshots || snapshots.length === 0) {
+    return (
+      <p className="py-4 text-center text-sm text-neutral-500">
+        No balance history yet. Data will appear after the first monitoring cycle.
+      </p>
+    );
+  }
+
+  const chartData = snapshots.map((s) => ({
+    date: new Date(s.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+    xlm: parseFloat(s.xlmBalance),
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <LineChart data={chartData} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+        <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+        <YAxis tick={{ fontSize: 11 }} width={50} />
+        <Tooltip formatter={(v: number) => [`${v.toFixed(2)} XLM`, 'Balance']} />
+        <Line
+          type="monotone"
+          dataKey="xlm"
+          stroke="#2563eb"
+          strokeWidth={2}
+          dot={false}
+          activeDot={{ r: 4 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+function AlertThresholdSettings({
+  settings,
+  onSave,
+  saving,
+}: {
+  settings: BalanceAlerts;
+  onSave: (data: BalanceAlerts) => void;
+  saving: boolean;
+}) {
+  const [form, setForm] = useState<BalanceAlerts>(settings);
+
+  const handleChange = (key: keyof BalanceAlerts, value: number | boolean) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSave(form);
+      }}
+      className="space-y-4"
+    >
+      <div className="flex items-center gap-3">
+        <input
+          id="alertsEnabled"
+          type="checkbox"
+          checked={form.alertsEnabled}
+          onChange={(e) => handleChange('alertsEnabled', e.target.checked)}
+          className="h-4 w-4 rounded border-neutral-300 text-primary-600"
+        />
+        <label htmlFor="alertsEnabled" className="text-sm font-medium text-neutral-700">
+          Enable balance alerts
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Input
+          label="Low Balance Warning (XLM)"
+          type="number"
+          min="0"
+          step="1"
+          value={String(form.lowBalanceWarningXlm)}
+          onChange={(e) => handleChange('lowBalanceWarningXlm', Number(e.target.value))}
+          helperText="Alert when balance drops below this"
+          disabled={!form.alertsEnabled}
+        />
+        <Input
+          label="Critical Balance (XLM)"
+          type="number"
+          min="0"
+          step="1"
+          value={String(form.criticalBalanceXlm)}
+          onChange={(e) => handleChange('criticalBalanceXlm', Number(e.target.value))}
+          helperText="Critical alert threshold"
+          disabled={!form.alertsEnabled}
+        />
+        <Input
+          label="Large Transaction (XLM)"
+          type="number"
+          min="0"
+          step="1"
+          value={String(form.largeTransactionXlm)}
+          onChange={(e) => handleChange('largeTransactionXlm', Number(e.target.value))}
+          helperText="Alert for transactions above this"
+          disabled={!form.alertsEnabled}
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <Button type="submit" loading={saving} disabled={!form.alertsEnabled && !settings.alertsEnabled}>
+          Save Alert Settings
+        </Button>
+      </div>
+    </form>
+  );
+}
+
 export default function WalletClient() {
   const queryClient = useQueryClient();
   const { data: wallet, isLoading, error, refetch } = useWalletBalance();
+  const { data: snapshots } = useBalanceSnapshots();
+  const { data: alertSettings } = useBalanceAlerts();
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const [showSendForm, setShowSendForm] = useState(false);
   const [pendingPayment, setPendingPayment] = useState<{
@@ -184,6 +343,29 @@ export default function WalletClient() {
     amount: string;
     memo?: string;
   } | null>(null);
+
+  const saveAlertsMutation = useMutation({
+    mutationFn: async (data: BalanceAlerts) => {
+      const res = await fetch(`${API}/api/v1/settings`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ balanceAlerts: data }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? `Error ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setToast({ message: 'Alert settings saved.', type: 'success' });
+      queryClient.invalidateQueries({ queryKey: ['wallet', 'alert-settings'] });
+    },
+    onError: (err: Error) => {
+      setToast({ message: err.message, type: 'error' });
+    },
+  });
 
   const fundMutation = useMutation({
     mutationFn: async () => {
@@ -442,6 +624,31 @@ export default function WalletClient() {
                   </tbody>
                 </table>
               </div>
+            )}
+          </Card>
+
+          {/* Balance Trend Chart */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Balance Trend</CardTitle>
+              <span className="text-xs text-neutral-500">Last 30 days</span>
+            </CardHeader>
+            <BalanceTrendChart snapshots={snapshots ?? []} />
+          </Card>
+
+          {/* Alert Threshold Settings */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Balance Alert Settings</CardTitle>
+            </CardHeader>
+            {alertSettings ? (
+              <AlertThresholdSettings
+                settings={alertSettings}
+                onSave={(data) => saveAlertsMutation.mutate(data)}
+                saving={saveAlertsMutation.isPending}
+              />
+            ) : (
+              <p className="text-sm text-neutral-500">Loading alert settings…</p>
             )}
           </Card>
         </>

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -17,11 +17,13 @@ export const queryKeys = {
   wallet: {
     all: ['wallet'] as const,
     balance: () => [...queryKeys.wallet.all, 'balance'] as const,
+    snapshots: () => [...queryKeys.wallet.all, 'snapshots'] as const,
   },
   notifications: {
     all: ['notifications'] as const,
     list: (page?: number) => [...queryKeys.notifications.all, 'list', page] as const,
     unreadCount: () => [...queryKeys.notifications.all, 'unread-count'] as const,
+  },
   labResults: {
     all: ['lab-results'] as const,
     byPatient: (patientId: string) => [...queryKeys.labResults.all, 'patient', patientId] as const,


### PR DESCRIPTION
pr close #388 

- Add balance monitoring job (15-min polling) for all active clinic accounts
- Alert thresholds: low balance (<100 XLM), critical (<10 XLM), large tx (>1000 XLM)
- Flag unrecognized transactions not initiated through Health Watchers
- In-app notifications + email alerts for all threshold breaches
- Daily BalanceSnapshot model for balance trend history
- Horizon SSE streaming via /monitor/stream endpoint in stellar-service
- GET /payments/balance-snapshots API endpoint (last 30 days)
- Balance trend chart (recharts) and configurable alert settings in WalletClient
- Migration for BalanceSnapshot unique compound index
- Fix broken email.service.ts (unclosed function, duplicate exports)
- Fix getServer() bug in stellar.ts (should be getHorizonServer())
- Fix missing closing brace in queryKeys.ts