### PR TITLE
feat: implement CPT billing codes for insurance claims

### DIFF
--- a/apps/api/src/modules/cpt/cpt.controller.ts
+++ b/apps/api/src/modules/cpt/cpt.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import { CPTModel } from './cpt.model';
+
+export async function searchCPTCodes(req: Request, res: Response): Promise<void> {
+  const { q } = req.query;
+
+  if (!q || typeof q !== 'string') {
+    res.status(400).json({
+      success: false,
+      error: 'Query parameter "q" is required',
+    });
+    return;
+  }
+
+  const results = await CPTModel.find(
+    { $text: { $search: q } },
+    { score: { $meta: 'textScore' } }
+  )
+    .sort({ score: { $meta: 'textScore' } })
+    .limit(10)
+    .lean();
+
+  res.json({
+    success: true,
+    data: results,
+  });
+}
+
+export async function getCPTByCode(req: Request, res: Response): Promise<void> {
+  const { code } = req.params;
+
+  const cpt = await CPTModel.findOne({ code }).lean();
+
+  if (!cpt) {
+    res.status(404).json({
+      success: false,
+      error: 'CPT code not found',
+    });
+    return;
+  }
+
+  res.json({
+    success: true,
+    data: cpt,
+  });
+}

--- a/apps/api/src/modules/cpt/cpt.model.ts
+++ b/apps/api/src/modules/cpt/cpt.model.ts
@@ -1,0 +1,27 @@
+import { Schema, model, models } from 'mongoose';
+
+export interface CPT {
+  code: string;
+  description: string;
+  category: 'office-visit' | 'preventive-care' | 'procedure' | 'lab' | 'imaging' | 'other';
+  defaultFee: string; // USD
+}
+
+const cptSchema = new Schema<CPT>(
+  {
+    code: { type: String, required: true, unique: true, index: true },
+    description: { type: String, required: true },
+    category: { 
+      type: String, 
+      enum: ['office-visit', 'preventive-care', 'procedure', 'lab', 'imaging', 'other'],
+      required: true,
+      index: true
+    },
+    defaultFee: { type: String, required: true },
+  },
+  { timestamps: true, versionKey: false }
+);
+
+cptSchema.index({ description: 'text', code: 'text' });
+
+export const CPTModel = models.CPT || model<CPT>('CPT', cptSchema);

--- a/apps/api/src/modules/cpt/cpt.seed.ts
+++ b/apps/api/src/modules/cpt/cpt.seed.ts
@@ -1,0 +1,56 @@
+import { CPTModel } from './cpt.model';
+
+export const commonCPTCodes = [
+  // Office Visits - New Patient
+  { code: '99201', description: 'Office visit, new patient, straightforward', category: 'office-visit', defaultFee: '75.00' },
+  { code: '99202', description: 'Office visit, new patient, low complexity', category: 'office-visit', defaultFee: '110.00' },
+  { code: '99203', description: 'Office visit, new patient, moderate complexity', category: 'office-visit', defaultFee: '150.00' },
+  { code: '99204', description: 'Office visit, new patient, moderate to high complexity', category: 'office-visit', defaultFee: '210.00' },
+  { code: '99205', description: 'Office visit, new patient, high complexity', category: 'office-visit', defaultFee: '280.00' },
+  
+  // Office Visits - Established Patient
+  { code: '99211', description: 'Office visit, established patient, minimal', category: 'office-visit', defaultFee: '45.00' },
+  { code: '99212', description: 'Office visit, established patient, straightforward', category: 'office-visit', defaultFee: '75.00' },
+  { code: '99213', description: 'Office visit, established patient, low complexity', category: 'office-visit', defaultFee: '110.00' },
+  { code: '99214', description: 'Office visit, established patient, moderate complexity', category: 'office-visit', defaultFee: '165.00' },
+  { code: '99215', description: 'Office visit, established patient, high complexity', category: 'office-visit', defaultFee: '220.00' },
+  
+  // Preventive Care - New Patient
+  { code: '99381', description: 'Preventive care, new patient, infant (under 1 year)', category: 'preventive-care', defaultFee: '150.00' },
+  { code: '99382', description: 'Preventive care, new patient, child (1-4 years)', category: 'preventive-care', defaultFee: '160.00' },
+  { code: '99383', description: 'Preventive care, new patient, child (5-11 years)', category: 'preventive-care', defaultFee: '170.00' },
+  { code: '99384', description: 'Preventive care, new patient, adolescent (12-17 years)', category: 'preventive-care', defaultFee: '180.00' },
+  { code: '99385', description: 'Preventive care, new patient, adult (18-39 years)', category: 'preventive-care', defaultFee: '190.00' },
+  { code: '99386', description: 'Preventive care, new patient, adult (40-64 years)', category: 'preventive-care', defaultFee: '210.00' },
+  { code: '99387', description: 'Preventive care, new patient, senior (65+ years)', category: 'preventive-care', defaultFee: '220.00' },
+  
+  // Preventive Care - Established Patient
+  { code: '99391', description: 'Preventive care, established patient, infant (under 1 year)', category: 'preventive-care', defaultFee: '130.00' },
+  { code: '99392', description: 'Preventive care, established patient, child (1-4 years)', category: 'preventive-care', defaultFee: '140.00' },
+  { code: '99393', description: 'Preventive care, established patient, child (5-11 years)', category: 'preventive-care', defaultFee: '150.00' },
+  { code: '99394', description: 'Preventive care, established patient, adolescent (12-17 years)', category: 'preventive-care', defaultFee: '160.00' },
+  { code: '99395', description: 'Preventive care, established patient, adult (18-39 years)', category: 'preventive-care', defaultFee: '170.00' },
+  { code: '99396', description: 'Preventive care, established patient, adult (40-64 years)', category: 'preventive-care', defaultFee: '190.00' },
+  { code: '99397', description: 'Preventive care, established patient, senior (65+ years)', category: 'preventive-care', defaultFee: '200.00' },
+  
+  // Common Procedures
+  { code: '93000', description: 'Electrocardiogram (ECG), complete', category: 'procedure', defaultFee: '85.00' },
+  { code: '85025', description: 'Complete blood count (CBC) with differential', category: 'lab', defaultFee: '45.00' },
+  { code: '80053', description: 'Comprehensive metabolic panel', category: 'lab', defaultFee: '65.00' },
+  { code: '36415', description: 'Venipuncture (blood draw)', category: 'procedure', defaultFee: '25.00' },
+  { code: '94010', description: 'Spirometry (lung function test)', category: 'procedure', defaultFee: '95.00' },
+  { code: '71045', description: 'Chest X-ray, single view', category: 'imaging', defaultFee: '120.00' },
+  { code: '71046', description: 'Chest X-ray, two views', category: 'imaging', defaultFee: '150.00' },
+  { code: '73610', description: 'Ankle X-ray, complete', category: 'imaging', defaultFee: '130.00' },
+];
+
+export async function seedCPTCodes(): Promise<void> {
+  const count = await CPTModel.countDocuments();
+  
+  if (count === 0) {
+    await CPTModel.insertMany(commonCPTCodes);
+    console.log(`Seeded ${commonCPTCodes.length} CPT codes`);
+  } else {
+    console.log('CPT codes already seeded');
+  }
+}

--- a/apps/api/src/modules/encounters/billing.controller.ts
+++ b/apps/api/src/modules/encounters/billing.controller.ts
@@ -1,0 +1,171 @@
+import { Request, Response } from 'express';
+import { EncounterModel } from './encounter.model';
+import { PatientModel } from '../patients/patient.model';
+import { UserModel } from '../auth/models/user.model';
+
+export async function getBillingSummary(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const { clinicId } = req.user!;
+
+  const encounter = await EncounterModel.findOne({ _id: id, clinicId })
+    .populate('patientId', 'fullName dateOfBirth gender insurance')
+    .populate('attendingDoctorId', 'fullName npiNumber')
+    .lean();
+
+  if (!encounter) {
+    res.status(404).json({
+      success: false,
+      error: 'Encounter not found',
+    });
+    return;
+  }
+
+  const billingSummary = {
+    patient: {
+      fullName: (encounter.patientId as any).fullName,
+      dateOfBirth: (encounter.patientId as any).dateOfBirth,
+      gender: (encounter.patientId as any).gender,
+      insurance: (encounter.patientId as any).insurance,
+    },
+    encounter: {
+      date: encounter.createdAt,
+      chiefComplaint: encounter.chiefComplaint,
+      status: encounter.status,
+    },
+    provider: {
+      fullName: (encounter.attendingDoctorId as any).fullName,
+      npiNumber: (encounter.attendingDoctorId as any).npiNumber,
+    },
+    diagnosis: encounter.diagnosis || [],
+    billing: encounter.billing || {
+      cptCodes: [],
+      billingStatus: 'unbilled',
+      totalFee: '0.00',
+    },
+  };
+
+  res.json({
+    success: true,
+    data: billingSummary,
+  });
+}
+
+export async function generateClaim(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const { clinicId } = req.user!;
+
+  const encounter = await EncounterModel.findOne({ _id: id, clinicId })
+    .populate('patientId')
+    .populate('attendingDoctorId')
+    .lean();
+
+  if (!encounter) {
+    res.status(404).json({
+      success: false,
+      error: 'Encounter not found',
+    });
+    return;
+  }
+
+  if (!encounter.billing || encounter.billing.cptCodes.length === 0) {
+    res.status(400).json({
+      success: false,
+      error: 'No billing codes assigned to this encounter',
+    });
+    return;
+  }
+
+  if (!encounter.diagnosis || encounter.diagnosis.length === 0) {
+    res.status(400).json({
+      success: false,
+      error: 'No diagnosis codes assigned to this encounter',
+    });
+    return;
+  }
+
+  // CMS-1500 compatible claim summary
+  const claim = {
+    claimType: 'CMS-1500',
+    patient: {
+      fullName: (encounter.patientId as any).fullName,
+      dateOfBirth: (encounter.patientId as any).dateOfBirth,
+      gender: (encounter.patientId as any).gender,
+      address: (encounter.patientId as any).address,
+      insurance: (encounter.patientId as any).insurance,
+    },
+    provider: {
+      fullName: (encounter.attendingDoctorId as any).fullName,
+      npiNumber: (encounter.attendingDoctorId as any).npiNumber,
+    },
+    serviceDate: encounter.createdAt,
+    diagnosisCodes: encounter.diagnosis.map(d => ({
+      code: d.code,
+      description: d.description,
+      isPrimary: d.isPrimary,
+    })),
+    procedureCodes: encounter.billing.cptCodes.map(cpt => ({
+      code: cpt.code,
+      description: cpt.description,
+      units: cpt.units,
+      fee: cpt.fee,
+    })),
+    totalCharges: encounter.billing.totalFee,
+    billingStatus: encounter.billing.billingStatus,
+  };
+
+  res.json({
+    success: true,
+    data: claim,
+  });
+}
+
+export async function updateBilling(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const { clinicId } = req.user!;
+  const { cptCodes, billingStatus, insuranceClaimId } = req.body;
+
+  const encounter = await EncounterModel.findOne({ _id: id, clinicId });
+
+  if (!encounter) {
+    res.status(404).json({
+      success: false,
+      error: 'Encounter not found',
+    });
+    return;
+  }
+
+  // Calculate total fee
+  let totalFee = 0;
+  if (cptCodes && Array.isArray(cptCodes)) {
+    for (const cpt of cptCodes) {
+      const fee = parseFloat(cpt.fee) * cpt.units;
+      totalFee += fee;
+    }
+  }
+
+  const billingUpdate: any = {
+    cptCodes: cptCodes || encounter.billing?.cptCodes || [],
+    billingStatus: billingStatus || encounter.billing?.billingStatus || 'unbilled',
+    totalFee: totalFee.toFixed(2),
+  };
+
+  if (insuranceClaimId) {
+    billingUpdate.insuranceClaimId = insuranceClaimId;
+  }
+
+  if (billingStatus === 'billed' && !encounter.billing?.billedAt) {
+    billingUpdate.billedAt = new Date();
+  }
+
+  if (billingStatus === 'paid' && !encounter.billing?.paidAt) {
+    billingUpdate.paidAt = new Date();
+  }
+
+  encounter.billing = billingUpdate;
+  await encounter.save();
+
+  res.json({
+    success: true,
+    data: encounter.billing,
+  });
+}

--- a/apps/api/src/modules/encounters/encounter.model.ts
+++ b/apps/api/src/modules/encounters/encounter.model.ts
@@ -31,6 +31,22 @@ export interface Prescription {
   allergyOverride?: { allergyId: string; reason: string };
 }
 
+export interface CPTCode {
+  code: string; // CPT code (e.g., "99213")
+  description: string;
+  units: number; // Number of times procedure was performed
+  fee: string; // Fee in USD (stored as string to avoid floating point issues)
+}
+
+export interface BillingInfo {
+  cptCodes: CPTCode[];
+  billingStatus: 'unbilled' | 'billed' | 'paid' | 'denied';
+  insuranceClaimId?: string; // External reference to insurance claim
+  totalFee: string; // Total fee in USD
+  billedAt?: Date;
+  paidAt?: Date;
+}
+
 export interface Encounter {
   patientId: Schema.Types.ObjectId;
   clinicId: Schema.Types.ObjectId;
@@ -46,6 +62,7 @@ export interface Encounter {
   followUpDate?: Date;
   aiSummary?: string;
   isActive?: boolean;
+  billing?: BillingInfo;
 }
 
 const vitalSignsSchema = new Schema<VitalSigns>(
@@ -90,6 +107,33 @@ const prescriptionSchema = new Schema<Prescription>(
   { timestamps: true }
 );
 
+const cptCodeSchema = new Schema<CPTCode>(
+  {
+    code: { type: String, required: true },
+    description: { type: String, required: true },
+    units: { type: Number, required: true, min: 1, default: 1 },
+    fee: { type: String, required: true },
+  },
+  { _id: false }
+);
+
+const billingInfoSchema = new Schema<BillingInfo>(
+  {
+    cptCodes: { type: [cptCodeSchema], default: [] },
+    billingStatus: { 
+      type: String, 
+      enum: ['unbilled', 'billed', 'paid', 'denied'], 
+      default: 'unbilled',
+      index: true 
+    },
+    insuranceClaimId: { type: String },
+    totalFee: { type: String, required: true, default: '0.00' },
+    billedAt: { type: Date },
+    paidAt: { type: Date },
+  },
+  { _id: false }
+);
+
 const encounterSchema = new Schema<Encounter>(
   {
     patientId:         { type: Schema.Types.ObjectId, ref: 'Patient',  required: true, index: true },
@@ -106,6 +150,7 @@ const encounterSchema = new Schema<Encounter>(
     followUpDate:      { type: Date },
     aiSummary:         { type: String },
     isActive:          { type: Boolean, default: true, index: true },
+    billing:           { type: billingInfoSchema },
   },
   { timestamps: true, versionKey: false }
 );


### PR DESCRIPTION
- Add billing fields to Encounter model (cptCodes, billingStatus, insuranceClaimId, totalFee)
- Create CPT code model with common codes (office visits, preventive care, procedures)
- Add CPT search endpoint for code lookup
- Implement billing summary endpoint with patient, provider, and diagnosis info
- Add claim generation endpoint for CMS-1500 compatible claims
- Include seed data for 30+ common CPT codes
- Add billing update endpoint to assign codes and track status

Closes #402