### PR TITLE
feat(api): Add MongoDB connection pooling, retry logic, and health check

### DIFF
--- a/apps/api/src/config/__tests__/db.test.ts
+++ b/apps/api/src/config/__tests__/db.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for connectDB retry logic.
+ * Mocks mongoose.connect to fail N times then succeed.
+ */
+
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return {
+    ...actual,
+    connect: jest.fn(),
+    connection: {
+      ...actual.connection,
+      readyState: 1,
+      on: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@health-watchers/config', () => ({
+  config: { mongoUri: 'mongodb://localhost:27017/test' },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import mongoose from 'mongoose';
+
+// Speed up retries in tests
+jest.useFakeTimers();
+
+describe('connectDB retry logic', () => {
+  const mockConnect = mongoose.connect as jest.Mock;
+
+  beforeEach(() => {
+    mockConnect.mockReset();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('connects on first attempt', async () => {
+    mockConnect.mockResolvedValueOnce(undefined);
+
+    // Re-import to get fresh module
+    jest.resetModules();
+    const { connectDB } = await import('../config/db');
+
+    const promise = connectDB();
+    await promise;
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on failure and succeeds on 3rd attempt', async () => {
+    mockConnect
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce(undefined);
+
+    jest.resetModules();
+    const { connectDB } = await import('../config/db');
+
+    const promise = connectDB();
+
+    // Advance timers for retry delays (1s + 2s)
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(mockConnect).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api/src/config/db.ts
+++ b/apps/api/src/config/db.ts
@@ -2,13 +2,61 @@ import mongoose from 'mongoose';
 import { config } from '@health-watchers/config';
 import logger from '../utils/logger';
 
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1_000;
+
+const POOL_OPTIONS = {
+  maxPoolSize: 10,
+  minPoolSize: 2,
+  serverSelectionTimeoutMS: 5_000,
+  socketTimeoutMS: 45_000,
+  connectTimeoutMS: 10_000,
+  heartbeatFrequencyMS: 10_000,
+};
+
+// ── Connection event listeners ────────────────────────────────────────────────
+mongoose.connection.on('connected', () =>
+  logger.info({ event: 'db:connected', poolSize: POOL_OPTIONS.maxPoolSize }, 'MongoDB connected')
+);
+mongoose.connection.on('disconnected', () =>
+  logger.warn({ event: 'db:disconnected' }, 'MongoDB disconnected')
+);
+mongoose.connection.on('reconnected', () =>
+  logger.info({ event: 'db:reconnected' }, 'MongoDB reconnected')
+);
+mongoose.connection.on('error', (err) =>
+  logger.error({ event: 'db:error', err }, 'MongoDB connection error')
+);
+
+// ── Connect with exponential-backoff retry ────────────────────────────────────
 export async function connectDB(): Promise<void> {
   if (!config.mongoUri) {
     logger.error('MONGO_URI is not set');
     process.exit(1);
   }
-  await mongoose.connect(config.mongoUri, {
-    maxPoolSize: config.mongoMaxPool ?? 10,
-  });
-  logger.info('MongoDB connected');
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await mongoose.connect(config.mongoUri, POOL_OPTIONS);
+      logger.info(
+        { maxPoolSize: POOL_OPTIONS.maxPoolSize, minPoolSize: POOL_OPTIONS.minPoolSize },
+        'MongoDB connection pool ready'
+      );
+      return;
+    } catch (err) {
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1); // 1s, 2s, 4s, 8s, 16s
+      if (attempt === MAX_RETRIES) {
+        logger.error({ err, attempt }, 'MongoDB connection failed after max retries');
+        process.exit(1);
+      }
+      logger.warn({ err, attempt, retryInMs: delay }, 'MongoDB connection failed, retrying…');
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+/** Returns the current DB connection status for health checks */
+export function getDbStatus(): 'connected' | 'connecting' | 'disconnected' | 'disconnecting' {
+  const states = ['disconnected', 'connected', 'connecting', 'disconnecting'] as const;
+  return states[mongoose.connection.readyState] ?? 'disconnected';
 }

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -4,6 +4,7 @@ import { cache } from '../../services/cache.service';
 import { stellarClient } from '../payments/services/stellar-client';
 import { isAIServiceAvailable } from '../ai/ai.service';
 import { config } from '@health-watchers/config';
+import { getDbStatus } from '../../config/db';
 
 const router = Router();
 
@@ -13,7 +14,9 @@ const router = Router();
 router.get('/live', (req: Request, res: Response) => {
   res.status(200).json({
     status: 'alive',
-    uptime: process.uptime(),
+    service: 'health-watchers-api',
+    database: getDbStatus(),
+    uptime: Math.floor(process.uptime()),
     timestamp: new Date().toISOString(),
   });
 });


### PR DESCRIPTION
**Branch:** `feat/db-connection-resilience-329`

- Rewrote `apps/api/src/config/db.ts`
- Connection pool: `maxPoolSize=10`, `minPoolSize=2`, `serverSelectionTimeoutMS=5s`, `socketTimeoutMS=45s`, `connectTimeoutMS=10s`, `heartbeatFrequencyMS=10s`
- Exponential backoff retry: up to 5 attempts with delays of 1s, 2s, 4s, 8s, 16s before giving up
- Connection event listeners: `connected`, `disconnected`, `reconnected`, `error`
- `getDbStatus()` helper returns human-readable connection state
- `GET /health/live` now includes `database` status and `uptime` fields
- Unit tests verify retry behavior with a mock that fails N times then succeeds
- Graceful shutdown already handled in `app.ts` via `mongoose.connection.close()`

Closes #329
