### PR TITLE
feat(db): add missing indexes to Encounter, PaymentRecord, and User m…

### DIFF
--- a/apps/api/src/migrations/20260425_add_missing_indexes.ts
+++ b/apps/api/src/migrations/20260425_add_missing_indexes.ts
@@ -1,0 +1,57 @@
+import { Db } from 'mongodb';
+
+export async function up(db: Db): Promise<void> {
+  // ── EncounterModel indexes ──────────────────────────────────────────────────
+  await db.collection('encounters').createIndex(
+    { clinicId: 1, createdAt: -1 },
+    { background: true, name: 'clinicId_1_createdAt_-1' }
+  );
+  await db.collection('encounters').createIndex(
+    { patientId: 1, createdAt: -1 },
+    { background: true, name: 'patientId_1_createdAt_-1' }
+  );
+  await db.collection('encounters').createIndex(
+    { clinicId: 1, patientId: 1, status: 1 },
+    { background: true, name: 'clinicId_1_patientId_1_status_1' }
+  );
+  await db.collection('encounters').createIndex(
+    { encounteredBy: 1, createdAt: -1 },
+    { background: true, name: 'encounteredBy_1_createdAt_-1' }
+  );
+
+  // ── PaymentRecordModel indexes ──────────────────────────────────────────────
+  await db.collection('paymentrecords').createIndex(
+    { clinicId: 1, createdAt: -1 },
+    { background: true, name: 'clinicId_1_createdAt_-1' }
+  );
+  await db.collection('paymentrecords').createIndex(
+    { clinicId: 1, status: 1 },
+    { background: true, name: 'clinicId_1_status_1' }
+  );
+  await db.collection('paymentrecords').createIndex(
+    { txHash: 1 },
+    { background: true, sparse: true, name: 'txHash_1_sparse' }
+  );
+
+  // ── UserModel indexes ───────────────────────────────────────────────────────
+  await db.collection('users').createIndex(
+    { clinicId: 1, role: 1 },
+    { background: true, name: 'clinicId_1_role_1' }
+  );
+  await db.collection('users').createIndex(
+    { clinicId: 1, isActive: 1 },
+    { background: true, name: 'clinicId_1_isActive_1' }
+  );
+}
+
+export async function down(db: Db): Promise<void> {
+  await db.collection('encounters').dropIndex('clinicId_1_createdAt_-1').catch(() => {});
+  await db.collection('encounters').dropIndex('patientId_1_createdAt_-1').catch(() => {});
+  await db.collection('encounters').dropIndex('clinicId_1_patientId_1_status_1').catch(() => {});
+  await db.collection('encounters').dropIndex('encounteredBy_1_createdAt_-1').catch(() => {});
+  await db.collection('paymentrecords').dropIndex('clinicId_1_createdAt_-1').catch(() => {});
+  await db.collection('paymentrecords').dropIndex('clinicId_1_status_1').catch(() => {});
+  await db.collection('paymentrecords').dropIndex('txHash_1_sparse').catch(() => {});
+  await db.collection('users').dropIndex('clinicId_1_role_1').catch(() => {});
+  await db.collection('users').dropIndex('clinicId_1_isActive_1').catch(() => {});
+}

--- a/apps/api/src/modules/auth/models/user.model.ts
+++ b/apps/api/src/modules/auth/models/user.model.ts
@@ -137,4 +137,7 @@ userSchema.pre('save', async function () {
   this.password = await bcrypt.hash(this.password, 12);
 });
 
+userSchema.index({ clinicId: 1, role: 1 });     // List users by clinic and role
+userSchema.index({ clinicId: 1, isActive: 1 }); // Active users per clinic
+
 export const UserModel = models.User || model('User', userSchema);

--- a/apps/api/src/modules/encounters/encounter.model.ts
+++ b/apps/api/src/modules/encounters/encounter.model.ts
@@ -176,6 +176,10 @@ const encounterSchema = new Schema<Encounter>(
 
 // Compound index for paginated clinic-scoped queries
 encounterSchema.index({ clinicId: 1, patientId: 1, createdAt: -1 });
+encounterSchema.index({ clinicId: 1, createdAt: -1 });           // List encounters for clinic
+encounterSchema.index({ patientId: 1, createdAt: -1 });          // Patient encounter history
+encounterSchema.index({ clinicId: 1, patientId: 1, status: 1 }); // Filter by status
+encounterSchema.index({ encounteredBy: 1, createdAt: -1 });      // Doctor's encounters
 encounterSchema.index({ '$**': 'text' }); // full-text search across all string fields
 
 const FREE_TEXT_FIELDS = ['chiefComplaint', 'notes', 'treatmentPlan', 'aiSummary'] as const;

--- a/apps/api/src/modules/payments/models/payment-record.model.ts
+++ b/apps/api/src/modules/payments/models/payment-record.model.ts
@@ -66,6 +66,9 @@ const paymentRecordSchema = new Schema<PaymentRecord>(
 
 paymentRecordSchema.index({ status: 1, createdAt: 1 });
 paymentRecordSchema.index({ memo: 1, clinicId: 1 });
+paymentRecordSchema.index({ clinicId: 1, createdAt: -1 });        // List payments for clinic
+paymentRecordSchema.index({ clinicId: 1, status: 1 });            // Filter by status
+paymentRecordSchema.index({ txHash: 1 }, { sparse: true });       // Lookup by transaction hash
 
 export const PaymentRecordModel =
   models.PaymentRecord || model<PaymentRecord>('PaymentRecord', paymentRecordSchema);


### PR DESCRIPTION
**Branch:** `feat/db-indexes-346`

**EncounterModel** (`encounter.model.ts`):
- `{ clinicId: 1, createdAt: -1 }` — paginated clinic encounter list
- `{ patientId: 1, createdAt: -1 }` — patient encounter history
- `{ clinicId: 1, patientId: 1, status: 1 }` — status-filtered queries
- `{ encounteredBy: 1, createdAt: -1 }` — doctor's encounter list

**PaymentRecordModel** (`payment-record.model.ts`):
- `{ clinicId: 1, createdAt: -1 }` — paginated clinic payment list
- `{ clinicId: 1, status: 1 }` — status-filtered payment queries
- `{ txHash: 1 }` sparse — transaction hash lookup

**UserModel** (`user.model.ts`):
- `{ clinicId: 1, role: 1 }` — list users by clinic and role
- `{ clinicId: 1, isActive: 1 }` — active users per clinic

Migration `20260425_add_missing_indexes.ts` with idempotent `up`/`down` functions.

Closes #346 

