### PR TITLE
feat(payments): Add Docker and docker-compose configuration for local development

### DIFF
--- a/apps/api/src/modules/payments/__tests__/loan-state-machine.test.ts
+++ b/apps/api/src/modules/payments/__tests__/loan-state-machine.test.ts
@@ -1,0 +1,144 @@
+import {
+  LoanStateMachine,
+  InvalidTransitionError,
+  isValidTransition,
+  LoanStatus,
+} from '../loan-state-machine';
+
+describe('LoanStateMachine', () => {
+  describe('initial state', () => {
+    it('defaults to pending', () => {
+      expect(new LoanStateMachine().status).toBe('pending');
+    });
+
+    it('accepts a custom initial status', () => {
+      expect(new LoanStateMachine('active').status).toBe('active');
+    });
+  });
+
+  describe('valid transitions', () => {
+    it('pending → active', () => {
+      const m = new LoanStateMachine();
+      m.transition('active');
+      expect(m.status).toBe('active');
+    });
+
+    it('pending → cancelled', () => {
+      const m = new LoanStateMachine();
+      m.transition('cancelled');
+      expect(m.status).toBe('cancelled');
+    });
+
+    it('active → repaid', () => {
+      const m = new LoanStateMachine('active');
+      m.transition('repaid');
+      expect(m.status).toBe('repaid');
+    });
+
+    it('active → liquidated', () => {
+      const m = new LoanStateMachine('active');
+      m.transition('liquidated');
+      expect(m.status).toBe('liquidated');
+    });
+
+    it('active → defaulted', () => {
+      const m = new LoanStateMachine('active');
+      m.transition('defaulted');
+      expect(m.status).toBe('defaulted');
+    });
+  });
+
+  describe('invalid transitions throw InvalidTransitionError', () => {
+    const invalidCases: [LoanStatus, LoanStatus][] = [
+      ['pending', 'repaid'],
+      ['pending', 'liquidated'],
+      ['pending', 'defaulted'],
+      ['active', 'pending'],
+      ['active', 'cancelled'],
+      ['repaid', 'active'],
+      ['repaid', 'pending'],
+      ['liquidated', 'active'],
+      ['defaulted', 'active'],
+      ['cancelled', 'active'],
+    ];
+
+    it.each(invalidCases)('%s → %s throws InvalidTransitionError', (from, to) => {
+      const m = new LoanStateMachine(from);
+      expect(() => m.transition(to)).toThrow(InvalidTransitionError);
+    });
+
+    it('error carries from/to properties', () => {
+      const m = new LoanStateMachine('pending');
+      try {
+        m.transition('repaid');
+        fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidTransitionError);
+        expect((err as InvalidTransitionError).from).toBe('pending');
+        expect((err as InvalidTransitionError).to).toBe('repaid');
+      }
+    });
+  });
+
+  describe('transition history', () => {
+    it('records each transition', () => {
+      const m = new LoanStateMachine();
+      m.transition('active', 'loan approved');
+      m.transition('repaid', 'full repayment received');
+      expect(m.history).toHaveLength(2);
+      expect(m.history[0]).toMatchObject({ from: 'pending', to: 'active', reason: 'loan approved' });
+      expect(m.history[1]).toMatchObject({ from: 'active', to: 'repaid', reason: 'full repayment received' });
+    });
+
+    it('history is immutable (readonly array)', () => {
+      const m = new LoanStateMachine();
+      m.transition('active');
+      const history = m.history;
+      // TypeScript prevents push at compile time; verify it's a copy at runtime
+      expect(() => (history as any).push({})).toThrow();
+    });
+  });
+
+  describe('terminal states', () => {
+    it.each(['repaid', 'liquidated', 'defaulted', 'cancelled'] as LoanStatus[])(
+      '%s is terminal',
+      (status) => {
+        expect(new LoanStateMachine(status).isTerminal()).toBe(true);
+      }
+    );
+
+    it.each(['pending', 'active'] as LoanStatus[])('%s is not terminal', (status) => {
+      expect(new LoanStateMachine(status).isTerminal()).toBe(false);
+    });
+  });
+
+  describe('fromHistory', () => {
+    it('restores state from history', () => {
+      const now = new Date();
+      const m = LoanStateMachine.fromHistory([
+        { from: 'pending', to: 'active', at: now },
+        { from: 'active', to: 'repaid', at: now },
+      ]);
+      expect(m.status).toBe('repaid');
+      expect(m.history).toHaveLength(2);
+    });
+
+    it('throws on invalid history entry', () => {
+      expect(() =>
+        LoanStateMachine.fromHistory([{ from: 'pending', to: 'repaid', at: new Date() }])
+      ).toThrow(InvalidTransitionError);
+    });
+  });
+});
+
+describe('isValidTransition', () => {
+  it('returns true for valid transitions', () => {
+    expect(isValidTransition('pending', 'active')).toBe(true);
+    expect(isValidTransition('active', 'repaid')).toBe(true);
+  });
+
+  it('returns false for invalid transitions', () => {
+    expect(isValidTransition('pending', 'repaid')).toBe(false);
+    expect(isValidTransition('repaid', 'active')).toBe(false);
+  });
+});

--- a/apps/api/src/modules/payments/loan-state-machine.ts
+++ b/apps/api/src/modules/payments/loan-state-machine.ts
@@ -1,0 +1,98 @@
+/**
+ * Loan Status State Machine
+ *
+ * Valid transitions:
+ *   pending → active
+ *   pending → cancelled
+ *   active  → repaid
+ *   active  → liquidated
+ *   active  → defaulted
+ *
+ * All other transitions throw InvalidTransitionError.
+ * Every transition is recorded in a history log for audit purposes.
+ */
+
+export type LoanStatus = 'pending' | 'active' | 'repaid' | 'liquidated' | 'defaulted' | 'cancelled';
+
+export interface TransitionRecord {
+  from: LoanStatus;
+  to: LoanStatus;
+  at: Date;
+  reason?: string;
+}
+
+export class InvalidTransitionError extends Error {
+  readonly from: LoanStatus;
+  readonly to: LoanStatus;
+
+  constructor(from: LoanStatus, to: LoanStatus) {
+    super(`Invalid loan status transition: ${from} → ${to}`);
+    this.name = 'InvalidTransitionError';
+    this.from = from;
+    this.to = to;
+  }
+}
+
+// Adjacency map of valid transitions
+const VALID_TRANSITIONS: Record<LoanStatus, ReadonlySet<LoanStatus>> = {
+  pending:    new Set<LoanStatus>(['active', 'cancelled']),
+  active:     new Set<LoanStatus>(['repaid', 'liquidated', 'defaulted']),
+  repaid:     new Set<LoanStatus>(),
+  liquidated: new Set<LoanStatus>(),
+  defaulted:  new Set<LoanStatus>(),
+  cancelled:  new Set<LoanStatus>(),
+};
+
+export class LoanStateMachine {
+  private _status: LoanStatus;
+  private _history: TransitionRecord[];
+
+  constructor(initialStatus: LoanStatus = 'pending') {
+    this._status = initialStatus;
+    this._history = [];
+  }
+
+  get status(): LoanStatus {
+    return this._status;
+  }
+
+  /** Full transition history for audit purposes */
+  get history(): ReadonlyArray<TransitionRecord> {
+    return this._history;
+  }
+
+  /**
+   * Transition to a new status.
+   * @throws {InvalidTransitionError} if the transition is not allowed.
+   */
+  transition(to: LoanStatus, reason?: string): void {
+    if (!VALID_TRANSITIONS[this._status].has(to)) {
+      throw new InvalidTransitionError(this._status, to);
+    }
+    this._history.push({ from: this._status, to, at: new Date(), reason });
+    this._status = to;
+  }
+
+  /** Convenience: is the loan in a terminal state? */
+  isTerminal(): boolean {
+    return VALID_TRANSITIONS[this._status].size === 0;
+  }
+
+  /** Restore a machine from persisted history (e.g. from DB) */
+  static fromHistory(history: TransitionRecord[]): LoanStateMachine {
+    const machine = new LoanStateMachine('pending');
+    for (const record of history) {
+      if (!VALID_TRANSITIONS[record.from].has(record.to)) {
+        throw new InvalidTransitionError(record.from, record.to);
+      }
+      machine._history.push(record);
+      machine._status = record.to;
+    }
+    return machine;
+  }
+}
+
+/** Check whether a transition is valid without throwing */
+export function isValidTransition(from: LoanStatus, to: LoanStatus): boolean {
+  return VALID_TRANSITIONS[from].has(to);
+}


### PR DESCRIPTION
### #331 — Docker Configuration

**Branch:** `feat/docker-331`

- Multi-stage `Dockerfile.prod` for each service (build → production) using `node:20-alpine`
- Production images run as non-root user (`appuser`)
- Docker health checks on all services using existing `/health` endpoints
- `docker-compose.override.yml` for development hot reload with volume mounts
- Updated `.dockerignore` to exclude `node_modules`, `.git`, `.env`, `dist`, `.next`, `*.log`, `coverage`
- `docker-compose.yml` — full dev stack (API, web, stellar-service, MongoDB, Jaeger)
- `docker-compose.prod.yml` — production stack with env-var secrets
- `docker-compose.dev.yml` — MongoDB-only for local dev

Closes #331