### PR TITLE
feat: implement ai powered medication dosage calculator

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -66,7 +66,10 @@ import { portalRoutes } from './modules/portal/portal.controller';
 import { reportRoutes } from './modules/reports/reports.controller';
 import { consentRoutes } from './modules/consent/consent.controller';
 import { subscriptionRoutes } from './modules/subscriptions/subscriptions.controller';
-import { immunizationRoutes, cvxCodesRouter } from './modules/immunizations/immunizations.controller';
+import {
+  immunizationRoutes,
+  cvxCodesRouter,
+} from './modules/immunizations/immunizations.controller';
 import logger from './utils/logger';
 import apiKeyRoutes from './modules/api-keys/api-keys.routes';
 import scheduleRoutes from './modules/schedules/schedules.routes';
@@ -74,10 +77,8 @@ import { requestAuditMiddleware } from './middlewares/request-audit.middleware';
 import metricsRouter from './modules/metrics/metrics.routes';
 import { metricsMiddleware } from './middlewares/metrics.middleware';
 import { mongodbConnectionPoolSize } from './services/metrics.service';
-import scheduleRoutes from './modules/schedules/schedules.routes';
 import cdsRoutes from './modules/cds/cds.controller';
 import { seedBuiltInRules } from './modules/cds/cds-seed';
-
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -119,7 +120,7 @@ app.use(
       }
       return compression.filter(req, res);
     },
-  }),
+  })
 );
 
 // ── CORS ──────────────────────────────────────────────────────────────────────
@@ -148,7 +149,9 @@ app.use(
   pinoHttp({
     logger,
     genReqId: (req) => (req.headers['x-request-id'] as string) ?? crypto.randomUUID(),
-    autoLogging: { ignore: (req) => isProd && (req.url === '/health/live' || req.url === '/health/ready') },
+    autoLogging: {
+      ignore: (req) => isProd && (req.url === '/health/live' || req.url === '/health/ready'),
+    },
     redact: ['req.headers.authorization'],
   })
 );
@@ -175,7 +178,6 @@ app.use((req, res, next) => {
   next();
 });
 
-
 // ── Health check ──────────────────────────────────────────────────────────────
 app.use('/health', healthRoutes);
 
@@ -200,7 +202,7 @@ app.get('/api/versions', (_req, res) =>
       },
     ],
     current: 'v1',
-  }),
+  })
 );
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -235,7 +237,6 @@ app.use('/api/v1/subscriptions', subscriptionRoutes);
 app.use('/api/v1/schedules', scheduleRoutes);
 app.use('/api/v1/patients/:id/immunizations', immunizationRoutes);
 app.use('/api/v1/immunizations/cvx-codes', cvxCodesRouter);
-app.use('/api/v1/schedules', scheduleRoutes);
 app.use('/api/v1/cds', cdsRoutes);
 
 setupSwagger(app);
@@ -249,7 +250,7 @@ export default app;
 // ── Start server ──────────────────────────────────────────────────────────────
 async function startServer() {
   await connectDB();
-  
+
   // Seed built-in CDS rules
   await seedBuiltInRules();
 

--- a/apps/api/src/modules/ai/ai.routes.ts
+++ b/apps/api/src/modules/ai/ai.routes.ts
@@ -4,10 +4,11 @@ import {
   generateClinicalSummary,
   generateRawTextSummary,
   generatePatientInsights,
-  generateDifferentialDiagnosis,
   isAIServiceAvailable,
   AI_DISCLAIMER,
   checkDrugInteractions,
+  calculateDosage,
+  stripPII,
 } from './ai.service';
 import {
   generateDifferentialDiagnosis,
@@ -26,8 +27,6 @@ const router = Router();
 router.get('/health', (_req, res) => res.json({ status: 'ok', service: 'ai' }));
 
 // POST /api/v1/ai/summarize
-// Request body: { encounterId?: string, text?: string }
-// Returns: { success: boolean, summary: string, disclaimer: string }
 router.post('/summarize', authenticate, async (req: Request, res: Response) => {
   const startTime = Date.now();
   aiRequestsTotal.inc({ endpoint: 'summarize' });
@@ -41,7 +40,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
 
     const { encounterId, text } = req.body;
 
-    // Accept either encounterId or raw text
     if (!encounterId && !text) {
       return res.status(400).json({
         error: 'ValidationError',
@@ -53,7 +51,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
     let encounter: any;
 
     if (text) {
-      // Raw text input
       if (typeof text !== 'string' || text.trim().length < 10) {
         return res.status(400).json({
           error: 'ValidationError',
@@ -64,7 +61,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
         generateRawTextSummary(text)
       );
     } else {
-      // encounterId input
       if (!isValidObjectId(encounterId)) {
         return res.status(400).json({
           error: 'ValidationError',
@@ -78,7 +74,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
         return res.status(404).json({ error: 'NotFound', message: 'Encounter not found' });
       }
 
-      // Check ai_analysis consent
       const { hasConsent } = await import('../consent/consent.controller');
       const consentGranted = await hasConsent(
         String(encounter.patientId),
@@ -104,7 +99,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
           })
       );
 
-      // Store the summary in the encounter
       encounter.aiSummary = summary;
       await encounter.save();
     }
@@ -112,7 +106,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
     const duration = Date.now() - startTime;
     logger.info({ encounterId, duration, textLength: text?.length }, 'AI summary generated');
 
-    // Notify attending doctor (non-blocking)
     if (encounter) {
       try {
         const { UserModel } = await import('../auth/models/user.model');
@@ -139,14 +132,12 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
   } catch (error: unknown) {
     const duration = Date.now() - startTime;
     logger.error({ err: error, duration }, 'AI summarize error');
-
     if (error instanceof Error && error.message.includes('Failed to generate AI summary')) {
       return res.status(503).json({
         error: 'AIServiceError',
         message: 'Failed to generate AI summary. Please try again later.',
       });
     }
-
     return res.status(500).json({
       error: 'InternalServerError',
       message: error instanceof Error ? error.message : 'An unexpected error occurred',
@@ -155,8 +146,6 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
 });
 
 // POST /api/v1/ai/insights
-// Request body: { patientId: string }
-// Returns: { success: boolean, insights: string, disclaimer: string }
 router.post('/insights', authenticate, async (req: Request, res: Response) => {
   const startTime = Date.now();
   try {
@@ -176,8 +165,6 @@ router.post('/insights', authenticate, async (req: Request, res: Response) => {
     }
 
     const { EncounterModel } = await import('../encounters/encounter.model');
-
-    // Fetch last 10 encounters for the patient
     const encounters = await EncounterModel.find({
       patientId,
       clinicId: req.user!.clinicId,
@@ -219,14 +206,12 @@ router.post('/insights', authenticate, async (req: Request, res: Response) => {
   } catch (error: unknown) {
     const duration = Date.now() - startTime;
     logger.error({ err: error, duration }, 'AI insights error');
-
     if (error instanceof Error && error.message.includes('Failed to generate patient insights')) {
       return res.status(503).json({
         error: 'AIServiceError',
         message: 'Failed to generate patient insights. Please try again later.',
       });
     }
-
     return res.status(500).json({
       error: 'InternalServerError',
       message: error instanceof Error ? error.message : 'An unexpected error occurred',
@@ -235,26 +220,27 @@ router.post('/insights', authenticate, async (req: Request, res: Response) => {
 });
 
 // POST /api/v1/ai/drug-interactions
-// Stub endpoint for future drug interaction checking
-// Request body: { medications: string[] }
-// Returns: 501 Not Implemented
 router.post('/drug-interactions', authenticate, async (req: Request, res: Response) => {
-  logger.info(
-    { medications: req.body.medications },
-    'Drug interaction check requested (not implemented)'
-  );
-
-  return res.status(501).json({
-    error: 'NotImplemented',
-    message:
-      'Drug interaction checking is not yet implemented. This feature will be available in a future release.',
-    requestedMedications: req.body.medications || [],
-  });
+  try {
+    if (!isAIServiceAvailable()) {
+      return res.status(503).json({ error: 'AIUnavailable' });
+    }
+    const { currentMedications, newDrug } = req.body;
+    if (!newDrug || typeof newDrug !== 'string') {
+      return res.status(400).json({ error: 'ValidationError', message: 'newDrug is required' });
+    }
+    const result = await checkDrugInteractions({
+      currentMedications: Array.isArray(currentMedications) ? currentMedications : [],
+      newDrug,
+    });
+    return res.json({ success: true, ...result });
+  } catch (error: any) {
+    logger.error({ err: error }, 'AI drug-interactions error');
+    return res.status(500).json({ error: 'InternalServerError', message: error.message });
+  }
 });
 
 // POST /api/v1/ai/health-trends
-// Request body: { patientId: string }
-// Returns: { success: boolean, summary: string }
 router.post('/health-trends', authenticate, async (req: Request, res: Response) => {
   try {
     if (!isAIServiceAvailable()) {
@@ -283,7 +269,6 @@ router.post('/health-trends', authenticate, async (req: Request, res: Response) 
       return res.status(404).json({ error: 'NotFound', message: 'Patient not found' });
     }
 
-    // Anonymize: strip PII, keep only vitals + dates
     const anonymizedVitals = encounters
       .filter((e) => e.vitalSigns && Object.keys(e.vitalSigns).length > 0)
       .map((e) => ({ date: (e as any).createdAt, vitals: e.vitalSigns }));
@@ -300,12 +285,7 @@ router.post('/health-trends', authenticate, async (req: Request, res: Response) 
     const genAI = new GoogleGenerativeAI(config.geminiApiKey);
     const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
-    const prompt = `You are a medical AI assistant. Analyze the following anonymized vital sign history and provide a concise health trend summary in 2-3 sentences. Focus on notable patterns, improvements, or concerns.
-
-Vital Signs History (chronological):
-${JSON.stringify(anonymizedVitals, null, 2)}
-
-Provide a professional health trend summary:`;
+    const prompt = `You are a medical AI assistant. Analyze the following anonymized vital sign history and provide a concise health trend summary in 2-3 sentences. Focus on notable patterns, improvements, or concerns.\n\nVital Signs History (chronological):\n${JSON.stringify(anonymizedVitals, null, 2)}\n\nProvide a professional health trend summary:`;
 
     const result = await model.generateContent(prompt);
     const summary = result.response.text();
@@ -317,31 +297,7 @@ Provide a professional health trend summary:`;
   }
 });
 
-// POST /api/v1/ai/drug-interactions
-// Body: { currentMedications: string[], newDrug: string }
-router.post('/drug-interactions', authenticate, async (req: Request, res: Response) => {
-  try {
-    if (!isAIServiceAvailable()) {
-      return res.status(503).json({ error: 'AIUnavailable' });
-    }
-    const { currentMedications, newDrug } = req.body;
-    if (!newDrug || typeof newDrug !== 'string') {
-      return res.status(400).json({ error: 'ValidationError', message: 'newDrug is required' });
-    }
-    const result = await checkDrugInteractions({
-      currentMedications: Array.isArray(currentMedications) ? currentMedications : [],
-      newDrug,
-    });
-    return res.json({ success: true, ...result });
-  } catch (error: any) {
-    logger.error({ err: error }, 'AI drug-interactions error');
-    return res.status(500).json({ error: 'InternalServerError', message: error.message });
-  }
-});
-
 // POST /api/v1/ai/interpret-labs
-// Request body: { labResultId: string }
-// Returns: { success: boolean, interpretation: string, criticalValues: string[] }
 router.post('/interpret-labs', authenticate, async (req: Request, res: Response) => {
   try {
     if (!isAIServiceAvailable()) {
@@ -375,14 +331,7 @@ router.post('/interpret-labs', authenticate, async (req: Request, res: Response)
     const genAI = new GoogleGenerativeAI(config.geminiApiKey);
     const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
-    const prompt = `You are a medical AI assistant. Interpret the following lab results in plain language for a clinician.
-Highlight any abnormal values and flag critical values (HH/LL) for immediate attention. Keep the response to 3-4 sentences.
-
-Test: ${labResult.testName}${labResult.testCode ? ` (${labResult.testCode})` : ''}
-Results:
-${labResult.results.map((r) => `- ${r.parameter}: ${r.value} ${r.unit} (ref: ${r.referenceRange})${r.flag ? ` [${r.flag}]` : ''}`).join('\n')}
-
-Provide a plain-language clinical interpretation:`;
+    const prompt = `You are a medical AI assistant. Interpret the following lab results in plain language for a clinician.\nHighlight any abnormal values and flag critical values (HH/LL) for immediate attention. Keep the response to 3-4 sentences.\n\nTest: ${labResult.testName}${labResult.testCode ? ` (${labResult.testCode})` : ''}\nResults:\n${labResult.results.map((r) => `- ${r.parameter}: ${r.value} ${r.unit} (ref: ${r.referenceRange})${r.flag ? ` [${r.flag}]` : ''}`).join('\n')}\n\nProvide a plain-language clinical interpretation:`;
 
     const result = await model.generateContent(prompt);
     const interpretation = result.response.text();
@@ -395,8 +344,6 @@ Provide a plain-language clinical interpretation:`;
 });
 
 // POST /api/v1/ai/generate-care-plan
-// Input: { patientId, condition, icdCode? }
-// Returns: AI-suggested care plan (not saved — doctor must approve via POST /care-plans)
 router.post(
   '/generate-care-plan',
   authenticate,
@@ -438,11 +385,7 @@ router.post(
       const genAI = new GoogleGenerativeAI(config.geminiApiKey);
       const aiModel = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
-      const prompt = `You are a clinical decision support AI. Generate a structured chronic disease care plan for a patient with the following profile.
-
-Condition: ${condition}${icdCode ? ` (ICD-10: ${icdCode})` : ''}
-Patient sex: ${(patient as any).sex}
-Recent encounters (last 5): ${JSON.stringify(
+      const prompt = `You are a clinical decision support AI. Generate a structured chronic disease care plan for a patient with the following profile.\n\nCondition: ${condition}${icdCode ? ` (ICD-10: ${icdCode})` : ''}\nPatient sex: ${(patient as any).sex}\nRecent encounters (last 5): ${JSON.stringify(
         recentEncounters.map((e) => ({
           date: (e as any).createdAt,
           chiefComplaint: e.chiefComplaint,
@@ -451,22 +394,13 @@ Recent encounters (last 5): ${JSON.stringify(
         })),
         null,
         2
-      )}
-
-Respond ONLY with a valid JSON object matching this exact structure (no markdown, no explanation):
-{
-  "goals": [{ "description": string, "targetValue": string | null, "status": "active" }],
-  "interventions": [{ "type": "medication"|"lifestyle"|"monitoring"|"referral", "description": string, "frequency": string | null }],
-  "monitoringSchedule": [{ "parameter": string, "frequency": string, "targetRange": string | null }],
-  "reviewDate": "<ISO date 3 months from today>"
-}`;
+      )}\n\nRespond ONLY with a valid JSON object matching this exact structure (no markdown, no explanation):\n{\n  "goals": [{ "description": string, "targetValue": string | null, "status": "active" }],\n  "interventions": [{ "type": "medication"|"lifestyle"|"monitoring"|"referral", "description": string, "frequency": string | null }],\n  "monitoringSchedule": [{ "parameter": string, "frequency": string, "targetRange": string | null }],\n  "reviewDate": "<ISO date 3 months from today>"\n}`;
 
       const result = await aiModel.generateContent(prompt);
       const text = result.response.text().trim();
 
       let suggestion: unknown;
       try {
-        // Strip possible markdown code fences
         const json = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
         suggestion = JSON.parse(json);
       } catch {
@@ -485,7 +419,6 @@ Respond ONLY with a valid JSON object matching this exact structure (no markdown
 );
 
 // POST /api/v1/ai/risk-assessment
-// Body: { patientId: string }
 router.post('/risk-assessment', authenticate, async (req: Request, res: Response) => {
   try {
     if (!isAIServiceAvailable()) {
@@ -570,7 +503,6 @@ router.post('/risk-assessment', authenticate, async (req: Request, res: Response
       smokingHistory,
     });
 
-    // Ask Gemini for recommendations (PII-stripped)
     const anonymizedSummary = stripPII(
       JSON.stringify({
         ageGroup: ageYears > 65 ? '65+' : ageYears > 45 ? '45-65' : 'under-45',
@@ -581,14 +513,6 @@ router.post('/risk-assessment', authenticate, async (req: Request, res: Response
         missedAppointments: missedAppts,
       })
     );
-    const anonymizedSummary = stripPII(JSON.stringify({
-      ageGroup: ageYears > 65 ? '65+' : ageYears > 45 ? '45-65' : 'under-45',
-      sex: (patient as any).sex,
-      riskFactors: factors,
-      recentDiagnoses: allDiagnoses.slice(0, 5),
-      abnormalLabCount,
-      missedAppointments: missedAppts,
-    }));
 
     const genAI = new GoogleGenerativeAI(config.geminiApiKey);
     const aiModel = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
@@ -641,21 +565,7 @@ router.post('/risk-assessment', authenticate, async (req: Request, res: Response
   }
 });
 
-// POST /api/v1/ai/predict-duration
-// Predict appointment duration based on appointment type, patient age, chief complaint, and doctor history
-router.post('/predict-duration', authenticate, async (req: Request, res: Response) => {
-  try {
-    if (!isAIServiceAvailable()) {
-      return res.status(503).json({
-        error: 'AIUnavailable',
-        message: 'AI service is not configured',
-      });
-    }
-
-    const { appointmentType, patientAge, chiefComplaint, doctorId } = req.body;
 // POST /api/v1/ai/differential-diagnosis
-// Body: { chiefComplaint, symptoms, vitalSigns?, patientAge?, patientSex?, relevantHistory? }
-// Returns: { differentials, urgency, disclaimer }
 router.post(
   '/differential-diagnosis',
   authenticate,
@@ -672,16 +582,14 @@ router.post(
         });
       }
 
-      const {
-        chiefComplaint,
-        symptoms,
-        vitalSigns,
-        patientAge,
-        patientSex,
-        relevantHistory,
-      } = req.body as DifferentialDiagnosisInput;
+      const { chiefComplaint, symptoms, vitalSigns, patientAge, patientSex, relevantHistory } =
+        req.body as DifferentialDiagnosisInput;
 
-      if (!chiefComplaint || typeof chiefComplaint !== 'string' || chiefComplaint.trim().length < 3) {
+      if (
+        !chiefComplaint ||
+        typeof chiefComplaint !== 'string' ||
+        chiefComplaint.trim().length < 3
+      ) {
         return res.status(400).json({
           error: 'ValidationError',
           message: 'chiefComplaint is required and must be at least 3 characters',
@@ -693,7 +601,10 @@ router.post(
           message: 'symptoms must be a non-empty array of strings',
         });
       }
-      if (patientAge !== undefined && (typeof patientAge !== 'number' || patientAge < 0 || patientAge > 150)) {
+      if (
+        patientAge !== undefined &&
+        (typeof patientAge !== 'number' || patientAge < 0 || patientAge > 150)
+      ) {
         return res.status(400).json({
           error: 'ValidationError',
           message: 'patientAge must be a number between 0 and 150',
@@ -711,20 +622,19 @@ router.post(
             patientAge,
             patientSex,
             relevantHistory,
-          }),
+          })
       );
 
       const duration = Date.now() - startTime;
       logger.info(
         { clinicId: req.user!.clinicId, duration, differentialCount: result.differentials.length },
-        'AI differential diagnosis generated',
+        'AI differential diagnosis generated'
       );
 
       return res.json({ success: true, ...result });
     } catch (error: unknown) {
       const duration = Date.now() - startTime;
       logger.error({ err: error, duration }, 'AI differential-diagnosis error');
-
       if (error instanceof Error && error.message.includes('unparseable')) {
         return res.status(502).json({
           error: 'AIParseError',
@@ -732,24 +642,24 @@ router.post(
           disclaimer: DIFFERENTIAL_DISCLAIMER,
         });
       }
-
       return res.status(500).json({
         error: 'InternalServerError',
         message: error instanceof Error ? error.message : 'An unexpected error occurred',
       });
     }
-  },
+  }
 );
 
 // POST /api/v1/ai/predict-duration
 router.post('/predict-duration', authenticate, async (req: Request, res: Response) => {
   try {
     if (!isAIServiceAvailable()) {
-      return res.status(503).json({ error: 'AIUnavailable', message: 'AI service is not configured' });
+      return res
+        .status(503)
+        .json({ error: 'AIUnavailable', message: 'AI service is not configured' });
     }
 
     const { appointmentType, patientAge, chiefComplaint } = req.body;
-
     if (!appointmentType || !patientAge || !chiefComplaint) {
       return res.status(400).json({
         error: 'ValidationError',
@@ -757,7 +667,6 @@ router.post('/predict-duration', authenticate, async (req: Request, res: Respons
       });
     }
 
-    // Get historical encounter durations for similar cases
     const { EncounterModel } = await import('../encounters/encounter.model');
     const historicalEncounters = await EncounterModel.find({
       chiefComplaint: { $regex: chiefComplaint.split(' ')[0], $options: 'i' },
@@ -768,27 +677,19 @@ router.post('/predict-duration', authenticate, async (req: Request, res: Respons
       .limit(20)
       .lean();
 
-    // Calculate average duration from historical data
-    let baseDuration = 30; // default 30 minutes
+    let baseDuration = 30;
     if (historicalEncounters.length > 0) {
-      const durations = historicalEncounters.map((e: any) => {
-        const duration = Math.random() * 30 + 20; // Simulate 20-50 min range
-        return duration;
-      });
-      baseDuration = Math.round(
-        durations.reduce((a: number, b: number) => a + b, 0) / durations.length
-      );
+      const durations = historicalEncounters.map(() => Math.random() * 30 + 20);
+      baseDuration = Math.round(durations.reduce((a, b) => a + b, 0) / durations.length);
     }
 
-    // Adjust based on appointment type
     const typeMultipliers: Record<string, number> = {
       consultation: 1.0,
       'follow-up': 0.75,
       procedure: 1.5,
       emergency: 1.2,
     };
-    const multiplier = typeMultipliers[appointmentType] || 1.0;
-    const predictedDuration = Math.round(baseDuration * multiplier);
+    const predictedDuration = Math.round(baseDuration * (typeMultipliers[appointmentType] || 1.0));
 
     return res.json({
       status: 'success',
@@ -798,22 +699,6 @@ router.post('/predict-duration', authenticate, async (req: Request, res: Respons
         baselineDuration: baseDuration,
         disclaimer: AI_DISCLAIMER,
       },
-    }).select('createdAt').limit(20).lean();
-
-    let baseDuration = 30;
-    if (historicalEncounters.length > 0) {
-      const durations = historicalEncounters.map(() => Math.random() * 30 + 20);
-      baseDuration = Math.round(durations.reduce((a, b) => a + b, 0) / durations.length);
-    }
-
-    const typeMultipliers: Record<string, number> = {
-      consultation: 1.0, 'follow-up': 0.75, procedure: 1.5, emergency: 1.2,
-    };
-    const predictedDuration = Math.round(baseDuration * (typeMultipliers[appointmentType] || 1.0));
-
-    return res.json({
-      status: 'success',
-      data: { predictedDuration, confidence: 0.75, baselineDuration: baseDuration, disclaimer: AI_DISCLAIMER },
     });
   } catch (error: any) {
     logger.error({ err: error }, 'AI predict-duration error');
@@ -822,65 +707,44 @@ router.post('/predict-duration', authenticate, async (req: Request, res: Respons
 });
 
 // POST /api/v1/ai/no-show-risk
-// Predict no-show risk based on patient history
 router.post('/no-show-risk', authenticate, async (req: Request, res: Response) => {
   try {
     if (!isAIServiceAvailable()) {
-      return res.status(503).json({
-        error: 'AIUnavailable',
-        message: 'AI service is not configured',
-      });
-    }
-
-    const { patientId, appointmentDate, appointmentType } = req.body;
-
-    if (!patientId || !appointmentDate) {
-      return res.status(400).json({
-        error: 'ValidationError',
-        message: 'patientId and appointmentDate are required',
-      });
-    }
-
-    // Get patient's appointment history
-router.post('/no-show-risk', authenticate, async (req: Request, res: Response) => {
-  try {
-    if (!isAIServiceAvailable()) {
-      return res.status(503).json({ error: 'AIUnavailable', message: 'AI service is not configured' });
+      return res
+        .status(503)
+        .json({ error: 'AIUnavailable', message: 'AI service is not configured' });
     }
 
     const { patientId, appointmentDate } = req.body;
-
     if (!patientId || !appointmentDate) {
-      return res.status(400).json({ error: 'ValidationError', message: 'patientId and appointmentDate are required' });
+      return res
+        .status(400)
+        .json({ error: 'ValidationError', message: 'patientId and appointmentDate are required' });
     }
 
     const { AppointmentModel } = await import('../appointments/appointment.model');
     const appointments = await AppointmentModel.find({
       patientId,
       clinicId: req.user!.clinicId,
-      createdAt: { $gte: new Date(Date.now() - 180 * 24 * 60 * 60 * 1000) }, // Last 6 months
+      createdAt: { $gte: new Date(Date.now() - 180 * 24 * 60 * 60 * 1000) },
     })
       .select('status')
       .lean();
-      createdAt: { $gte: new Date(Date.now() - 180 * 24 * 60 * 60 * 1000) },
-    }).select('status').lean();
 
     const totalAppointments = appointments.length;
     const noShowCount = appointments.filter((a: any) => a.status === 'no-show').length;
     const cancelledCount = appointments.filter((a: any) => a.status === 'cancelled').length;
 
-    // Calculate risk score
     let riskScore = 0;
     if (totalAppointments > 0) {
-      const noShowRate = noShowCount / totalAppointments;
-      const cancelRate = cancelledCount / totalAppointments;
-      riskScore = Math.min(100, (noShowRate * 60 + cancelRate * 40) * 100);
+      riskScore = Math.min(
+        100,
+        ((noShowCount / totalAppointments) * 60 + (cancelledCount / totalAppointments) * 40) * 100
+      );
     }
 
-    // Determine risk level
-    let riskLevel: 'low' | 'medium' | 'high' = 'low';
-    if (riskScore > 60) riskLevel = 'high';
-    else if (riskScore > 30) riskLevel = 'medium';
+    const riskLevel: 'low' | 'medium' | 'high' =
+      riskScore > 60 ? 'high' : riskScore > 30 ? 'medium' : 'low';
 
     return res.json({
       status: 'success',
@@ -891,16 +755,6 @@ router.post('/no-show-risk', authenticate, async (req: Request, res: Response) =
         totalAppointments,
         disclaimer: AI_DISCLAIMER,
       },
-    let riskScore = 0;
-    if (totalAppointments > 0) {
-      riskScore = Math.min(100, ((noShowCount / totalAppointments) * 60 + (cancelledCount / totalAppointments) * 40) * 100);
-    }
-
-    const riskLevel: 'low' | 'medium' | 'high' = riskScore > 60 ? 'high' : riskScore > 30 ? 'medium' : 'low';
-
-    return res.json({
-      status: 'success',
-      data: { riskLevel, riskScore: Math.round(riskScore), noShowHistory: noShowCount, totalAppointments, disclaimer: AI_DISCLAIMER },
     });
   } catch (error: any) {
     logger.error({ err: error }, 'AI no-show-risk error');
@@ -916,15 +770,12 @@ router.post(
   async (req: Request, res: Response) => {
     try {
       if (!isAIServiceAvailable()) {
-        return res.status(503).json({
-          error: 'AIUnavailable',
-          message: 'AI service is not configured',
-        });
-        return res.status(503).json({ error: 'AIUnavailable', message: 'AI service is not configured' });
+        return res
+          .status(503)
+          .json({ error: 'AIUnavailable', message: 'AI service is not configured' });
       }
 
       const { date, availableSlots, pendingAppointments } = req.body;
-
       if (!date || !availableSlots || !pendingAppointments) {
         return res.status(400).json({
           error: 'ValidationError',
@@ -932,23 +783,12 @@ router.post(
         });
       }
 
-      // Simple optimization: sort by appointment type priority and patient risk
       const typeScores: Record<string, number> = {
         emergency: 1,
         consultation: 2,
         'follow-up': 3,
         procedure: 4,
       };
-
-      const optimized = pendingAppointments
-        .map((apt: any) => ({
-          ...apt,
-          score: typeScores[apt.type] || 5,
-        }))
-        .sort((a: any, b: any) => a.score - b.score);
-
-      // Assign to available slots
-      const typeScores: Record<string, number> = { emergency: 1, consultation: 2, 'follow-up': 3, procedure: 4 };
       const optimized = pendingAppointments
         .map((apt: any) => ({ ...apt, score: typeScores[apt.type] || 5 }))
         .sort((a: any, b: any) => a.score - b.score);
@@ -966,10 +806,97 @@ router.post(
           unscheduled: optimized.slice(availableSlots.length).length,
           disclaimer: AI_DISCLAIMER,
         },
-        data: { optimizedSchedule: scheduled, unscheduled: optimized.slice(availableSlots.length).length, disclaimer: AI_DISCLAIMER },
       });
     } catch (error: any) {
       logger.error({ err: error }, 'AI optimize-schedule error');
+      return res.status(500).json({ error: 'InternalServerError', message: error.message });
+    }
+  }
+);
+
+// POST /api/v1/ai/dosage-calculator
+router.post(
+  '/dosage-calculator',
+  authenticate,
+  requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN'),
+  async (req: Request, res: Response) => {
+    const startTime = Date.now();
+    try {
+      if (!isAIServiceAvailable()) {
+        return res
+          .status(503)
+          .json({ error: 'AIUnavailable', message: 'AI service is not configured.' });
+      }
+
+      const {
+        drugName,
+        patientWeight,
+        patientAge,
+        patientSex,
+        indication,
+        renalFunction,
+        hepaticFunction,
+      } = req.body;
+
+      if (!drugName || patientWeight == null || patientAge == null || !patientSex || !indication) {
+        return res.status(400).json({
+          error: 'ValidationError',
+          message: 'drugName, patientWeight, patientAge, patientSex, and indication are required',
+        });
+      }
+      if (typeof patientWeight !== 'number' || patientWeight <= 0 || patientWeight > 500) {
+        return res
+          .status(400)
+          .json({
+            error: 'ValidationError',
+            message: 'patientWeight must be a positive number (kg)',
+          });
+      }
+      if (typeof patientAge !== 'number' || patientAge < 0 || patientAge > 150) {
+        return res
+          .status(400)
+          .json({ error: 'ValidationError', message: 'patientAge must be 0–150' });
+      }
+      if (!['M', 'F'].includes(patientSex)) {
+        return res
+          .status(400)
+          .json({ error: 'ValidationError', message: 'patientSex must be M or F' });
+      }
+
+      const result = await calculateDosage({
+        drugName,
+        patientWeight,
+        patientAge,
+        patientSex,
+        indication,
+        renalFunction,
+        hepaticFunction,
+      });
+
+      const { auditLog } = await import('../audit/audit.service');
+      await auditLog(
+        {
+          action: 'DOSAGE_CALCULATION',
+          resourceType: 'Drug',
+          resourceId: drugName,
+          userId: req.user!.userId,
+          clinicId: req.user!.clinicId,
+          outcome: 'SUCCESS',
+          metadata: {
+            drugName,
+            patientAge,
+            patientWeight,
+            indication,
+            durationMs: Date.now() - startTime,
+          },
+        },
+        req
+      );
+
+      aiRequestsTotal.inc({ endpoint: 'dosage-calculator' });
+      return res.json({ success: true, data: result });
+    } catch (error: any) {
+      logger.error({ err: error }, 'AI dosage-calculator error');
       return res.status(500).json({ error: 'InternalServerError', message: error.message });
     }
   }

--- a/apps/api/src/modules/ai/ai.service.ts
+++ b/apps/api/src/modules/ai/ai.service.ts
@@ -20,13 +20,13 @@ export const AI_DISCLAIMER =
 // ── PII stripping using anonymization service ─────────────────────────────────
 export function stripPII(text: string, patientData?: Partial<PatientData>): string {
   if (patientData) {
-    const anonymized = anonymize(
-      { ...patientData, clinicalNotes: text } as PatientData,
-      { level: 'de-identification', purpose: 'ai' }
-    );
+    const anonymized = anonymize({ ...patientData, clinicalNotes: text } as PatientData, {
+      level: 'de-identification',
+      purpose: 'ai',
+    });
     return anonymized.clinicalNotes || text;
   }
-  
+
   // Fallback to basic PII patterns
   const PII_PATTERNS: [RegExp, string][] = [
     [/\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/g, '[PHONE]'],
@@ -35,7 +35,7 @@ export function stripPII(text: string, patientData?: Partial<PatientData>): stri
     [/\b(0[1-9]|1[0-2])[\/\-](0[1-9]|[12]\d|3[01])[\/\-]\d{2,4}\b/g, '[DOB]'],
     [/\b\d{5}(-\d{4})?\b/g, '[ZIP]'],
   ];
-  
+
   let sanitized = text;
   for (const [pattern, replacement] of PII_PATTERNS) {
     sanitized = sanitized.replace(pattern, replacement);
@@ -140,7 +140,9 @@ export interface DrugInteractionResult {
   recommendation: string;
 }
 
-export async function checkDrugInteractions(input: DrugInteractionInput): Promise<DrugInteractionResult> {
+export async function checkDrugInteractions(
+  input: DrugInteractionInput
+): Promise<DrugInteractionResult> {
   const client = getGeminiClient();
 
   const prompt = `You are a clinical pharmacist AI. Check for drug-drug interactions between the new drug and the current medications.
@@ -241,5 +243,95 @@ Respond ONLY with a valid JSON object matching this exact structure (no markdown
   } catch (error) {
     const msg = error instanceof Error ? error.message : 'Unknown error';
     throw new Error(`Failed to generate differential diagnosis: ${msg}`);
+  }
+}
+
+// ── Dosage Calculator ─────────────────────────────────────────────────────────
+
+export interface DosageCalculatorInput {
+  drugName: string;
+  patientWeight: number; // kg
+  patientAge: number; // years
+  patientSex: 'M' | 'F';
+  indication: string;
+  renalFunction?: 'normal' | 'mild_impairment' | 'moderate_impairment' | 'severe_impairment';
+  hepaticFunction?: 'normal' | 'impaired';
+}
+
+export interface DosageCalculatorResult {
+  recommendedDose: string;
+  frequency: string;
+  route: string;
+  maxDailyDose: string;
+  pediatricAdjustment: boolean;
+  renalAdjustment: boolean;
+  warnings: string[];
+  contraindications: string[];
+  disclaimer: string;
+}
+
+export async function calculateDosage(
+  input: DosageCalculatorInput
+): Promise<DosageCalculatorResult> {
+  const client = getGeminiClient();
+
+  const isPediatric = input.patientAge < 18;
+  const renalNote =
+    input.renalFunction && input.renalFunction !== 'normal'
+      ? `Renal function: ${input.renalFunction.replace(/_/g, ' ')}`
+      : 'Renal function: normal';
+  const hepaticNote =
+    input.hepaticFunction === 'impaired'
+      ? 'Hepatic function: impaired'
+      : 'Hepatic function: normal';
+
+  const prompt = `You are a clinical pharmacist AI providing evidence-based dosage guidance.
+
+Patient parameters (no PII):
+- Drug: ${input.drugName}
+- Indication: ${input.indication}
+- Weight: ${input.patientWeight} kg
+- Age: ${input.patientAge} years (${isPediatric ? 'pediatric' : 'adult'})
+- Sex: ${input.patientSex === 'M' ? 'Male' : 'Female'}
+- ${renalNote}
+- ${hepaticNote}
+
+Provide dosage recommendations based on standard clinical guidelines (e.g., BNF, Micromedex).
+Apply weight-based dosing for pediatric patients.
+Apply dose adjustments for renal/hepatic impairment if applicable.
+
+Respond ONLY with valid JSON matching this exact structure (no markdown):
+{
+  "recommendedDose": "string (e.g. '10 mg/kg' or '500 mg')",
+  "frequency": "string (e.g. 'every 8 hours' or 'twice daily')",
+  "route": "string (e.g. 'oral', 'IV', 'IM')",
+  "maxDailyDose": "string (e.g. '2000 mg/day')",
+  "pediatricAdjustment": boolean,
+  "renalAdjustment": boolean,
+  "warnings": ["string"],
+  "contraindications": ["string"]
+}`;
+
+  const model = client.getGenerativeModel({
+    model: 'gemini-1.5-flash',
+    generationConfig: { responseMimeType: 'application/json' },
+  });
+
+  const result = await model.generateContent(prompt);
+  const text = result.response
+    .text()
+    .trim()
+    .replace(/^```json\n?/, '')
+    .replace(/\n?```$/, '');
+
+  try {
+    const data = JSON.parse(text) as Omit<DosageCalculatorResult, 'disclaimer'>;
+    return {
+      ...data,
+      disclaimer:
+        'AI-generated dosage guidance for clinical reference only. Always verify against current formulary guidelines and use professional judgment. Not a substitute for clinical pharmacist review.',
+    };
+  } catch {
+    throw new Error(`Failed to parse dosage calculator response: ${text}`);
   }
 }

--- a/apps/api/src/modules/audit/audit.model.ts
+++ b/apps/api/src/modules/audit/audit.model.ts
@@ -24,7 +24,8 @@ export type AuditAction =
   | 'IMMUNIZATION_CREATE'
   | 'IMMUNIZATION_UPDATE'
   | 'IMMUNIZATION_DELETE'
-  | 'IMMUNIZATION_CERTIFICATE';
+  | 'IMMUNIZATION_CERTIFICATE'
+  | 'DOSAGE_CALCULATION';
 
 export interface AuditLog {
   userId?: Types.ObjectId;
@@ -71,6 +72,7 @@ const auditLogSchema = new Schema<AuditLog>(
         'IMMUNIZATION_UPDATE',
         'IMMUNIZATION_DELETE',
         'IMMUNIZATION_CERTIFICATE',
+        'DOSAGE_CALCULATION',
       ],
       index: true,
     },

--- a/apps/web/src/app/encounters/new/page.tsx
+++ b/apps/web/src/app/encounters/new/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/context/AuthContext';
 import { Input, Button, Textarea, Badge } from '@/components/ui';
 import { API_V1 } from '@/lib/api';
 import { formatDate } from '@health-watchers/types';
+import DosageCalculator, { type DosageResult } from '@/components/encounters/DosageCalculator';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -54,7 +55,6 @@ interface AiResponse {
   differentials: AiDifferential[];
   urgency: 'routine' | 'urgent' | 'emergency';
   disclaimer: string;
-}
 }
 
 // ─── ICD-10 local mini-list (fallback when no API) ────────────────────────────
@@ -132,11 +132,49 @@ export default function NewEncounterPage() {
   const [dxQuery, setDxQuery] = useState('');
   const [diagnoses, setDiagnoses] = useState<DiagnosisEntry[]>([]);
 
+  // Prescriptions
+  interface PrescriptionRow {
+    id: string;
+    drugName: string;
+    dosage: string;
+    frequency: string;
+    route: string;
+    notes: string;
+  }
+  const [prescriptions, setPrescriptions] = useState<PrescriptionRow[]>([]);
+  const newRxRow = (): PrescriptionRow => ({
+    id: crypto.randomUUID(),
+    drugName: '',
+    dosage: '',
+    frequency: '',
+    route: '',
+    notes: '',
+  });
+  const addRxRow = () => setPrescriptions((p) => [...p, newRxRow()]);
+  const removeRxRow = (id: string) => setPrescriptions((p) => p.filter((r) => r.id !== id));
+  const updateRxRow = (id: string, field: keyof PrescriptionRow, value: string) =>
+    setPrescriptions((p) => p.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+  const applyDosageResult = (id: string, result: DosageResult) =>
+    setPrescriptions((p) =>
+      p.map((r) =>
+        r.id === id
+          ? {
+              ...r,
+              dosage: result.recommendedDose,
+              frequency: result.frequency,
+              route: result.route,
+            }
+          : r
+      )
+    );
+
   // Submission
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
-  const [patientAllergies, setPatientAllergies] = useState<Array<{ _id: string; allergen: string; severity: string; reaction: string }>>([]);
+  const [patientAllergies, setPatientAllergies] = useState<
+    Array<{ _id: string; allergen: string; severity: string; reaction: string }>
+  >([]);
 
   // Templates
   const [templates, setTemplates] = useState<EncounterTemplate[]>([]);
@@ -145,8 +183,10 @@ export default function NewEncounterPage() {
 
   useEffect(() => {
     fetch(`${API_V1}/encounter-templates`)
-      .then(r => r.ok ? r.json() : null)
-      .then(d => { if (d?.data) setTemplates(d.data); })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.data) setTemplates(d.data);
+      })
       .catch(() => {});
   }, []);
 
@@ -357,16 +397,24 @@ export default function NewEncounterPage() {
       ...(diagnoses.length > 0 && { diagnosis: diagnoses }),
       ...(Object.keys(vitalSigns).length > 0 && { vitalSigns }),
       ...(followUpDate && { followUpDate: new Date(followUpDate).toISOString() }),
+      ...(prescriptions.filter((r) => r.drugName.trim()).length > 0 && {
+        prescriptions: prescriptions
+          .filter((r) => r.drugName.trim())
+          .map(({ id: _id, ...rest }) => rest),
+      }),
     };
 
     setSubmitting(true);
     setSubmitError('');
     try {
-      const res = await fetch(`${API_V1}/encounters${selectedTemplateId ? `?templateId=${selectedTemplateId}` : ''}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
+      const res = await fetch(
+        `${API_V1}/encounters${selectedTemplateId ? `?templateId=${selectedTemplateId}` : ''}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      );
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.message ?? `Error ${res.status}`);
@@ -438,8 +486,12 @@ export default function NewEncounterPage() {
               </div>
               <button
                 type="button"
-                onClick={() => { setSelectedPatient(null); setPatientQuery(''); setPatientAllergies([]); }}
-                className="text-xs text-primary-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded"
+                onClick={() => {
+                  setSelectedPatient(null);
+                  setPatientQuery('');
+                  setPatientAllergies([]);
+                }}
+                className="text-primary-600 focus-visible:ring-primary-500 rounded text-xs hover:underline focus:outline-none focus-visible:ring-2"
               >
                 Change
               </button>
@@ -513,36 +565,48 @@ export default function NewEncounterPage() {
         {/* ── Template Selector ── */}
         {templates.length > 0 && (
           <section aria-labelledby="section-template">
-            <h2 id="section-template" className="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">
-              Start from Template <span className="font-normal normal-case text-neutral-400">(optional)</span>
+            <h2
+              id="section-template"
+              className="mb-3 text-sm font-semibold tracking-wide text-neutral-500 uppercase"
+            >
+              Start from Template{' '}
+              <span className="font-normal text-neutral-400 normal-case">(optional)</span>
             </h2>
 
             {selectedTemplateId ? (
-              <div className="flex items-center justify-between rounded-lg border border-primary-200 bg-primary-50 px-4 py-3">
+              <div className="border-primary-200 bg-primary-50 flex items-center justify-between rounded-lg border px-4 py-3">
                 <p className="text-sm font-medium text-neutral-900">
-                  {templates.find(t => t._id === selectedTemplateId)?.name}
+                  {templates.find((t) => t._id === selectedTemplateId)?.name}
                 </p>
                 <button
                   type="button"
                   onClick={() => setSelectedTemplateId('')}
-                  className="text-xs text-primary-600 hover:underline focus:outline-none"
+                  className="text-primary-600 text-xs hover:underline focus:outline-none"
                 >
                   Remove
                 </button>
               </div>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                {templates.map(t => (
-                  <div key={t._id} className="rounded-lg border border-neutral-200 bg-white p-3 flex items-start justify-between gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {templates.map((t) => (
+                  <div
+                    key={t._id}
+                    className="flex items-start justify-between gap-2 rounded-lg border border-neutral-200 bg-white p-3"
+                  >
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-neutral-900 truncate">{t.name}</p>
-                      <p className="text-xs text-neutral-400">{t.category}{t.usageCount > 0 ? ` · used ${t.usageCount}×` : ''}</p>
+                      <p className="truncate text-sm font-medium text-neutral-900">{t.name}</p>
+                      <p className="text-xs text-neutral-400">
+                        {t.category}
+                        {t.usageCount > 0 ? ` · used ${t.usageCount}×` : ''}
+                      </p>
                     </div>
-                    <div className="flex gap-1 shrink-0">
+                    <div className="flex shrink-0 gap-1">
                       <button
                         type="button"
-                        onClick={() => setPreviewTemplate(previewTemplate?._id === t._id ? null : t)}
-                        className="text-xs text-neutral-500 hover:text-neutral-800 focus:outline-none px-2 py-1 rounded border border-neutral-200 hover:bg-neutral-50"
+                        onClick={() =>
+                          setPreviewTemplate(previewTemplate?._id === t._id ? null : t)
+                        }
+                        className="rounded border border-neutral-200 px-2 py-1 text-xs text-neutral-500 hover:bg-neutral-50 hover:text-neutral-800 focus:outline-none"
                         aria-expanded={previewTemplate?._id === t._id}
                       >
                         Preview
@@ -550,7 +614,7 @@ export default function NewEncounterPage() {
                       <button
                         type="button"
                         onClick={() => applyTemplate(t)}
-                        className="text-xs text-primary-600 hover:text-primary-800 focus:outline-none px-2 py-1 rounded border border-primary-200 hover:bg-primary-50"
+                        className="text-primary-600 hover:text-primary-800 border-primary-200 hover:bg-primary-50 rounded border px-2 py-1 text-xs focus:outline-none"
                       >
                         Apply
                       </button>
@@ -561,16 +625,21 @@ export default function NewEncounterPage() {
             )}
 
             {previewTemplate && (
-              <div className="mt-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm space-y-2">
+              <div className="mt-3 space-y-2 rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm">
                 <p className="font-semibold text-neutral-800">{previewTemplate.name}</p>
-                {previewTemplate.description && <p className="text-neutral-600">{previewTemplate.description}</p>}
+                {previewTemplate.description && (
+                  <p className="text-neutral-600">{previewTemplate.description}</p>
+                )}
                 {previewTemplate.defaultChiefComplaint && (
-                  <p className="text-neutral-600"><span className="font-medium">Chief complaint:</span> {previewTemplate.defaultChiefComplaint}</p>
+                  <p className="text-neutral-600">
+                    <span className="font-medium">Chief complaint:</span>{' '}
+                    {previewTemplate.defaultChiefComplaint}
+                  </p>
                 )}
                 {previewTemplate.suggestedDiagnoses?.length ? (
                   <p className="text-neutral-600">
                     <span className="font-medium">Diagnoses:</span>{' '}
-                    {previewTemplate.suggestedDiagnoses.map(d => d.code).join(', ')}
+                    {previewTemplate.suggestedDiagnoses.map((d) => d.code).join(', ')}
                   </p>
                 ) : null}
                 {previewTemplate.suggestedTests?.length ? (
@@ -579,11 +648,15 @@ export default function NewEncounterPage() {
                     {previewTemplate.suggestedTests.join(', ')}
                   </p>
                 ) : null}
-                {previewTemplate.notes && <p className="text-neutral-600"><span className="font-medium">Notes:</span> {previewTemplate.notes}</p>}
+                {previewTemplate.notes && (
+                  <p className="text-neutral-600">
+                    <span className="font-medium">Notes:</span> {previewTemplate.notes}
+                  </p>
+                )}
                 <button
                   type="button"
                   onClick={() => applyTemplate(previewTemplate)}
-                  className="mt-1 text-xs font-medium text-primary-600 hover:underline focus:outline-none"
+                  className="text-primary-600 mt-1 text-xs font-medium hover:underline focus:outline-none"
                 >
                   Apply this template →
                 </button>
@@ -594,13 +667,16 @@ export default function NewEncounterPage() {
 
         {/* ── Allergy Alert ── */}
         {patientAllergies.length > 0 && (
-          <div role="alert" aria-live="assertive" className="rounded-lg border border-danger-300 bg-danger-50 px-4 py-3">
-            <p className="text-sm font-semibold text-danger-800 mb-2">⚠ Known Allergies</p>
+          <div
+            role="alert"
+            aria-live="assertive"
+            className="border-danger-300 bg-danger-50 rounded-lg border px-4 py-3"
+          >
+            <p className="text-danger-800 mb-2 text-sm font-semibold">⚠ Known Allergies</p>
             <ul className="space-y-1">
               {patientAllergies.map((a) => (
-                <li key={a._id} className="text-sm text-danger-700">
-                  <span className="font-medium">{a.allergen}</span>
-                  {' '}— {a.severity} · {a.reaction}
+                <li key={a._id} className="text-danger-700 text-sm">
+                  <span className="font-medium">{a.allergen}</span> — {a.severity} · {a.reaction}
                 </li>
               ))}
             </ul>
@@ -683,7 +759,7 @@ export default function NewEncounterPage() {
                             {diff.icdCode}
                           </span>
                         </div>
-                        <p className="mt-1 text-xs text-neutral-600 leading-relaxed">
+                        <p className="mt-1 text-xs leading-relaxed text-neutral-600">
                           {diff.reasoning}
                         </p>
                         {diff.recommendedTests?.length > 0 && (
@@ -716,7 +792,9 @@ export default function NewEncounterPage() {
                           }
                           disabled={diagnoses.some((d) => d.code === diff.icdCode)}
                         >
-                          {diagnoses.some((d) => d.code === diff.icdCode) ? 'Added' : 'Add Diagnosis'}
+                          {diagnoses.some((d) => d.code === diff.icdCode)
+                            ? 'Added'
+                            : 'Add Diagnosis'}
                         </Button>
                       </div>
                     </div>
@@ -724,7 +802,7 @@ export default function NewEncounterPage() {
                 ))}
               </div>
 
-              <p className="mt-4 text-[10px] italic text-neutral-400">{aiSuggestions.disclaimer}</p>
+              <p className="mt-4 text-[10px] text-neutral-400 italic">{aiSuggestions.disclaimer}</p>
             </div>
           )}
         </section>
@@ -943,6 +1021,151 @@ export default function NewEncounterPage() {
                 </ul>
               )}
             </div>
+          )}
+        </section>
+
+        {/* ── Prescriptions ── */}
+        <section aria-labelledby="section-prescriptions">
+          <div className="mb-3 flex items-center justify-between">
+            <h2
+              id="section-prescriptions"
+              className="text-sm font-semibold tracking-wide text-neutral-500 uppercase"
+            >
+              Prescriptions{' '}
+              <span className="font-normal text-neutral-400 normal-case">(optional)</span>
+            </h2>
+            <Button type="button" size="sm" variant="outline" onClick={addRxRow}>
+              + Add medication
+            </Button>
+          </div>
+
+          {prescriptions.length === 0 ? (
+            <p className="rounded-lg border border-dashed border-neutral-200 px-4 py-6 text-center text-sm text-neutral-400">
+              No prescriptions added.{' '}
+              <button
+                type="button"
+                onClick={addRxRow}
+                className="text-primary-600 hover:underline focus:outline-none"
+              >
+                Add one
+              </button>
+            </p>
+          ) : (
+            <ul className="space-y-4">
+              {prescriptions.map((rx) => (
+                <li
+                  key={rx.id}
+                  className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm"
+                >
+                  {/* Drug name row with Calculate Dose button */}
+                  <div className="mb-3 flex items-end gap-2">
+                    <div className="flex-1">
+                      <label className="mb-1 block text-xs font-semibold tracking-wide text-neutral-600 uppercase">
+                        Drug name <span className="text-danger-500">*</span>
+                      </label>
+                      <input
+                        type="text"
+                        value={rx.drugName}
+                        onChange={(e) => updateRxRow(rx.id, 'drugName', e.target.value)}
+                        placeholder="e.g. Amoxicillin"
+                        className="focus:border-primary-400 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm text-neutral-700 outline-none"
+                      />
+                    </div>
+                    <DosageCalculator
+                      drugName={rx.drugName}
+                      patientWeight={
+                        weight
+                          ? parseFloat(
+                              weightUnit === 'lbs'
+                                ? (parseFloat(weight) * 0.453592).toFixed(2)
+                                : weight
+                            )
+                          : undefined
+                      }
+                      patientAge={
+                        fullPatient?.dateOfBirth
+                          ? Math.floor(
+                              (Date.now() - new Date(fullPatient.dateOfBirth).getTime()) /
+                                (1000 * 60 * 60 * 24 * 365.25)
+                            )
+                          : undefined
+                      }
+                      patientSex={
+                        fullPatient?.sex === 'M' || fullPatient?.sex === 'F'
+                          ? fullPatient.sex
+                          : undefined
+                      }
+                      indication={diagnoses[0]?.description}
+                      onApply={(result) => applyDosageResult(rx.id, result)}
+                    />
+                  </div>
+
+                  {/* Dosage / frequency / route */}
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs font-semibold tracking-wide text-neutral-600 uppercase">
+                        Dosage
+                      </span>
+                      <input
+                        type="text"
+                        value={rx.dosage}
+                        onChange={(e) => updateRxRow(rx.id, 'dosage', e.target.value)}
+                        placeholder="e.g. 500 mg"
+                        className="focus:border-primary-400 rounded-md border border-neutral-200 px-3 py-2 text-sm text-neutral-700 outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs font-semibold tracking-wide text-neutral-600 uppercase">
+                        Frequency
+                      </span>
+                      <input
+                        type="text"
+                        value={rx.frequency}
+                        onChange={(e) => updateRxRow(rx.id, 'frequency', e.target.value)}
+                        placeholder="e.g. twice daily"
+                        className="focus:border-primary-400 rounded-md border border-neutral-200 px-3 py-2 text-sm text-neutral-700 outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1">
+                      <span className="text-xs font-semibold tracking-wide text-neutral-600 uppercase">
+                        Route
+                      </span>
+                      <input
+                        type="text"
+                        value={rx.route}
+                        onChange={(e) => updateRxRow(rx.id, 'route', e.target.value)}
+                        placeholder="e.g. oral"
+                        className="focus:border-primary-400 rounded-md border border-neutral-200 px-3 py-2 text-sm text-neutral-700 outline-none"
+                      />
+                    </label>
+                  </div>
+
+                  {/* Notes + remove */}
+                  <div className="mt-3 flex items-start gap-2">
+                    <label className="flex flex-1 flex-col gap-1">
+                      <span className="text-xs font-semibold tracking-wide text-neutral-600 uppercase">
+                        Notes
+                      </span>
+                      <input
+                        type="text"
+                        value={rx.notes}
+                        onChange={(e) => updateRxRow(rx.id, 'notes', e.target.value)}
+                        placeholder="e.g. take with food"
+                        className="focus:border-primary-400 rounded-md border border-neutral-200 px-3 py-2 text-sm text-neutral-700 outline-none"
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => removeRxRow(rx.id)}
+                      className="mt-5 rounded p-1.5 text-neutral-400 hover:bg-red-50 hover:text-red-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                      aria-label={`Remove ${rx.drugName || 'medication'}`}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
           )}
         </section>
 

--- a/apps/web/src/components/encounters/DosageCalculator.tsx
+++ b/apps/web/src/components/encounters/DosageCalculator.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
+import { Spinner } from '@/components/ui/Spinner';
+import { API_V1 } from '@/lib/api';
+
+export interface DosageResult {
+  recommendedDose: string;
+  frequency: string;
+  route: string;
+  maxDailyDose: string;
+  pediatricAdjustment: boolean;
+  renalAdjustment: boolean;
+  warnings: string[];
+  contraindications: string[];
+  disclaimer: string;
+}
+
+interface Props {
+  drugName: string;
+  patientWeight?: number;
+  patientAge?: number;
+  patientSex?: 'M' | 'F';
+  indication?: string;
+  onApply: (result: DosageResult) => void;
+}
+
+export default function DosageCalculator({
+  drugName,
+  patientWeight,
+  patientAge,
+  patientSex,
+  indication,
+  onApply,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<DosageResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Local overrides when patient data is incomplete
+  const [localWeight, setLocalWeight] = useState('');
+  const [localAge, setLocalAge] = useState('');
+  const [localSex, setLocalSex] = useState<'M' | 'F'>('M');
+  const [localIndication, setLocalIndication] = useState('');
+  const [renalFunction, setRenalFunction] = useState<string>('normal');
+  const [hepaticFunction, setHepatic] = useState<string>('normal');
+
+  const effectiveWeight = patientWeight ?? parseFloat(localWeight);
+  const effectiveAge = patientAge ?? parseFloat(localAge);
+  const effectiveSex = patientSex ?? localSex;
+  const effectiveIndication = indication || localIndication;
+
+  const canCalculate =
+    drugName.trim() &&
+    effectiveWeight > 0 &&
+    effectiveAge >= 0 &&
+    effectiveSex &&
+    effectiveIndication.trim();
+
+  const calculate = async () => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch(`${API_V1}/ai/dosage-calculator`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          drugName,
+          patientWeight: effectiveWeight,
+          patientAge: effectiveAge,
+          patientSex: effectiveSex,
+          indication: effectiveIndication,
+          renalFunction: renalFunction !== 'normal' ? renalFunction : undefined,
+          hepaticFunction: hepaticFunction !== 'normal' ? hepaticFunction : undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message ?? 'Calculation failed');
+      setResult(data.data as DosageResult);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApply = () => {
+    if (result) {
+      onApply(result);
+      setOpen(false);
+      setResult(null);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setOpen(true);
+          setResult(null);
+          setError(null);
+        }}
+        disabled={!drugName.trim()}
+        className="border-purple-200 text-purple-700 hover:bg-purple-50 disabled:opacity-40"
+        aria-label={`Calculate dose for ${drugName}`}
+      >
+        <span aria-hidden="true">⚕</span> Calculate Dose
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        title={`Dosage Calculator — ${drugName}`}
+        size="md"
+      >
+        <div className="space-y-4">
+          {/* Missing patient data inputs */}
+          {(!patientWeight || !patientAge || !patientSex || !indication) && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              <p className="mb-2 font-medium">Complete missing patient parameters:</p>
+              <div className="grid grid-cols-2 gap-3">
+                {!patientWeight && (
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs font-medium">Weight (kg)</span>
+                    <input
+                      type="number"
+                      min={0.5}
+                      max={500}
+                      step={0.1}
+                      value={localWeight}
+                      onChange={(e) => setLocalWeight(e.target.value)}
+                      className="rounded border border-amber-300 px-2 py-1 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      placeholder="e.g. 70"
+                    />
+                  </label>
+                )}
+                {!patientAge && (
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs font-medium">Age (years)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      max={150}
+                      value={localAge}
+                      onChange={(e) => setLocalAge(e.target.value)}
+                      className="rounded border border-amber-300 px-2 py-1 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      placeholder="e.g. 35"
+                    />
+                  </label>
+                )}
+                {!patientSex && (
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs font-medium">Sex</span>
+                    <select
+                      value={localSex}
+                      onChange={(e) => setLocalSex(e.target.value as 'M' | 'F')}
+                      className="rounded border border-amber-300 px-2 py-1 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                    >
+                      <option value="M">Male</option>
+                      <option value="F">Female</option>
+                    </select>
+                  </label>
+                )}
+                {!indication && (
+                  <label className="col-span-2 flex flex-col gap-1">
+                    <span className="text-xs font-medium">Indication</span>
+                    <input
+                      type="text"
+                      value={localIndication}
+                      onChange={(e) => setLocalIndication(e.target.value)}
+                      className="rounded border border-amber-300 px-2 py-1 text-sm focus:ring-2 focus:ring-amber-400 focus:outline-none"
+                      placeholder="e.g. community-acquired pneumonia"
+                    />
+                  </label>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Organ function adjustments */}
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-neutral-600">Renal function</span>
+              <select
+                value={renalFunction}
+                onChange={(e) => setRenalFunction(e.target.value)}
+                className="rounded border border-neutral-300 px-2 py-1 text-sm focus:ring-2 focus:ring-purple-400 focus:outline-none"
+              >
+                <option value="normal">Normal</option>
+                <option value="mild_impairment">Mild impairment</option>
+                <option value="moderate_impairment">Moderate impairment</option>
+                <option value="severe_impairment">Severe impairment</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-neutral-600">Hepatic function</span>
+              <select
+                value={hepaticFunction}
+                onChange={(e) => setHepatic(e.target.value)}
+                className="rounded border border-neutral-300 px-2 py-1 text-sm focus:ring-2 focus:ring-purple-400 focus:outline-none"
+              >
+                <option value="normal">Normal</option>
+                <option value="impaired">Impaired</option>
+              </select>
+            </label>
+          </div>
+
+          <Button
+            onClick={calculate}
+            disabled={loading || !canCalculate}
+            loading={loading}
+            className="w-full"
+          >
+            {loading ? 'Calculating…' : 'Calculate'}
+          </Button>
+
+          {error && (
+            <p role="alert" className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+
+          {/* Results */}
+          {result && (
+            <div className="space-y-3">
+              {/* Contraindications — red */}
+              {result.contraindications.length > 0 && (
+                <div className="rounded-md border border-red-300 bg-red-50 p-3" role="alert">
+                  <p className="mb-1 text-sm font-semibold text-red-800">⛔ Contraindications</p>
+                  <ul className="list-disc space-y-0.5 pl-4 text-sm text-red-700">
+                    {result.contraindications.map((c, i) => (
+                      <li key={i}>{c}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Warnings — amber */}
+              {result.warnings.length > 0 && (
+                <div className="rounded-md border border-amber-300 bg-amber-50 p-3" role="alert">
+                  <p className="mb-1 text-sm font-semibold text-amber-800">⚠ Warnings</p>
+                  <ul className="list-disc space-y-0.5 pl-4 text-sm text-amber-700">
+                    {result.warnings.map((w, i) => (
+                      <li key={i}>{w}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Dose details */}
+              <div className="space-y-1.5 rounded-md border border-neutral-200 bg-neutral-50 p-3 text-sm">
+                <Row label="Recommended dose" value={result.recommendedDose} />
+                <Row label="Frequency" value={result.frequency} />
+                <Row label="Route" value={result.route} />
+                <Row label="Max daily dose" value={result.maxDailyDose} />
+                {result.pediatricAdjustment && (
+                  <p className="text-xs font-medium text-blue-700">
+                    ✓ Pediatric weight-based adjustment applied
+                  </p>
+                )}
+                {result.renalAdjustment && (
+                  <p className="text-xs font-medium text-blue-700">
+                    ✓ Renal dose adjustment applied
+                  </p>
+                )}
+              </div>
+
+              {/* Disclaimer */}
+              <p className="text-xs text-neutral-500 italic">{result.disclaimer}</p>
+
+              {/* Confirmation */}
+              <div className="flex gap-3 pt-1">
+                <Button variant="secondary" onClick={() => setResult(null)} className="flex-1">
+                  Recalculate
+                </Button>
+                <Button
+                  onClick={handleApply}
+                  className="flex-1 bg-purple-600 hover:bg-purple-700"
+                  disabled={result.contraindications.length > 0}
+                >
+                  Apply to prescription
+                </Button>
+              </div>
+              {result.contraindications.length > 0 && (
+                <p className="text-center text-xs text-red-600">
+                  Cannot apply — contraindications present. Review before prescribing.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <span className="text-neutral-500">{label}</span>
+      <span className="text-right font-medium text-neutral-900">{value}</span>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "pdfkit": "^0.18.0",
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
+        "prom-client": "15.1.3",
         "qrcode": "^1.5.3",
         "socket.io": "^4.8.1",
         "zod": "^3.22.0"
@@ -197,7 +198,8 @@
         "dotenv": "^16.0.0",
         "express": "^4.18.2",
         "pino": "^9.0.0",
-        "pino-pretty": "^11.0.0"
+        "pino-pretty": "^11.0.0",
+        "prom-client": "15.1.3"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -3207,6 +3209,10 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@health-watchers/anonymize": {
+      "resolved": "packages/anonymize",
+      "link": true
     },
     "node_modules/@health-watchers/config": {
       "resolved": "packages/config",
@@ -10090,6 +10096,16 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -12271,6 +12287,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -13051,6 +13073,973 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/create-jest/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/create-jest/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/create-jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/create-jest/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/create-jest/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -13072,6 +14061,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "license": "ISC"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -13531,6 +14527,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dijkstrajs": {
@@ -14477,6 +15483,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/exit-x": {
@@ -16985,6 +18000,16 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-haste-map": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
@@ -17909,6 +18934,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -20280,6 +21315,33 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
@@ -21036,6 +22098,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -21630,6 +22702,13 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -22458,6 +23537,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/term-size": {
@@ -24127,6 +25215,1231 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/anonymize": {
+      "name": "@health-watchers/anonymize",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "crypto": "^1.0.1"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/@jest/core/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "packages/anonymize/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/anonymize/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/anonymize/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "packages/anonymize/node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/anonymize/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/anonymize/node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/anonymize/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/anonymize/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/anonymize/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/anonymize/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/anonymize/node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/jest-cli/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "packages/anonymize/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "packages/anonymize/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/anonymize/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "packages/anonymize/node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "packages/anonymize/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/anonymize/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "packages/anonymize/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/anonymize/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/anonymize/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/anonymize/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "packages/config": {


### PR DESCRIPTION
## What was implemented

  Backend (apps/api/src/modules/ai/ai.routes.ts)
  
  - Rewrote the file from scratch to eliminate: duplicate generateDifferentialDiagnosis import, duplicate /drug-interactions route (stub replaced by real
  implementation), duplicate /predict-duration, /no-show-risk, /optimize-schedule routes, and broken code fragments that had been appended after export default
  router
  - The /dosage-calculator endpoint was already partially there — it's now clean, validates all inputs, calls calculateDosage() from ai.service, writes an immutable
  DOSAGE_CALCULATION audit log, and increments the metrics counter
  
  Frontend (apps/web/src/app/encounters/new/page.tsx)
  
  - Added DosageCalculator import
  - Added PrescriptionRow interface and full state management (prescriptions, addRxRow, removeRxRow, updateRxRow, applyDosageResult)
  - Added a Prescriptions section between Diagnosis and Follow-up Date: each row has a drug name input with a "Calculate Dose" button next to it, plus
  dosage/frequency/route fields that auto-fill when the doctor confirms the AI result
  - Contraindications block the "Apply to prescription" button in the calculator (red warning shown)
  - Prescriptions included in the encounter submit body
  
  Also fixed
  
  - Stray } after AiResponse interface in the encounter page (pre-existing syntax error)
  - Duplicate scheduleRoutes import and registration in app.ts

closes #418 