### PR TITLE
feat: stellar account federation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -77,6 +77,7 @@ import { mongodbConnectionPoolSize } from './services/metrics.service';
 import scheduleRoutes from './modules/schedules/schedules.routes';
 import cdsRoutes from './modules/cds/cds.controller';
 import { seedBuiltInRules } from './modules/cds/cds-seed';
+import federationRouter from './modules/federation/federation.router';
 
 
 const app = express();
@@ -237,6 +238,10 @@ app.use('/api/v1/patients/:id/immunizations', immunizationRoutes);
 app.use('/api/v1/immunizations/cvx-codes', cvxCodesRouter);
 app.use('/api/v1/schedules', scheduleRoutes);
 app.use('/api/v1/cds', cdsRoutes);
+
+// ── Stellar federation (public, no auth) ──────────────────────────────────────
+app.use('/.well-known', federationRouter);
+app.use('/federation', federationRouter);
 
 setupSwagger(app);
 

--- a/apps/api/src/modules/clinics/clinic.model.ts
+++ b/apps/api/src/modules/clinics/clinic.model.ts
@@ -6,6 +6,7 @@ export interface IClinic {
   phone: string;
   email: string;
   stellarPublicKey?: string;
+  federationAddress?: string;
   subscriptionTier: 'free' | 'basic' | 'premium';
   isActive: boolean;
   createdBy: Types.ObjectId;
@@ -18,6 +19,7 @@ const clinicSchema = new Schema<IClinic>(
     phone: { type: String, required: true, trim: true },
     email: { type: String, required: true, lowercase: true, trim: true },
     stellarPublicKey: { type: String, sparse: true, index: true },
+    federationAddress: { type: String, sparse: true, unique: true, index: true },
     subscriptionTier: { type: String, enum: ['free', 'basic', 'premium'], default: 'free' },
     isActive: { type: Boolean, default: true, index: true },
     createdBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },

--- a/apps/api/src/modules/clinics/clinics.controller.ts
+++ b/apps/api/src/modules/clinics/clinics.controller.ts
@@ -20,12 +20,24 @@ router.post('/', authenticate, requireRoles('SUPER_ADMIN'), async (req: Request,
     // Generate Stellar keypair for the new clinic
     const { publicKey, encryptedSecretKey, iv } = generateClinicKeypair();
 
+    // Generate a unique federation address slug from the clinic name
+    const baseSlug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    let slug = baseSlug;
+    let suffix = 1;
+    while (await ClinicModel.exists({ federationAddress: slug })) {
+      slug = `${baseSlug}-${suffix++}`;
+    }
+
     const clinic = await ClinicModel.create({
       name,
       address,
       phone,
       email,
       stellarPublicKey: publicKey,
+      federationAddress: slug,
       subscriptionTier,
       createdBy: req.user!.userId,
     });

--- a/apps/api/src/modules/federation/federation.router.ts
+++ b/apps/api/src/modules/federation/federation.router.ts
@@ -1,0 +1,70 @@
+import { Router, Request, Response } from 'express';
+import { ClinicModel } from '@api/modules/clinics/clinic.model';
+
+const router = Router();
+
+const DOMAIN = process.env.FEDERATION_DOMAIN || 'healthwatchers.com';
+const STELLAR_NETWORK = process.env.STELLAR_NETWORK || 'testnet';
+const PLATFORM_PUBLIC_KEY = process.env.STELLAR_PLATFORM_PUBLIC_KEY || '';
+const API_URL = process.env.API_URL || 'http://localhost:3001';
+
+const NETWORK_PASSPHRASE =
+  STELLAR_NETWORK === 'mainnet'
+    ? 'Public Global Stellar Network ; September 2015'
+    : 'Test SDF Network ; September 2015';
+
+// GET /.well-known/stellar.toml
+router.get('/stellar.toml', async (_req: Request, res: Response) => {
+  const accounts = PLATFORM_PUBLIC_KEY ? `ACCOUNTS=["${PLATFORM_PUBLIC_KEY}"]` : '';
+
+  const toml = [
+    `NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE}"`,
+    `FEDERATION_SERVER="${API_URL}/federation"`,
+    accounts,
+    '',
+    '[DOCUMENTATION]',
+    `ORG_NAME="Health Watchers"`,
+    `ORG_URL="https://${DOMAIN}"`,
+    `ORG_DESCRIPTION="HIPAA-compliant healthcare management platform"`,
+  ]
+    .filter((line) => line !== undefined)
+    .join('\n');
+
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  return res.send(toml);
+});
+
+// GET /federation?q={address}&type=name
+router.get('/', async (req: Request, res: Response) => {
+  const { q, type } = req.query as { q?: string; type?: string };
+
+  if (!q || type !== 'name') {
+    return res.status(400).json({ detail: 'q and type=name are required' });
+  }
+
+  // Parse address: slug*domain
+  const parts = q.split('*');
+  if (parts.length !== 2 || parts[1] !== DOMAIN) {
+    return res.status(404).json({ detail: 'Not found' });
+  }
+
+  const slug = parts[0].toLowerCase();
+
+  const clinic = await ClinicModel.findOne({ federationAddress: slug, isActive: true })
+    .select('stellarPublicKey federationAddress name')
+    .lean();
+
+  if (!clinic || !clinic.stellarPublicKey) {
+    return res.status(404).json({ detail: 'Not found' });
+  }
+
+  return res.json({
+    stellar_address: `${slug}*${DOMAIN}`,
+    account_id: clinic.stellarPublicKey,
+    memo_type: 'text',
+    memo: clinic.name,
+  });
+});
+
+export default router;

--- a/apps/api/src/modules/federation/federation.test.ts
+++ b/apps/api/src/modules/federation/federation.test.ts
@@ -1,0 +1,82 @@
+import request from 'supertest';
+import express from 'express';
+import federationRouter from './federation.router';
+
+// Mock ClinicModel
+jest.mock('@api/modules/clinics/clinic.model', () => ({
+  ClinicModel: {
+    findOne: jest.fn(),
+  },
+}));
+
+import { ClinicModel } from '@api/modules/clinics/clinic.model';
+
+const app = express();
+app.use('/.well-known', federationRouter);
+app.use('/federation', federationRouter);
+
+const mockFindOne = ClinicModel.findOne as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.FEDERATION_DOMAIN = 'healthwatchers.com';
+});
+
+describe('GET /.well-known/stellar.toml', () => {
+  it('returns TOML with FEDERATION_SERVER and NETWORK_PASSPHRASE', async () => {
+    const res = await request(app).get('/.well-known/stellar.toml');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/plain/);
+    expect(res.text).toContain('FEDERATION_SERVER=');
+    expect(res.text).toContain('NETWORK_PASSPHRASE=');
+    expect(res.text).toContain('[DOCUMENTATION]');
+  });
+
+  it('sets Access-Control-Allow-Origin: *', async () => {
+    const res = await request(app).get('/.well-known/stellar.toml');
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+});
+
+describe('GET /federation', () => {
+  it('returns 400 when q is missing', async () => {
+    const res = await request(app).get('/federation?type=name');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when type is not name', async () => {
+    const res = await request(app).get('/federation?q=lagos-general*healthwatchers.com&type=id');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown domain', async () => {
+    const res = await request(app).get('/federation?q=lagos-general*unknown.com&type=name');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when clinic not found', async () => {
+    mockFindOne.mockReturnValue({ select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }) });
+    const res = await request(app).get('/federation?q=unknown-clinic*healthwatchers.com&type=name');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns correct public key for a known federation address', async () => {
+    const mockClinic = {
+      stellarPublicKey: 'GABC1234567890',
+      federationAddress: 'lagos-general',
+      name: 'Lagos General Hospital',
+    };
+    mockFindOne.mockReturnValue({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(mockClinic) }),
+    });
+
+    const res = await request(app).get(
+      '/federation?q=lagos-general*healthwatchers.com&type=name'
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.stellar_address).toBe('lagos-general*healthwatchers.com');
+    expect(res.body.account_id).toBe('GABC1234567890');
+    expect(res.body.memo).toBe('Lagos General Hospital');
+  });
+});

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -59,11 +59,16 @@ router.get(
 
     try {
       const data = await stellarClient.getBalance(clinic.stellarPublicKey);
+      const domain = process.env.FEDERATION_DOMAIN || 'healthwatchers.com';
       return res.json({
         status: 'success',
         data: {
           publicKey: clinic.stellarPublicKey,
+          federationAddress: clinic.federationAddress
+            ? `${clinic.federationAddress}*${domain}`
+            : null,
           xlmBalance: data.balance,
+          balance: data.balance,
           usdcBalance: data.usdcBalance,
           usdcIssuer: config.stellar.usdcIssuer,
           transactions: data.transactions,

--- a/apps/web/src/app/wallet/WalletClient.tsx
+++ b/apps/web/src/app/wallet/WalletClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { queryKeys } from '@/lib/queryKeys';
@@ -25,6 +25,48 @@ const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
 const IS_TESTNET = NETWORK === 'testnet';
 const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
+function FederationAddressCard({ address }: { address: string }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    import('qrcode').then((QRCode) => {
+      QRCode.toCanvas(canvasRef.current!, address, { width: 160, margin: 1 });
+    });
+  }, [address]);
+
+  const copy = () => {
+    navigator.clipboard.writeText(address).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Federation Address</CardTitle>
+        <Badge variant="default">Stellar</Badge>
+      </CardHeader>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+        <canvas ref={canvasRef} aria-label={`QR code for ${address}`} className="rounded border border-neutral-100" />
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-neutral-500">
+            Patients can send payments using this human-readable address instead of the full public key.
+          </p>
+          <div className="flex items-center gap-2 rounded-lg bg-neutral-50 px-3 py-2 font-mono text-sm font-medium text-neutral-800">
+            {address}
+          </div>
+          <Button variant="outline" onClick={copy} className="w-fit">
+            {copied ? '✓ Copied' : 'Copy Address'}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 interface Transaction {
   id: string;
   type: string;
@@ -40,6 +82,7 @@ interface WalletBalance {
   publicKey: string;
   balance: string;
   xlmBalance?: string;
+  federationAddress?: string | null;
   usdcBalance: string | null;
   usdcIssuer?: string;
   transactions: Transaction[];
@@ -538,6 +581,11 @@ export default function WalletClient() {
               </div>
             </div>
           </Card>
+
+          {/* Federation Address */}
+          {wallet.federationAddress && (
+            <FederationAddressCard address={wallet.federationAddress} />
+          )}
 
           {/* Send Payment Form */}
           {showSendForm && !pendingPayment && (


### PR DESCRIPTION
## What was implemented  

Backend (API)
  
  - clinic.model.ts — added federationAddress field (sparse unique index) to IClinic and schema
  - clinics.controller.ts — auto-generates a URL-safe slug from the clinic name on creation, with a suffix counter to guarantee uniqueness (lagos-general, lagos-general-1, etc.)
  - payments.controller.ts — includes federationAddress (formatted as slug*healthwatchers.com) in the /balance response
  - federation/federation.router.ts — two public endpoints:
    - GET /.well-known/stellar.toml — serves the TOML file with NETWORK_PASSPHRASE, FEDERATION_SERVER, and [DOCUMENTATION]
    - GET /federation?q={address}&type=name — looks up a clinic by slug and returns { stellar_address, account_id, memo_type, memo }
  
  - app.ts — registers both routes
  
  Frontend (Web)
  
  - WalletClient.tsx — added federationAddress to the WalletBalance interface, added a FederationAddressCard component that renders a QR code (via the existing qrcode package) and a copy-to-clipboard
  button, displayed between Account Overview and Send Payment
  
  Tests
  
  - federation.test.ts — 7 passing tests covering TOML content, CORS header, missing params, wrong domain, unknown clinic, and correct public key lookup
closes #423 