### PR TITLE
feat: add Stellar payment escrow for insurance pre-authorization

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -84,6 +84,7 @@ import cdsRoutes from './modules/cds/cds.controller';
 import { seedBuiltInRules } from './modules/cds/cds-seed';
 import onboardingRoutes from './modules/clinics/onboarding.routes';
 import peerReviewsRouter from './modules/peer-reviews/peer-reviews.router';
+import { preAuthRoutes } from './modules/pre-auth/pre-auth.controller';
 import federationRouter from './modules/federation/federation.router';
 
 
@@ -247,6 +248,7 @@ app.use('/api/v1/schedules', scheduleRoutes);
 app.use('/api/v1/patients/:id/immunizations', immunizationRoutes);
 app.use('/api/v1/cds', cdsRoutes);
 app.use('/api/v1/onboarding', onboardingRoutes);
+app.use('/api/v1/pre-auth', paymentLimiter, preAuthRoutes);
 app.use('/api/v1/peer-reviews', peerReviewsRouter);
 
 // ── Stellar federation (public, no auth) ──────────────────────────────────────

--- a/apps/api/src/modules/payments/services/stellar-client.ts
+++ b/apps/api/src/modules/payments/services/stellar-client.ts
@@ -184,6 +184,54 @@ class StellarClient {
   }
 
   /**
+   * Create a claimable balance (escrow) on Stellar
+   * Calls the stellar-service POST /claimable-balance endpoint
+   */
+  async createClaimableBalance(params: {
+    fromPublicKey: string;
+    amount: string;
+    claimantPublicKey: string;
+    claimableUntil: string;
+    memo?: string;
+  }): Promise<{ balanceId: string; txHash?: string; dryRun?: boolean }> {
+    const secret = process.env.STELLAR_SERVICE_SECRET;
+    const response = await this.client.post(
+      '/claimable-balance',
+      params,
+      { headers: { Authorization: `Bearer ${secret}` } }
+    );
+    return response.data;
+  }
+
+  /**
+   * Claim a claimable balance by ID
+   * Calls the stellar-service POST /claimable-balance/:balanceId/claim endpoint
+   */
+  async claimBalance(balanceId: string): Promise<{ txHash: string; dryRun?: boolean }> {
+    const secret = process.env.STELLAR_SERVICE_SECRET;
+    const response = await this.client.post(
+      `/claimable-balance/${encodeURIComponent(balanceId)}/claim`,
+      {},
+      { headers: { Authorization: `Bearer ${secret}` } }
+    );
+    return response.data;
+  }
+
+  /**
+   * Reclaim a claimable balance back to the patient
+   * Calls the stellar-service POST /claimable-balance/:balanceId/reclaim endpoint
+   */
+  async reclaimBalance(balanceId: string): Promise<{ txHash: string; dryRun?: boolean }> {
+    const secret = process.env.STELLAR_SERVICE_SECRET;
+    const response = await this.client.post(
+      `/claimable-balance/${encodeURIComponent(balanceId)}/reclaim`,
+      {},
+      { headers: { Authorization: `Bearer ${secret}` } }
+    );
+    return response.data;
+  }
+
+  /**
    * Check if the stellar-service is healthy
    */
   async healthCheck(): Promise<{ status: string; network: string; dryRun: boolean }> {

--- a/apps/api/src/modules/pre-auth/pre-auth.controller.test.ts
+++ b/apps/api/src/modules/pre-auth/pre-auth.controller.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for /api/v1/pre-auth endpoints
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'abcdefghijklmnopqrstuvwxyz012345';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'abcdefghijklmnopqrstuvwxyz012345';
+process.env.API_PORT = '3001';
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret',
+      refreshTokenSecret: 'test-refresh-secret',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    apiPort: '3001',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellarHorizonUrl: '',
+    stellarSecretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+    fieldEncryptionKey: '',
+  },
+}));
+
+// Stub all unrelated route modules
+jest.mock('@api/modules/auth/auth.controller', () => ({ authRoutes: require('express').Router() }));
+jest.mock('@api/modules/patients/patients.controller', () => ({ patientRoutes: require('express').Router() }));
+jest.mock('@api/modules/encounters/encounters.controller', () => ({ encounterRoutes: require('express').Router() }));
+jest.mock('@api/modules/ai/ai.routes', () => require('express').Router());
+jest.mock('@api/modules/dashboard/dashboard.routes', () => require('express').Router());
+jest.mock('@api/modules/appointments/appointments.controller', () => ({ appointmentRoutes: require('express').Router() }));
+jest.mock('@api/modules/clinics/clinics.controller', () => ({ clinicRoutes: require('express').Router() }));
+jest.mock('@api/config/db', () => ({ connectDB: jest.fn().mockReturnValue(new Promise(() => {})) }));
+jest.mock('@api/docs/swagger', () => ({ setupSwagger: jest.fn() }));
+jest.mock('@api/modules/payments/services/payment-expiration-job', () => ({
+  startPaymentExpirationJob: jest.fn(),
+  stopPaymentExpirationJob: jest.fn(),
+}));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@api/modules/pre-auth/pre-auth.model', () => ({
+  PreAuthModel: {
+    create: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/payments/services/stellar-client', () => ({
+  stellarClient: {
+    verifyTransaction: jest.fn(),
+    findPaths: jest.fn(),
+    getOrderbook: jest.fn(),
+    getFeeEstimate: jest.fn(),
+    createClaimableBalance: jest.fn(),
+    claimBalance: jest.fn(),
+    reclaimBalance: jest.fn(),
+  },
+}));
+
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '@api/app';
+import { PreAuthModel } from './pre-auth.model';
+import { stellarClient } from '@api/modules/payments/services/stellar-client';
+
+function makeToken(role = 'CLINIC_ADMIN') {
+  return jwt.sign(
+    { userId: '507f1f77bcf86cd799439011', role, clinicId: 'clinic-abc' },
+    'test-access-secret',
+    { expiresIn: '15m', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+  );
+}
+
+const adminToken = makeToken('CLINIC_ADMIN');
+const doctorToken = makeToken('DOCTOR');
+
+const mockPreAuth = {
+  _id: '507f1f77bcf86cd799439020',
+  patientId: '507f1f77bcf86cd799439030',
+  clinicId: 'clinic-abc',
+  procedureCode: '99213',
+  estimatedAmount: '50.00',
+  insuranceProvider: 'BlueCross',
+  status: 'pending',
+  claimableBalanceId: 'cb_abc123',
+  expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  save: jest.fn().mockResolvedValue(undefined),
+  toObject: jest.fn().mockReturnThis(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── POST /pre-auth ────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/pre-auth', () => {
+  it('creates a pre-auth and claimable balance', async () => {
+    (stellarClient.createClaimableBalance as jest.Mock).mockResolvedValue({ balanceId: 'cb_abc123' });
+    (PreAuthModel.create as jest.Mock).mockResolvedValue(mockPreAuth);
+
+    const res = await request(app)
+      .post('/api/v1/pre-auth')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        patientId: '507f1f77bcf86cd799439030',
+        procedureCode: '99213',
+        estimatedAmount: '50.00',
+        insuranceProvider: 'BlueCross',
+        patientPublicKey: 'GPATIENT123',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe('success');
+    expect(stellarClient.createClaimableBalance).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: '50.00', fromPublicKey: 'GPATIENT123' })
+    );
+  });
+
+  it('returns 502 when stellar service fails', async () => {
+    (stellarClient.createClaimableBalance as jest.Mock).mockRejectedValue(new Error('Horizon down'));
+
+    const res = await request(app)
+      .post('/api/v1/pre-auth')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        patientId: '507f1f77bcf86cd799439030',
+        procedureCode: '99213',
+        estimatedAmount: '50.00',
+        insuranceProvider: 'BlueCross',
+        patientPublicKey: 'GPATIENT123',
+      });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('StellarServiceError');
+  });
+
+  it('returns 400 on missing required fields', async () => {
+    const res = await request(app)
+      .post('/api/v1/pre-auth')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ procedureCode: '99213' }); // missing patientId, estimatedAmount, etc.
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── PUT /pre-auth/:id/approve ─────────────────────────────────────────────────
+
+describe('PUT /api/v1/pre-auth/:id/approve', () => {
+  it('approves a pending pre-auth', async () => {
+    const pa = { ...mockPreAuth, status: 'pending', save: jest.fn() };
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue(pa);
+
+    const res = await request(app)
+      .put(`/api/v1/pre-auth/${mockPreAuth._id}/approve`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ preAuthNumber: 'PA-001' });
+
+    expect(res.status).toBe(200);
+    expect(pa.save).toHaveBeenCalled();
+    expect(pa.status).toBe('approved');
+    expect(pa.preAuthNumber).toBe('PA-001');
+  });
+
+  it('returns 409 when pre-auth is already approved', async () => {
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue({ ...mockPreAuth, status: 'approved' });
+
+    const res = await request(app)
+      .put(`/api/v1/pre-auth/${mockPreAuth._id}/approve`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ preAuthNumber: 'PA-002' });
+
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 403 for non-admin roles', async () => {
+    const res = await request(app)
+      .put(`/api/v1/pre-auth/${mockPreAuth._id}/approve`)
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ preAuthNumber: 'PA-003' });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── POST /pre-auth/:id/claim ──────────────────────────────────────────────────
+
+describe('POST /api/v1/pre-auth/:id/claim', () => {
+  it('claims funds after approval', async () => {
+    const pa = { ...mockPreAuth, status: 'approved', save: jest.fn(), toObject: jest.fn().mockReturnThis() };
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue(pa);
+    (stellarClient.claimBalance as jest.Mock).mockResolvedValue({ txHash: 'tx_claim_abc' });
+
+    const res = await request(app)
+      .post(`/api/v1/pre-auth/${mockPreAuth._id}/claim`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(pa.status).toBe('claimed');
+    expect(stellarClient.claimBalance).toHaveBeenCalledWith('cb_abc123');
+  });
+
+  it('returns 409 when pre-auth is not approved', async () => {
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue({ ...mockPreAuth, status: 'pending' });
+
+    const res = await request(app)
+      .post(`/api/v1/pre-auth/${mockPreAuth._id}/claim`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(409);
+    expect(stellarClient.claimBalance).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /pre-auth/:id/deny ───────────────────────────────────────────────────
+
+describe('POST /api/v1/pre-auth/:id/deny', () => {
+  it('denies and triggers patient reclaim', async () => {
+    const pa = { ...mockPreAuth, status: 'pending', save: jest.fn(), toObject: jest.fn().mockReturnThis() };
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue(pa);
+    (stellarClient.reclaimBalance as jest.Mock).mockResolvedValue({ txHash: 'tx_reclaim_abc' });
+
+    const res = await request(app)
+      .post(`/api/v1/pre-auth/${mockPreAuth._id}/deny`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(pa.status).toBe('denied');
+    expect(stellarClient.reclaimBalance).toHaveBeenCalledWith('cb_abc123');
+  });
+
+  it('returns 409 when pre-auth is already claimed', async () => {
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue({ ...mockPreAuth, status: 'claimed' });
+
+    const res = await request(app)
+      .post(`/api/v1/pre-auth/${mockPreAuth._id}/deny`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(409);
+    expect(stellarClient.reclaimBalance).not.toHaveBeenCalled();
+  });
+});
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+describe('Pre-auth expiry', () => {
+  it('returns 410 when approving an expired pre-auth', async () => {
+    const expired = {
+      ...mockPreAuth,
+      status: 'pending',
+      expiresAt: new Date(Date.now() - 1000), // already expired
+    };
+    (PreAuthModel.findOne as jest.Mock).mockResolvedValue(expired);
+
+    const res = await request(app)
+      .put(`/api/v1/pre-auth/${mockPreAuth._id}/approve`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ preAuthNumber: 'PA-EXP' });
+
+    expect(res.status).toBe(410);
+    expect(res.body.error).toBe('Expired');
+  });
+});

--- a/apps/api/src/modules/pre-auth/pre-auth.controller.ts
+++ b/apps/api/src/modules/pre-auth/pre-auth.controller.ts
@@ -1,0 +1,191 @@
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { PreAuthModel } from './pre-auth.model';
+import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
+import { validateRequest } from '@api/middlewares/validate.middleware';
+import { asyncHandler } from '@api/middlewares/async.handler';
+import { createPreAuthSchema, approvePreAuthSchema } from './pre-auth.validation';
+import { stellarClient } from '@api/modules/payments/services/stellar-client';
+import logger from '@api/utils/logger';
+
+const router = Router();
+router.use(authenticate);
+
+const PRE_AUTH_EXPIRY_DAYS = 30;
+
+// POST /pre-auth — create pre-authorization request and lock funds in escrow
+router.post(
+  '/',
+  validateRequest({ body: createPreAuthSchema }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const { patientId, encounterId, procedureCode, estimatedAmount, insuranceProvider, patientPublicKey } =
+      req.body;
+
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + PRE_AUTH_EXPIRY_DAYS);
+
+    // Create a claimable balance on Stellar:
+    // - claimant (clinic) can claim after approval
+    // - patient can reclaim after expiry
+    let claimableBalanceId: string | undefined;
+    try {
+      const result = await stellarClient.createClaimableBalance({
+        fromPublicKey: patientPublicKey,
+        amount: estimatedAmount,
+        claimantPublicKey: patientPublicKey, // patient reclaims if denied/expired
+        claimableUntil: expiresAt.toISOString(),
+        memo: `PRE-AUTH:${procedureCode}`,
+      });
+      claimableBalanceId = result.balanceId;
+    } catch (err: any) {
+      logger.error({ err, patientId, procedureCode }, 'Failed to create claimable balance for pre-auth');
+      return res.status(502).json({ error: 'StellarServiceError', message: err.message });
+    }
+
+    const preAuth = await PreAuthModel.create({
+      patientId,
+      clinicId,
+      encounterId,
+      procedureCode,
+      estimatedAmount,
+      insuranceProvider,
+      claimableBalanceId,
+      status: 'pending',
+      expiresAt,
+    });
+
+    logger.info({ preAuthId: preAuth._id, claimableBalanceId }, 'Pre-auth created');
+
+    return res.status(201).json({ status: 'success', data: preAuth });
+  })
+);
+
+// GET /pre-auth/:id — get pre-auth status
+router.get(
+  '/:id',
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const preAuth = await PreAuthModel.findOne({ _id: req.params.id, clinicId }).lean();
+    if (!preAuth) {
+      return res.status(404).json({ error: 'NotFound', message: 'Pre-authorization not found' });
+    }
+    return res.json({ status: 'success', data: preAuth });
+  })
+);
+
+// GET /pre-auth — list pending pre-auths for CLINIC_ADMIN
+router.get(
+  '/',
+  requireRoles('CLINIC_ADMIN', 'SUPER_ADMIN'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const status = (req.query.status as string) || 'pending';
+    const preAuths = await PreAuthModel.find({ clinicId, status })
+      .sort({ createdAt: -1 })
+      .lean();
+    return res.json({ status: 'success', data: preAuths });
+  })
+);
+
+// PUT /pre-auth/:id/approve — mark as approved (CLINIC_ADMIN only)
+router.put(
+  '/:id/approve',
+  requireRoles('CLINIC_ADMIN', 'SUPER_ADMIN'),
+  validateRequest({ body: approvePreAuthSchema }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const preAuth = await PreAuthModel.findOne({ _id: req.params.id, clinicId });
+    if (!preAuth) {
+      return res.status(404).json({ error: 'NotFound', message: 'Pre-authorization not found' });
+    }
+    if (preAuth.status !== 'pending') {
+      return res.status(409).json({ error: 'InvalidStatus', message: `Cannot approve a pre-auth with status '${preAuth.status}'` });
+    }
+    if (new Date() > preAuth.expiresAt) {
+      return res.status(410).json({ error: 'Expired', message: 'Pre-authorization has expired' });
+    }
+
+    preAuth.status = 'approved';
+    preAuth.preAuthNumber = req.body.preAuthNumber;
+    preAuth.approvedAt = new Date();
+    await preAuth.save();
+
+    logger.info({ preAuthId: preAuth._id }, 'Pre-auth approved');
+    return res.json({ status: 'success', data: preAuth });
+  })
+);
+
+// POST /pre-auth/:id/claim — clinic claims the escrowed funds after approval
+router.post(
+  '/:id/claim',
+  requireRoles('CLINIC_ADMIN', 'SUPER_ADMIN'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const preAuth = await PreAuthModel.findOne({ _id: req.params.id, clinicId });
+    if (!preAuth) {
+      return res.status(404).json({ error: 'NotFound', message: 'Pre-authorization not found' });
+    }
+    if (preAuth.status !== 'approved') {
+      return res.status(409).json({ error: 'InvalidStatus', message: 'Pre-auth must be approved before claiming' });
+    }
+    if (!preAuth.claimableBalanceId) {
+      return res.status(400).json({ error: 'MissingBalance', message: 'No claimable balance linked to this pre-auth' });
+    }
+    if (new Date() > preAuth.expiresAt) {
+      return res.status(410).json({ error: 'Expired', message: 'Pre-authorization has expired' });
+    }
+
+    let txHash: string;
+    try {
+      const result = await stellarClient.claimBalance(preAuth.claimableBalanceId);
+      txHash = result.txHash;
+    } catch (err: any) {
+      logger.error({ err, preAuthId: preAuth._id }, 'Failed to claim claimable balance');
+      return res.status(502).json({ error: 'StellarServiceError', message: err.message });
+    }
+
+    preAuth.status = 'claimed';
+    preAuth.claimedAt = new Date();
+    await preAuth.save();
+
+    logger.info({ preAuthId: preAuth._id, txHash }, 'Pre-auth funds claimed');
+    return res.json({ status: 'success', data: { ...preAuth.toObject(), txHash } });
+  })
+);
+
+// POST /pre-auth/:id/deny — deny and trigger patient reclaim
+router.post(
+  '/:id/deny',
+  requireRoles('CLINIC_ADMIN', 'SUPER_ADMIN'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const preAuth = await PreAuthModel.findOne({ _id: req.params.id, clinicId });
+    if (!preAuth) {
+      return res.status(404).json({ error: 'NotFound', message: 'Pre-authorization not found' });
+    }
+    if (!['pending', 'approved'].includes(preAuth.status)) {
+      return res.status(409).json({ error: 'InvalidStatus', message: `Cannot deny a pre-auth with status '${preAuth.status}'` });
+    }
+    if (!preAuth.claimableBalanceId) {
+      return res.status(400).json({ error: 'MissingBalance', message: 'No claimable balance linked to this pre-auth' });
+    }
+
+    let txHash: string;
+    try {
+      const result = await stellarClient.reclaimBalance(preAuth.claimableBalanceId);
+      txHash = result.txHash;
+    } catch (err: any) {
+      logger.error({ err, preAuthId: preAuth._id }, 'Failed to reclaim balance on denial');
+      return res.status(502).json({ error: 'StellarServiceError', message: err.message });
+    }
+
+    preAuth.status = 'denied';
+    await preAuth.save();
+
+    logger.info({ preAuthId: preAuth._id, txHash }, 'Pre-auth denied, funds reclaimed to patient');
+    return res.json({ status: 'success', data: { ...preAuth.toObject(), txHash } });
+  })
+);
+
+export { router as preAuthRoutes };

--- a/apps/api/src/modules/pre-auth/pre-auth.model.ts
+++ b/apps/api/src/modules/pre-auth/pre-auth.model.ts
@@ -1,0 +1,44 @@
+import { Schema, model, models } from 'mongoose';
+
+export interface IPreAuth {
+  patientId: Schema.Types.ObjectId;
+  clinicId: Schema.Types.ObjectId;
+  encounterId?: Schema.Types.ObjectId;
+  procedureCode: string; // CPT code
+  estimatedAmount: string;
+  insuranceProvider: string;
+  preAuthNumber?: string; // assigned by insurance on approval
+  status: 'pending' | 'approved' | 'denied' | 'claimed' | 'reclaimed';
+  claimableBalanceId?: string;
+  approvedAt?: Date;
+  claimedAt?: Date;
+  expiresAt: Date; // 30 days from creation
+}
+
+const preAuthSchema = new Schema<IPreAuth>(
+  {
+    patientId: { type: Schema.Types.ObjectId, ref: 'Patient', required: true, index: true },
+    clinicId: { type: Schema.Types.ObjectId, ref: 'Clinic', required: true, index: true },
+    encounterId: { type: Schema.Types.ObjectId, ref: 'Encounter', index: true },
+    procedureCode: { type: String, required: true, trim: true, index: true },
+    estimatedAmount: { type: String, required: true },
+    insuranceProvider: { type: String, required: true, trim: true },
+    preAuthNumber: { type: String, trim: true },
+    status: {
+      type: String,
+      enum: ['pending', 'approved', 'denied', 'claimed', 'reclaimed'],
+      default: 'pending',
+      index: true,
+    },
+    claimableBalanceId: { type: String, index: true },
+    approvedAt: { type: Date },
+    claimedAt: { type: Date },
+    expiresAt: { type: Date, required: true, index: true },
+  },
+  { timestamps: true, versionKey: false }
+);
+
+preAuthSchema.index({ clinicId: 1, status: 1 });
+preAuthSchema.index({ clinicId: 1, createdAt: -1 });
+
+export const PreAuthModel = models.PreAuth || model<IPreAuth>('PreAuth', preAuthSchema);

--- a/apps/api/src/modules/pre-auth/pre-auth.validation.ts
+++ b/apps/api/src/modules/pre-auth/pre-auth.validation.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+const objectIdRegex = /^[a-f\d]{24}$/i;
+
+export const createPreAuthSchema = z.object({
+  patientId: z.string().regex(objectIdRegex, 'Invalid patientId'),
+  encounterId: z.string().regex(objectIdRegex, 'Invalid encounterId').optional(),
+  procedureCode: z.string().min(1, 'procedureCode (CPT) is required'),
+  estimatedAmount: z
+    .string()
+    .regex(/^\d+(\.\d{1,7})?$/, 'estimatedAmount must be a positive numeric string'),
+  insuranceProvider: z.string().min(1, 'insuranceProvider is required'),
+  /** Patient's Stellar public key — funds are locked here as claimable balance */
+  patientPublicKey: z.string().min(1, 'patientPublicKey is required'),
+});
+
+export const approvePreAuthSchema = z.object({
+  preAuthNumber: z.string().min(1, 'preAuthNumber is required'),
+});
+
+export type CreatePreAuthDto = z.infer<typeof createPreAuthSchema>;
+export type ApprovePreAuthDto = z.infer<typeof approvePreAuthSchema>;

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -19,7 +19,14 @@ import {
   issueRefund,
   streamAccountTransactions,
   getNetworkStatus,
+  getHorizonServer,
+  getNetworkPassphrase,
 } from './stellar.js';
+import {
+  createClaimableBalance as buildCreateClaimableBalance,
+  claimClaimableBalance as buildClaimClaimableBalance,
+} from './operations/claimable-balance.js';
+import { Keypair, BASE_FEE, Asset } from '@stellar/stellar-sdk';
 import dotenv from 'dotenv';
 import logger from './logger.js';
 import { stellarConfig } from './config.js';
@@ -282,6 +289,118 @@ app.get('/orderbook', async (req, res) => {
     return res.json({ success: true, data: result });
   } catch (error: any) {
     return res.status(500).json({ error: error.message });
+  }
+});
+
+// ✅ PROTECTED: POST /claimable-balance — create escrow claimable balance for insurance pre-auth
+app.post('/claimable-balance', requireSecret, checkCircuitBreakerMiddleware, async (req, res) => {
+  try {
+    const { fromPublicKey, amount, claimantPublicKey, claimableUntil, memo } = req.body;
+    if (!fromPublicKey || !amount || !claimantPublicKey || !claimableUntil) {
+      return res.status(400).json({ error: 'fromPublicKey, amount, claimantPublicKey, claimableUntil are required' });
+    }
+
+    const server = getHorizonServer();
+    const platformKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
+    const sourceAccount = await server.loadAccount(fromPublicKey);
+    const fee = await server.fetchBaseFee();
+
+    const claimableAfter = new Date(); // claimable immediately
+    const claimableUntilDate = new Date(claimableUntil);
+
+    const tx = buildCreateClaimableBalance({
+      sourceAccount,
+      amount,
+      asset: Asset.native(),
+      claimantPublicKey,
+      claimableAfter,
+      claimableUntil: claimableUntilDate,
+      networkPassphrase: getNetworkPassphrase(),
+      baseFee: String(fee),
+    });
+
+    tx.sign(platformKeypair);
+
+    if (stellarConfig.dryRun) {
+      const balanceId = `dry-run-balance-${Date.now()}`;
+      return res.json({ success: true, balanceId, dryRun: true });
+    }
+
+    const result = await server.submitTransaction(tx);
+    // Extract balance ID from the transaction result
+    const balanceId = (result as any).id ?? `balance-${result.hash}`;
+    recordSuccess();
+    return res.json({ success: true, balanceId, txHash: result.hash });
+  } catch (error: any) {
+    recordFailure();
+    const horizonError = parseHorizonError(error);
+    return res.status(horizonError.statusCode).json(horizonError);
+  }
+});
+
+// ✅ PROTECTED: POST /claimable-balance/:balanceId/claim — clinic claims the escrowed funds
+app.post('/claimable-balance/:balanceId/claim', requireSecret, checkCircuitBreakerMiddleware, async (req, res) => {
+  try {
+    const { balanceId } = req.params;
+    const server = getHorizonServer();
+    const platformKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
+    const claimerAccount = await server.loadAccount(platformKeypair.publicKey());
+    const fee = await server.fetchBaseFee();
+
+    const tx = buildClaimClaimableBalance({
+      claimerAccount,
+      balanceId: decodeURIComponent(balanceId),
+      networkPassphrase: getNetworkPassphrase(),
+      baseFee: String(fee),
+    });
+
+    tx.sign(platformKeypair);
+
+    if (stellarConfig.dryRun) {
+      return res.json({ success: true, txHash: `dry-run-claim-${Date.now()}`, dryRun: true });
+    }
+
+    const result = await server.submitTransaction(tx);
+    recordSuccess();
+    return res.json({ success: true, txHash: result.hash });
+  } catch (error: any) {
+    recordFailure();
+    const horizonError = parseHorizonError(error);
+    return res.status(horizonError.statusCode).json(horizonError);
+  }
+});
+
+// ✅ PROTECTED: POST /claimable-balance/:balanceId/reclaim — patient reclaims after denial
+app.post('/claimable-balance/:balanceId/reclaim', requireSecret, checkCircuitBreakerMiddleware, async (req, res) => {
+  try {
+    const { balanceId } = req.params;
+    const server = getHorizonServer();
+    const platformKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
+    const claimerAccount = await server.loadAccount(platformKeypair.publicKey());
+    const fee = await server.fetchBaseFee();
+
+    // Reclaim uses the same ClaimClaimableBalance operation but signed by the platform
+    // acting on behalf of the patient (or the patient's key if available)
+    const tx = buildClaimClaimableBalance({
+      claimerAccount,
+      balanceId: decodeURIComponent(balanceId),
+      networkPassphrase: getNetworkPassphrase(),
+      baseFee: String(fee),
+    });
+
+    tx.sign(platformKeypair);
+
+    if (stellarConfig.dryRun) {
+      return res.json({ success: true, txHash: `dry-run-reclaim-${Date.now()}`, dryRun: true });
+    }
+
+    const result = await server.submitTransaction(tx);
+    recordSuccess();
+    return res.json({ success: true, txHash: result.hash });
+  } catch (error: any) {
+    recordFailure();
+    const horizonError = parseHorizonError(error);
+    return res.status(horizonError.statusCode).json(horizonError);
   }
 });
 

--- a/apps/web/src/components/encounters/EncounterDetail.tsx
+++ b/apps/web/src/components/encounters/EncounterDetail.tsx
@@ -3,6 +3,8 @@
 import AiSummaryCard from './AiSummaryCard';
 import { SoapNotesView } from './SoapNotesView';
 import type { EncounterRecord } from './EncounterTable';
+import { usePreAuths } from '@/lib/queries/usePreAuth';
+import { PreAuthStatusBadge } from '@/components/pre-auth/PreAuthStatusBadge';
 
 interface EncounterDetailProps {
   encounter: EncounterRecord;
@@ -34,6 +36,8 @@ function formatDate(value?: string) {
 }
 
 export default function EncounterDetail({ encounter, onBack, onEdit }: EncounterDetailProps) {
+  const { data: preAuths = [] } = usePreAuths('pending');
+  const encounterPreAuths = preAuths.filter((pa) => pa.encounterId === encounter.id);
   return (
     <section className="space-y-4 rounded-xl bg-white p-5 shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -138,6 +142,28 @@ export default function EncounterDetail({ encounter, onBack, onEdit }: Encounter
             </h3>
             <p className="mt-2 text-gray-900">{formatDate(encounter.followUpDate)}</p>
           </article>
+
+          {encounterPreAuths.length > 0 && (
+            <article className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+              <h3 className="text-sm font-semibold tracking-wide text-gray-600 uppercase mb-3">
+                Insurance Pre-Authorizations
+              </h3>
+              <ul className="space-y-2">
+                {encounterPreAuths.map((pa) => (
+                  <li key={pa._id} className="rounded-md border border-gray-200 bg-white p-3 space-y-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">CPT: {pa.procedureCode}</span>
+                      <PreAuthStatusBadge status={pa.status} />
+                    </div>
+                    <p className="text-xs text-gray-500">{pa.insuranceProvider} · {pa.estimatedAmount} XLM</p>
+                    {pa.preAuthNumber && (
+                      <p className="text-xs text-gray-500">Pre-auth #: {pa.preAuthNumber}</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          )}
         </div>
       </div>
     </section>

--- a/apps/web/src/components/pre-auth/PreAuthList.tsx
+++ b/apps/web/src/components/pre-auth/PreAuthList.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import { usePreAuths, useApprovePreAuth, useClaimPreAuth, useDenyPreAuth } from '@/lib/queries/usePreAuth';
+import { PreAuthStatusBadge } from './PreAuthStatusBadge';
+
+const STATUS_TABS = ['pending', 'approved', 'denied', 'claimed', 'reclaimed'] as const;
+
+export function PreAuthList() {
+  const [activeStatus, setActiveStatus] = useState<string>('pending');
+  const [approvingId, setApprovingId] = useState<string | null>(null);
+  const [preAuthNumber, setPreAuthNumber] = useState('');
+
+  const { data: preAuths = [], isLoading } = usePreAuths(activeStatus);
+  const approve = useApprovePreAuth();
+  const claim = useClaimPreAuth();
+  const deny = useDenyPreAuth();
+
+  const handleApprove = async (id: string) => {
+    if (!preAuthNumber.trim()) return;
+    await approve.mutateAsync({ id, preAuthNumber });
+    setApprovingId(null);
+    setPreAuthNumber('');
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Insurance Pre-Authorizations</h2>
+
+      {/* Status tabs */}
+      <div className="flex gap-2 border-b">
+        {STATUS_TABS.map((s) => (
+          <button
+            key={s}
+            onClick={() => setActiveStatus(s)}
+            className={`px-3 py-2 text-sm capitalize transition-colors ${
+              activeStatus === s
+                ? 'border-b-2 border-blue-600 font-medium text-blue-600'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="text-sm text-gray-500">Loading...</p>}
+
+      {!isLoading && preAuths.length === 0 && (
+        <p className="text-sm text-gray-500">No {activeStatus} pre-authorizations.</p>
+      )}
+
+      <ul className="divide-y rounded-lg border">
+        {preAuths.map((pa) => (
+          <li key={pa._id} className="p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div>
+                <span className="font-medium text-sm">CPT: {pa.procedureCode}</span>
+                <span className="ml-2 text-xs text-gray-500">{pa.insuranceProvider}</span>
+              </div>
+              <PreAuthStatusBadge status={pa.status} />
+            </div>
+
+            <div className="text-xs text-gray-600 space-y-0.5">
+              <p>Amount: <strong>{pa.estimatedAmount} XLM</strong></p>
+              {pa.preAuthNumber && <p>Pre-auth #: {pa.preAuthNumber}</p>}
+              <p>Expires: {new Date(pa.expiresAt).toLocaleDateString()}</p>
+              {pa.claimableBalanceId && (
+                <p className="truncate">Balance ID: {pa.claimableBalanceId}</p>
+              )}
+            </div>
+
+            {/* Approve flow */}
+            {pa.status === 'pending' && (
+              <div className="flex gap-2 pt-1">
+                {approvingId === pa._id ? (
+                  <>
+                    <input
+                      type="text"
+                      placeholder="Pre-auth number from insurer"
+                      value={preAuthNumber}
+                      onChange={(e) => setPreAuthNumber(e.target.value)}
+                      className="flex-1 rounded border px-2 py-1 text-xs"
+                    />
+                    <button
+                      onClick={() => handleApprove(pa._id)}
+                      disabled={approve.isPending}
+                      className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      onClick={() => setApprovingId(null)}
+                      className="rounded border px-3 py-1 text-xs hover:bg-gray-50"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => setApprovingId(pa._id)}
+                      className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => deny.mutate(pa._id)}
+                      disabled={deny.isPending}
+                      className="rounded border border-red-300 px-3 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50"
+                    >
+                      Deny
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Claim flow */}
+            {pa.status === 'approved' && (
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={() => claim.mutate(pa._id)}
+                  disabled={claim.isPending}
+                  className="rounded bg-green-600 px-3 py-1 text-xs text-white hover:bg-green-700 disabled:opacity-50"
+                >
+                  Claim Funds
+                </button>
+                <button
+                  onClick={() => deny.mutate(pa._id)}
+                  disabled={deny.isPending}
+                  className="rounded border border-red-300 px-3 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50"
+                >
+                  Deny
+                </button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/pre-auth/PreAuthStatusBadge.tsx
+++ b/apps/web/src/components/pre-auth/PreAuthStatusBadge.tsx
@@ -1,0 +1,21 @@
+import type { PreAuth } from '@/lib/queries/usePreAuth';
+
+const statusConfig: Record<
+  PreAuth['status'],
+  { label: string; className: string }
+> = {
+  pending:   { label: 'Pending',   className: 'bg-yellow-100 text-yellow-800' },
+  approved:  { label: 'Approved',  className: 'bg-blue-100 text-blue-800' },
+  denied:    { label: 'Denied',    className: 'bg-red-100 text-red-800' },
+  claimed:   { label: 'Claimed',   className: 'bg-green-100 text-green-800' },
+  reclaimed: { label: 'Reclaimed', className: 'bg-gray-100 text-gray-700' },
+};
+
+export function PreAuthStatusBadge({ status }: { status: PreAuth['status'] }) {
+  const { label, className } = statusConfig[status] ?? statusConfig.pending;
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/lib/queries/usePreAuth.ts
+++ b/apps/web/src/lib/queries/usePreAuth.ts
@@ -1,0 +1,121 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+import { fetchWithAuth } from '@/lib/auth';
+import { API_V1 } from '@/lib/api';
+
+export interface PreAuth {
+  _id: string;
+  patientId: string;
+  clinicId: string;
+  encounterId?: string;
+  procedureCode: string;
+  estimatedAmount: string;
+  insuranceProvider: string;
+  preAuthNumber?: string;
+  status: 'pending' | 'approved' | 'denied' | 'claimed' | 'reclaimed';
+  claimableBalanceId?: string;
+  approvedAt?: string;
+  claimedAt?: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+export function usePreAuths(status = 'pending') {
+  return useQuery<PreAuth[]>({
+    queryKey: queryKeys.preAuth.list(status),
+    queryFn: async () => {
+      const res = await fetchWithAuth(`${API_V1}/pre-auth?status=${status}`);
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      const data = await res.json();
+      return data.data ?? [];
+    },
+  });
+}
+
+export function usePreAuth(id: string | null) {
+  return useQuery<PreAuth>({
+    queryKey: queryKeys.preAuth.detail(id!),
+    queryFn: async () => {
+      const res = await fetchWithAuth(`${API_V1}/pre-auth/${id}`);
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      const data = await res.json();
+      return data.data;
+    },
+    enabled: !!id,
+  });
+}
+
+export function useCreatePreAuth() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: {
+      patientId: string;
+      encounterId?: string;
+      procedureCode: string;
+      estimatedAmount: string;
+      insuranceProvider: string;
+      patientPublicKey: string;
+    }) => {
+      const res = await fetchWithAuth(`${API_V1}/pre-auth`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message ?? `Request failed (${res.status})`);
+      }
+      return (await res.json()).data as PreAuth;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.preAuth.all }),
+  });
+}
+
+export function useApprovePreAuth() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, preAuthNumber }: { id: string; preAuthNumber: string }) => {
+      const res = await fetchWithAuth(`${API_V1}/pre-auth/${id}/approve`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ preAuthNumber }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message ?? `Request failed (${res.status})`);
+      }
+      return (await res.json()).data as PreAuth;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.preAuth.all }),
+  });
+}
+
+export function useClaimPreAuth() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetchWithAuth(`${API_V1}/pre-auth/${id}/claim`, { method: 'POST' });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message ?? `Request failed (${res.status})`);
+      }
+      return (await res.json()).data as PreAuth & { txHash: string };
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.preAuth.all }),
+  });
+}
+
+export function useDenyPreAuth() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetchWithAuth(`${API_V1}/pre-auth/${id}/deny`, { method: 'POST' });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message ?? `Request failed (${res.status})`);
+      }
+      return (await res.json()).data as PreAuth & { txHash: string };
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.preAuth.all }),
+  });
+}

--- a/apps/web/src/lib/queryKeys.ts
+++ b/apps/web/src/lib/queryKeys.ts
@@ -33,4 +33,9 @@ export const queryKeys = {
     list: () => [...queryKeys.invoices.all, 'list'] as const,
     detail: (id: string) => [...queryKeys.invoices.all, 'detail', id] as const,
   },
+  preAuth: {
+    all: ['pre-auth'] as const,
+    list: (status?: string) => [...queryKeys.preAuth.all, 'list', status] as const,
+    detail: (id: string) => [...queryKeys.preAuth.all, 'detail', id] as const,
+  },
 } as const;


### PR DESCRIPTION
- PreAuth model with all required fields (patientId, clinicId, encounterId, procedureCode, estimatedAmount, insuranceProvider, preAuthNumber, status, claimableBalanceId, approvedAt, claimedAt, expiresAt)
- 30-day expiry enforced on approve and claim endpoints
- API routes: POST /pre-auth, GET /pre-auth/:id, GET /pre-auth, PUT /pre-auth/:id/approve, POST /pre-auth/:id/claim, POST /pre-auth/:id/deny
- CLINIC_ADMIN role guard on approve/claim/deny/list endpoints
- StellarClient extended with createClaimableBalance, claimBalance, reclaimBalance
- stellar-service: POST /claimable-balance, /claimable-balance/:id/claim, /claimable-balance/:id/reclaim endpoints using existing SDK operations
- Frontend: usePreAuth query hooks, PreAuthStatusBadge, PreAuthList component with approve/deny/claim actions, pre-auth section on EncounterDetail
- Tests: approve+claim, deny+reclaim, expiry, 502 on Stellar failure, RBAC
closes #439 