### PR TITLE
feat: implement patient age calculation and age-based clinical alerts…

### DIFF
--- a/apps/api/src/modules/encounters/encounters.controller.ts
+++ b/apps/api/src/modules/encounters/encounters.controller.ts
@@ -271,6 +271,21 @@ router.post(
       }
     }
 
+    // Age-based clinical alerts (Issue #396)
+    const ageAlerts: string[] = [];
+    if (req.body.patientId) {
+      const agePatient = await PatientModel.findById(req.body.patientId).select('dateOfBirth').lean();
+      if (agePatient?.dateOfBirth) {
+        const dob = new Date(agePatient.dateOfBirth);
+        const today = new Date();
+        let age = today.getFullYear() - dob.getFullYear();
+        const m = today.getMonth() - dob.getMonth();
+        if (m < 0 || (m === 0 && today.getDate() < dob.getDate())) age--;
+        const ageMonths = (today.getFullYear() - dob.getFullYear()) * 12 + (today.getMonth() - dob.getMonth());
+        if (age < 12) ageAlerts.push(`PEDIATRIC_WEIGHT_DOSING: Patient is ${ageMonths} months old — use weight-based dosing calculations.`);
+        if (age >= 65) ageAlerts.push(`ELDERLY_POLYPHARMACY: Patient is ${age} years old — review for polypharmacy risk and renal dosing adjustments.`)       if (age >= 18 && age < 65 && req.body.prescriptions?.length) ageAlerts.push(`STANDARD_ADULT_DOSING: Verify standard adult dosing for patient age ${age}.`);
+      }
+    }
     const doc = await EncounterModel.create(req.body);
     
     emitToClinic(req.user!.clinicId, 'encounter:created', { encounterId: String(doc._id), patientId: String(doc.patientId) });
@@ -291,6 +306,7 @@ router.post(
       status: 'success',
       data: toEncounterResponse(doc),
       cdsAlerts: cdsAlerts.length > 0 ? cdsAlerts : undefined,
+      ageAlerts: ageAlerts.length > 0 ? ageAlerts : undefined,
     });
   })
 );
@@ -480,6 +496,7 @@ router.post(
       status: 'success',
       data: toEncounterResponse(encounter),
       cdsAlerts: cdsAlerts.length > 0 ? cdsAlerts : undefined,
+      ageAlerts: ageAlerts.length > 0 ? ageAlerts : undefined,
       message: 'Prescription added successfully'
       message: 'Prescription added successfully',
     });

--- a/apps/api/src/modules/patients/models/patient.model.ts
+++ b/apps/api/src/modules/patients/models/patient.model.ts
@@ -104,7 +104,7 @@ const patientSchema = new Schema<Patient>(
     photoUrl: { type: String },
     thumbnailUrl: { type: String },
   },
-  { timestamps: true, versionKey: false }
+  { timestamps: true, versionKey: false, toJSON: { virtuals: true }, toObject: { virtuals: true } }
 );
 
 patientSchema.pre('save', function () {
@@ -132,5 +132,26 @@ patientSchema.post('find', function (docs: Record<string, unknown>[]) {
 });
 patientSchema.post('findOne', decryptDoc);
 patientSchema.post('findOneAndUpdate', decryptDoc);
+
+patientSchema.virtual('age').get(function () {
+  if (!this.dateOfBirth) return null;
+  const dob = new Date(this.dateOfBirth);
+  const today = new Date();
+  let age = today.getFullYear() - dob.getFullYear();
+  const m = today.getMonth() - dob.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < dob.getDate())) age--;
+  return age;
+});
+
+patientSchema.virtual('ageGroup').get(function () {
+  const age = (this as any).age;
+  if (age === null) return null;
+  if (age < 1)  return 'infant';
+  if (age < 3)  return 'toddler';
+  if (age < 12) return 'child';
+  if (age < 18) return 'adolescent';
+  if (age < 65) return 'adult';
+  return 'elderly';
+});
 
 export const PatientModel = models.Patient || model<Patient>('Patient', patientSchema);

--- a/apps/api/src/modules/patients/patients.transformer.ts
+++ b/apps/api/src/modules/patients/patients.transformer.ts
@@ -15,6 +15,9 @@ export interface PatientResponse {
   updatedAt: string;
   photoUrl?: string;
   thumbnailUrl?: string;
+  age?: number | null;
+  ageGroup?: string | null;
+  thumbnailUrl?: string;
 }
 
 export function toPatientResponse(doc: Document & Record<string, any>): PatientResponse {
@@ -33,5 +36,7 @@ export function toPatientResponse(doc: Document & Record<string, any>): PatientR
     updatedAt:     doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : doc.updatedAt,
     photoUrl:      doc.photoUrl,
     thumbnailUrl:  doc.thumbnailUrl,
+    age:           doc.age ?? null,
+    ageGroup:      doc.ageGroup ?? null,
   };
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,3 +46,29 @@ export function formatDate(dateStr: string | undefined): string {
     day: 'numeric',
   });
 }
+
+// ─── Age Calculation Utilities (Issue #396) ──────────────────────────────────
+
+export type AgeGroup = 'infant' | 'toddler' | 'child' | 'adolescent' | 'adult' | 'elderly';
+
+export function calculateAge(dateOfBirth: Date | string): number {
+  const dob = new Date(dateOfBirth);
+  const today = new Date();
+  let age = today.getFullYear() - dob.getFullYear();
+  const monthDiff = today.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < dob.getDate())) age--;
+  return age;
+}
+
+export function calculateAgeInMonths(dateOfBirth: Date | string): number {
+  const dob = new Date(dateOfBirth);
+  const today = new Date();
+  return (today.getFullYear() - dob.getFullYear()) * 12 + (today.getMonth() - dob.getMonth());
+}
+
+export function getAgeGroup(age: number): AgeGroup {
+  if (age < 1)  return 'infant';
+  if (age < 3)  return 'toddler';
+  if (age < 12) return 'child';  if (age < 18) return 'adolescent';  if (age < 65) return 'adult';
+  return 'elderly';
+}


### PR DESCRIPTION
## Summary
Resolves #396

Adds age calculation utilities and age-based clinical alert system across the patient and encounter modules.

## Changes

### packages/types
- `calculateAge(dateOfBirth)` — returns age in years
- `calculateAgeInMonths(dateOfBirth)` — for pediatric patients
- `getAgeGroup(age)` — returns `infant | toddler | child | adolescent | adult | elderly`

### patient.model.ts
- Added `age` virtual field — calculated from `dateOfBirth` at query time
- Added `ageGroup` virtual field — derived from `age`
- Enabled `toJSON/toObject` virtuals on schema

### patients.transformer.ts
- `age` and `ageGroup` now included in `PatientResponse`

### encounters.controller.ts
- On encounter creation, fetches patient `dateOfBirth` and generates `ageAlerts[]`
- Pediatric (< 12): flags weight-based dosing
- Elderly (≥ 65): flags polypharmacy and renal dosing risk
- `ageAlerts` returned alongside existing `cdsAlerts` in the response