### PR TITLE
feat(export): add FHIR R4 export support

### DIFF
--- a/apps/api/src/modules/export/export.routes.ts
+++ b/apps/api/src/modules/export/export.routes.ts
@@ -10,6 +10,7 @@ import {
   buildClinicRecord,
   sendClinicZip,
 } from './export.service';
+import { buildFhirBundle } from './fhir-mapper';
 
 /** Roles considered "authorized staff" for cross-patient access within a clinic */
 const STAFF_ROLES = ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE', 'ASSISTANT'] as const;
@@ -32,8 +33,8 @@ router.get('/patients/:id/export', authenticate, async (req: Request, res: Respo
   if (!Types.ObjectId.isValid(id))
     return res.status(400).json({ error: 'BadRequest', message: 'Invalid patient ID format' });
 
-  if (!['json', 'pdf'].includes(format))
-    return res.status(400).json({ error: 'BadRequest', message: 'format must be "json" or "pdf"' });
+  if (!['json', 'pdf', 'fhir'].includes(format))
+    return res.status(400).json({ error: 'BadRequest', message: 'format must be "json", "pdf", or "fhir"' });
 
   try {
     const record = await buildPatientRecord(id);
@@ -70,9 +71,70 @@ router.get('/patients/:id/export', authenticate, async (req: Request, res: Respo
     ).catch((err) => logger.error({ err }, 'Audit log failed for patient export'));
 
     if (format === 'json') return sendPatientJson(res, record);
+    if (format === 'fhir') {
+      const bundle = buildFhirBundle(record.patient as any, record.encounters as any[]);
+      res.setHeader('Content-Type', 'application/fhir+json');
+      res.setHeader('Content-Disposition', `attachment; filename="patient-${(record.patient as any).systemId}-fhir.json"`);
+      return res.json(bundle);
+    }
     return sendPatientPdf(res, record);
   } catch (err: any) {
     logger.error({ err }, 'Patient export error');
+    return res.status(500).json({ error: 'InternalError', message: 'Export failed' });
+  }
+});
+
+/**
+ * @swagger
+ * /patients/{id}/fhir:
+ *   get:
+ *     summary: Export a patient's complete health record as a FHIR R4 Bundle
+ *     tags: [Export]
+ *     security:
+ *       - bearerAuth: []
+ */
+router.get('/patients/:id/fhir', authenticate, async (req: Request, res: Response) => {
+  const { id } = req.params;
+
+  if (!Types.ObjectId.isValid(id))
+    return res.status(400).json({ error: 'BadRequest', message: 'Invalid patient ID format' });
+
+  try {
+    const record = await buildPatientRecord(id);
+    if (!record) return res.status(404).json({ error: 'NotFound', message: 'Patient not found' });
+
+    const { role, clinicId, userId } = req.user!;
+    const patientClinicId = String((record.patient as any).clinicId);
+
+    const isSelf = role === 'READ_ONLY' && userId === id;
+    const isStaff = (STAFF_ROLES as readonly string[]).includes(role) && patientClinicId === clinicId;
+    const isSuperAdmin = role === 'SUPER_ADMIN';
+
+    if (!isSelf && !isStaff && !isSuperAdmin)
+      return res.status(403).json({ error: 'Forbidden', message: 'Access denied to this patient record' });
+
+    if (isStaff && !isSuperAdmin) {
+      const { hasConsent } = await import('../consent/consent.controller');
+      const consentGranted = await hasConsent(id, clinicId, 'data_sharing');
+      if (!consentGranted) {
+        return res.status(403).json({
+          error: 'ConsentRequired',
+          message: 'Patient has not consented to data sharing. Please obtain consent first.',
+        });
+      }
+    }
+
+    auditLog(
+      { action: 'EXPORT_PATIENT_DATA', resourceType: 'Patient', resourceId: id, userId, clinicId },
+      req
+    ).catch((err) => logger.error({ err }, 'Audit log failed for FHIR export'));
+
+    const bundle = buildFhirBundle(record.patient as any, record.encounters as any[]);
+    res.setHeader('Content-Type', 'application/fhir+json');
+    res.setHeader('Content-Disposition', `attachment; filename="patient-${(record.patient as any).systemId}-fhir.json"`);
+    return res.json(bundle);
+  } catch (err: any) {
+    logger.error({ err }, 'FHIR export error');
     return res.status(500).json({ error: 'InternalError', message: 'Export failed' });
   }
 });

--- a/apps/api/src/modules/export/fhir-mapper.test.ts
+++ b/apps/api/src/modules/export/fhir-mapper.test.ts
@@ -1,0 +1,306 @@
+import {
+  mapPatient,
+  mapEncounter,
+  mapConditions,
+  mapObservations,
+  mapMedicationRequests,
+  buildFhirBundle,
+} from '@api/modules/export/fhir-mapper';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const patientId = '507f1f77bcf86cd799439011';
+
+const basePatient = {
+  _id: patientId,
+  systemId: 'HW-001',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  sex: 'F' as const,
+  dateOfBirth: '1990-06-15',
+  contactNumber: '+1-555-0100',
+  address: '123 Main St, Springfield',
+  clinicId: '507f1f77bcf86cd799439012',
+};
+
+const encounterId = '507f1f77bcf86cd799439013';
+
+const baseEncounter = {
+  _id: encounterId,
+  patientId,
+  clinicId: '507f1f77bcf86cd799439012',
+  chiefComplaint: 'Chest pain',
+  status: 'closed' as const,
+  createdAt: new Date('2024-03-01T10:00:00Z'),
+  diagnosis: [
+    { code: 'I10', description: 'Essential hypertension', isPrimary: true },
+    { code: 'R07.9', description: 'Chest pain, unspecified', isPrimary: false },
+  ],
+  vitalSigns: {
+    bloodPressure: '130/85',
+    heartRate: 78,
+    temperature: 37.2,
+    respiratoryRate: 16,
+    oxygenSaturation: 98,
+    weight: 65,
+    height: 168,
+  },
+  prescriptions: [
+    {
+      drugName: 'Lisinopril',
+      genericName: 'lisinopril',
+      dosage: '10mg',
+      frequency: 'once daily',
+      duration: '30 days',
+      route: 'oral' as const,
+      prescribedBy: '507f1f77bcf86cd799439014',
+      prescribedAt: new Date('2024-03-01T11:00:00Z'),
+      refillsAllowed: 2,
+    },
+  ],
+};
+
+// ─── mapPatient ────────────────────────────────────────────────────────────
+
+describe('mapPatient', () => {
+  it('maps required fields correctly', () => {
+    const result = mapPatient(basePatient);
+    expect(result.resourceType).toBe('Patient');
+    expect(result.id).toBe(patientId);
+    expect(result.identifier[0].value).toBe('HW-001');
+    expect(result.name[0]).toEqual({ use: 'official', family: 'Doe', given: ['Jane'] });
+    expect(result.gender).toBe('female');
+    expect(result.birthDate).toBe('1990-06-15');
+  });
+
+  it('maps sex M -> male, O -> other', () => {
+    expect(mapPatient({ ...basePatient, sex: 'M' }).gender).toBe('male');
+    expect(mapPatient({ ...basePatient, sex: 'O' }).gender).toBe('other');
+  });
+
+  it('includes telecom when contactNumber present', () => {
+    const result = mapPatient(basePatient);
+    expect(result.telecom).toEqual([{ system: 'phone', value: '+1-555-0100', use: 'home' }]);
+  });
+
+  it('includes address when present', () => {
+    const result = mapPatient(basePatient);
+    expect(result.address).toEqual([{ text: '123 Main St, Springfield' }]);
+  });
+
+  it('omits telecom and address when absent', () => {
+    const { contactNumber, address, ...minimal } = basePatient;
+    const result = mapPatient(minimal);
+    expect(result.telecom).toBeUndefined();
+    expect(result.address).toBeUndefined();
+  });
+
+  it('omits birthDate for invalid date', () => {
+    const result = mapPatient({ ...basePatient, dateOfBirth: 'not-a-date' });
+    expect(result.birthDate).toBeUndefined();
+  });
+});
+
+// ─── mapEncounter ──────────────────────────────────────────────────────────
+
+describe('mapEncounter', () => {
+  it('maps required fields', () => {
+    const result = mapEncounter(baseEncounter, patientId);
+    expect(result.resourceType).toBe('Encounter');
+    expect(result.id).toBe(encounterId);
+    expect(result.subject.reference).toBe(`Patient/${patientId}`);
+  });
+
+  it('maps status correctly', () => {
+    expect(mapEncounter({ ...baseEncounter, status: 'closed' }, patientId).status).toBe('finished');
+    expect(mapEncounter({ ...baseEncounter, status: 'open' }, patientId).status).toBe('in-progress');
+    expect(mapEncounter({ ...baseEncounter, status: 'cancelled' }, patientId).status).toBe('cancelled');
+    expect(mapEncounter({ ...baseEncounter, status: 'follow-up' }, patientId).status).toBe('finished');
+    expect(mapEncounter({ ...baseEncounter, status: 'pending_cosignature' }, patientId).status).toBe('in-progress');
+  });
+
+  it('sets reasonCode from chiefComplaint', () => {
+    const result = mapEncounter(baseEncounter, patientId);
+    expect(result.reasonCode?.[0].text).toBe('Chest pain');
+  });
+
+  it('sets period.start from createdAt', () => {
+    const result = mapEncounter(baseEncounter, patientId);
+    expect(result.period?.start).toBe('2024-03-01T10:00:00.000Z');
+  });
+
+  it('uses ambulatory class code', () => {
+    const result = mapEncounter(baseEncounter, patientId);
+    expect(result.class.code).toBe('AMB');
+  });
+});
+
+// ─── mapConditions ─────────────────────────────────────────────────────────
+
+describe('mapConditions', () => {
+  it('returns empty array when no diagnosis', () => {
+    expect(mapConditions({ ...baseEncounter, diagnosis: undefined }, patientId)).toEqual([]);
+    expect(mapConditions({ ...baseEncounter, diagnosis: [] }, patientId)).toEqual([]);
+  });
+
+  it('maps each diagnosis to a Condition resource', () => {
+    const results = mapConditions(baseEncounter, patientId);
+    expect(results).toHaveLength(2);
+    expect(results[0].resourceType).toBe('Condition');
+    expect(results[0].code.coding?.[0].code).toBe('I10');
+    expect(results[0].code.text).toBe('Essential hypertension');
+    expect(results[0].subject.reference).toBe(`Patient/${patientId}`);
+    expect(results[0].encounter.reference).toBe(`Encounter/${encounterId}`);
+  });
+
+  it('uses ICD-10 coding system', () => {
+    const results = mapConditions(baseEncounter, patientId);
+    expect(results[0].code.coding?.[0].system).toBe('http://hl7.org/fhir/sid/icd-10');
+  });
+
+  it('sets encounter-diagnosis category', () => {
+    const results = mapConditions(baseEncounter, patientId);
+    expect(results[0].category[0].coding?.[0].code).toBe('encounter-diagnosis');
+  });
+});
+
+// ─── mapObservations ───────────────────────────────────────────────────────
+
+describe('mapObservations', () => {
+  it('returns empty array when no vitalSigns', () => {
+    expect(mapObservations({ ...baseEncounter, vitalSigns: undefined }, patientId)).toEqual([]);
+    expect(mapObservations({ ...baseEncounter, vitalSigns: {} }, patientId)).toEqual([]);
+  });
+
+  it('maps blood pressure as a panel with two components', () => {
+    const results = mapObservations(baseEncounter, patientId);
+    const bp = results.find((o) => o.id === `${encounterId}-bp`);
+    expect(bp).toBeDefined();
+    expect(bp!.component).toHaveLength(2);
+    expect(bp!.component![0].valueQuantity?.value).toBe(130);
+    expect(bp!.component![1].valueQuantity?.value).toBe(85);
+  });
+
+  it('maps scalar vitals with correct LOINC codes', () => {
+    const results = mapObservations(baseEncounter, patientId);
+    const hr = results.find((o) => o.id === `${encounterId}-heartRate`);
+    expect(hr).toBeDefined();
+    expect(hr!.code.coding?.[0].code).toBe('8867-4');
+    expect(hr!.valueQuantity?.value).toBe(78);
+    expect(hr!.valueQuantity?.unit).toBe('beats/min');
+  });
+
+  it('maps all 6 scalar vital types', () => {
+    const results = mapObservations(baseEncounter, patientId);
+    const ids = results.map((o) => o.id);
+    expect(ids).toContain(`${encounterId}-heartRate`);
+    expect(ids).toContain(`${encounterId}-temperature`);
+    expect(ids).toContain(`${encounterId}-respiratoryRate`);
+    expect(ids).toContain(`${encounterId}-oxygenSaturation`);
+    expect(ids).toContain(`${encounterId}-weight`);
+    expect(ids).toContain(`${encounterId}-height`);
+  });
+
+  it('sets subject and encounter references', () => {
+    const results = mapObservations(baseEncounter, patientId);
+    for (const obs of results) {
+      expect(obs.subject.reference).toBe(`Patient/${patientId}`);
+      expect(obs.encounter.reference).toBe(`Encounter/${encounterId}`);
+    }
+  });
+
+  it('sets status to final', () => {
+    const results = mapObservations(baseEncounter, patientId);
+    for (const obs of results) {
+      expect(obs.status).toBe('final');
+    }
+  });
+});
+
+// ─── mapMedicationRequests ─────────────────────────────────────────────────
+
+describe('mapMedicationRequests', () => {
+  it('returns empty array when no prescriptions', () => {
+    expect(mapMedicationRequests({ ...baseEncounter, prescriptions: undefined }, patientId)).toEqual([]);
+    expect(mapMedicationRequests({ ...baseEncounter, prescriptions: [] }, patientId)).toEqual([]);
+  });
+
+  it('maps prescription to MedicationRequest', () => {
+    const results = mapMedicationRequests(baseEncounter, patientId);
+    expect(results).toHaveLength(1);
+    const rx = results[0];
+    expect(rx.resourceType).toBe('MedicationRequest');
+    expect(rx.intent).toBe('order');
+    expect(rx.status).toBe('active');
+    expect(rx.medicationCodeableConcept.text).toBe('Lisinopril (lisinopril)');
+    expect(rx.subject.reference).toBe(`Patient/${patientId}`);
+    expect(rx.encounter.reference).toBe(`Encounter/${encounterId}`);
+  });
+
+  it('sets dosage instruction text', () => {
+    const results = mapMedicationRequests(baseEncounter, patientId);
+    expect(results[0].dosageInstruction?.[0].text).toBe('10mg once daily for 30 days');
+  });
+
+  it('maps oral route to SNOMED code', () => {
+    const results = mapMedicationRequests(baseEncounter, patientId);
+    const route = results[0].dosageInstruction?.[0].route;
+    expect(route?.coding?.[0].code).toBe('26643006');
+  });
+
+  it('sets dispenseRequest.numberOfRepeatsAllowed', () => {
+    const results = mapMedicationRequests(baseEncounter, patientId);
+    expect(results[0].dispenseRequest?.numberOfRepeatsAllowed).toBe(2);
+  });
+
+  it('sets authoredOn from prescribedAt', () => {
+    const results = mapMedicationRequests(baseEncounter, patientId);
+    expect(results[0].authoredOn).toBe('2024-03-01T11:00:00.000Z');
+  });
+
+  it('uses drug name only when no genericName', () => {
+    const enc = {
+      ...baseEncounter,
+      prescriptions: [{ ...baseEncounter.prescriptions[0], genericName: undefined }],
+    };
+    const results = mapMedicationRequests(enc, patientId);
+    expect(results[0].medicationCodeableConcept.text).toBe('Lisinopril');
+  });
+});
+
+// ─── buildFhirBundle ───────────────────────────────────────────────────────
+
+describe('buildFhirBundle', () => {
+  it('returns a valid FHIR Bundle', () => {
+    const bundle = buildFhirBundle(basePatient, [baseEncounter]);
+    expect(bundle.resourceType).toBe('Bundle');
+    expect(bundle.type).toBe('collection');
+    expect(bundle.timestamp).toBeDefined();
+  });
+
+  it('includes Patient as first entry', () => {
+    const bundle = buildFhirBundle(basePatient, [baseEncounter]);
+    expect(bundle.entry[0].resource.resourceType).toBe('Patient');
+  });
+
+  it('includes Encounter, Condition, Observation, and MedicationRequest entries', () => {
+    const bundle = buildFhirBundle(basePatient, [baseEncounter]);
+    const types = bundle.entry.map((e) => e.resource.resourceType);
+    expect(types).toContain('Encounter');
+    expect(types).toContain('Condition');
+    expect(types).toContain('Observation');
+    expect(types).toContain('MedicationRequest');
+  });
+
+  it('produces correct entry count for full encounter', () => {
+    const bundle = buildFhirBundle(basePatient, [baseEncounter]);
+    // 1 Patient + 1 Encounter + 2 Conditions + 7 Observations (bp + 6 scalars) + 1 MedicationRequest = 12
+    expect(bundle.entry).toHaveLength(12);
+  });
+
+  it('handles empty encounters array', () => {
+    const bundle = buildFhirBundle(basePatient, []);
+    expect(bundle.entry).toHaveLength(1);
+    expect(bundle.entry[0].resource.resourceType).toBe('Patient');
+  });
+});

--- a/apps/api/src/modules/export/fhir-mapper.ts
+++ b/apps/api/src/modules/export/fhir-mapper.ts
@@ -1,0 +1,328 @@
+/**
+ * FHIR R4 resource mappers for Health Watchers patient data.
+ * Spec: https://hl7.org/fhir/R4/
+ */
+
+import { Patient } from '@api/modules/patients/models/patient.model';
+import { Encounter, VitalSigns, Prescription, Diagnosis } from '@api/modules/encounters/encounter.model';
+
+// ─── FHIR R4 type stubs (minimal, sufficient for our resources) ────────────
+
+export interface FhirCoding {
+  system: string;
+  code: string;
+  display?: string;
+}
+
+export interface FhirCodeableConcept {
+  coding?: FhirCoding[];
+  text?: string;
+}
+
+export interface FhirReference {
+  reference: string;
+}
+
+export interface FhirPatient {
+  resourceType: 'Patient';
+  id: string;
+  identifier: Array<{ system: string; value: string }>;
+  name: Array<{ use: string; family: string; given: string[] }>;
+  gender: 'male' | 'female' | 'other' | 'unknown';
+  birthDate?: string;
+  telecom?: Array<{ system: string; value: string; use: string }>;
+  address?: Array<{ text: string }>;
+}
+
+export interface FhirCondition {
+  resourceType: 'Condition';
+  id: string;
+  subject: FhirReference;
+  encounter: FhirReference;
+  code: FhirCodeableConcept;
+  clinicalStatus: FhirCodeableConcept;
+  category: FhirCodeableConcept[];
+}
+
+export interface FhirEncounter {
+  resourceType: 'Encounter';
+  id: string;
+  status: string;
+  class: FhirCoding;
+  subject: FhirReference;
+  reasonCode?: FhirCodeableConcept[];
+  diagnosis?: Array<{ condition: FhirReference; use?: FhirCodeableConcept }>;
+  period?: { start?: string };
+}
+
+export interface FhirObservation {
+  resourceType: 'Observation';
+  id: string;
+  status: 'final';
+  category: FhirCodeableConcept[];
+  code: FhirCodeableConcept;
+  subject: FhirReference;
+  encounter: FhirReference;
+  valueQuantity?: { value: number; unit: string; system: string; code: string };
+  valueString?: string;
+  component?: Array<{
+    code: FhirCodeableConcept;
+    valueQuantity?: { value: number; unit: string; system: string; code: string };
+    valueString?: string;
+  }>;
+}
+
+export interface FhirMedicationRequest {
+  resourceType: 'MedicationRequest';
+  id: string;
+  status: 'active' | 'completed' | 'stopped';
+  intent: 'order';
+  medicationCodeableConcept: FhirCodeableConcept;
+  subject: FhirReference;
+  encounter: FhirReference;
+  authoredOn?: string;
+  dosageInstruction?: Array<{
+    text: string;
+    route?: FhirCodeableConcept;
+    timing?: { repeat?: { boundsDuration?: { value: number; unit: string; system: string; code: string } } };
+  }>;
+  dispenseRequest?: { numberOfRepeatsAllowed: number };
+}
+
+export type FhirResource = FhirPatient | FhirEncounter | FhirCondition | FhirObservation | FhirMedicationRequest;
+
+export interface FhirBundle {
+  resourceType: 'Bundle';
+  type: 'collection';
+  timestamp: string;
+  entry: Array<{ resource: FhirResource }>;
+}
+
+// ─── Sex mapping ───────────────────────────────────────────────────────────
+
+function toFhirGender(sex: 'M' | 'F' | 'O'): FhirPatient['gender'] {
+  if (sex === 'M') return 'male';
+  if (sex === 'F') return 'female';
+  return 'other';
+}
+
+// ─── Encounter status mapping ──────────────────────────────────────────────
+
+function toFhirEncounterStatus(status: Encounter['status']): string {
+  const map: Record<Encounter['status'], string> = {
+    open: 'in-progress',
+    closed: 'finished',
+    'follow-up': 'finished',
+    cancelled: 'cancelled',
+    pending_cosignature: 'in-progress',
+  };
+  return map[status] ?? 'unknown';
+}
+
+// ─── Route mapping ─────────────────────────────────────────────────────────
+
+function toFhirRoute(route: Prescription['route']): FhirCodeableConcept {
+  const map: Record<Prescription['route'], { code: string; display: string }> = {
+    oral:      { code: '26643006', display: 'Oral route' },
+    topical:   { code: '6064005',  display: 'Topical route' },
+    injection: { code: '47625008', display: 'Intravenous route' },
+    inhaled:   { code: '18679011000001101', display: 'Inhalation route' },
+    other:     { code: '74964007', display: 'Other route' },
+  };
+  const entry = map[route] ?? map.other;
+  return { coding: [{ system: 'http://snomed.info/sct', ...entry }], text: entry.display };
+}
+
+// ─── Vital sign LOINC codes ────────────────────────────────────────────────
+
+const VITAL_LOINC: Record<string, { code: string; display: string; unit: string; ucum: string }> = {
+  heartRate:        { code: '8867-4',  display: 'Heart rate',           unit: 'beats/min', ucum: '/min' },
+  temperature:      { code: '8310-5',  display: 'Body temperature',     unit: '°C',        ucum: 'Cel' },
+  respiratoryRate:  { code: '9279-1',  display: 'Respiratory rate',     unit: 'breaths/min', ucum: '/min' },
+  oxygenSaturation: { code: '59408-5', display: 'Oxygen saturation',    unit: '%',         ucum: '%' },
+  weight:           { code: '29463-7', display: 'Body weight',          unit: 'kg',        ucum: 'kg' },
+  height:           { code: '8302-2',  display: 'Body height',          unit: 'cm',        ucum: 'cm' },
+};
+
+// ─── Mappers ───────────────────────────────────────────────────────────────
+
+export function mapPatient(patient: Record<string, any>): FhirPatient {
+  const resource: FhirPatient = {
+    resourceType: 'Patient',
+    id: String(patient._id ?? patient.systemId),
+    identifier: [{ system: 'urn:health-watchers:patient', value: patient.systemId }],
+    name: [{ use: 'official', family: patient.lastName, given: [patient.firstName] }],
+    gender: toFhirGender(patient.sex),
+  };
+
+  if (patient.dateOfBirth) {
+    const d = new Date(patient.dateOfBirth);
+    if (!isNaN(d.getTime())) resource.birthDate = d.toISOString().split('T')[0];
+  }
+
+  if (patient.contactNumber) {
+    resource.telecom = [{ system: 'phone', value: patient.contactNumber, use: 'home' }];
+  }
+
+  if (patient.address) {
+    resource.address = [{ text: patient.address }];
+  }
+
+  return resource;
+}
+
+export function mapEncounter(enc: Record<string, any>, patientFhirId: string): FhirEncounter {
+  const encId = String(enc._id);
+  const resource: FhirEncounter = {
+    resourceType: 'Encounter',
+    id: encId,
+    status: toFhirEncounterStatus(enc.status),
+    class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB', display: 'ambulatory' },
+    subject: { reference: `Patient/${patientFhirId}` },
+  };
+
+  if (enc.chiefComplaint) {
+    resource.reasonCode = [{ text: enc.chiefComplaint }];
+  }
+
+  if (enc.createdAt) {
+    resource.period = { start: new Date(enc.createdAt).toISOString() };
+  }
+
+  return resource;
+}
+
+export function mapConditions(enc: Record<string, any>, patientFhirId: string): FhirCondition[] {
+  if (!enc.diagnosis?.length) return [];
+  const encId = String(enc._id);
+
+  return (enc.diagnosis as Diagnosis[]).map((dx, i) => ({
+    resourceType: 'Condition',
+    id: `${encId}-condition-${i}`,
+    subject: { reference: `Patient/${patientFhirId}` },
+    encounter: { reference: `Encounter/${encId}` },
+    code: {
+      coding: [{ system: 'http://hl7.org/fhir/sid/icd-10', code: dx.code, display: dx.description }],
+      text: dx.description,
+    },
+    clinicalStatus: {
+      coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active' }],
+    },
+    category: [{
+      coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-category', code: 'encounter-diagnosis' }],
+    }],
+  }));
+}
+
+export function mapObservations(enc: Record<string, any>, patientFhirId: string): FhirObservation[] {
+  const vitals: VitalSigns = enc.vitalSigns ?? {};
+  const encId = String(enc._id);
+  const observations: FhirObservation[] = [];
+
+  // Blood pressure is a panel (component-based)
+  if (vitals.bloodPressure) {
+    const parts = vitals.bloodPressure.split('/');
+    const systolic = parseFloat(parts[0]);
+    const diastolic = parseFloat(parts[1]);
+
+    const obs: FhirObservation = {
+      resourceType: 'Observation',
+      id: `${encId}-bp`,
+      status: 'final',
+      category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] }],
+      code: { coding: [{ system: 'http://loinc.org', code: '55284-4', display: 'Blood pressure systolic and diastolic' }] },
+      subject: { reference: `Patient/${patientFhirId}` },
+      encounter: { reference: `Encounter/${encId}` },
+      component: [],
+    };
+
+    if (!isNaN(systolic)) {
+      obs.component!.push({
+        code: { coding: [{ system: 'http://loinc.org', code: '8480-6', display: 'Systolic blood pressure' }] },
+        valueQuantity: { value: systolic, unit: 'mmHg', system: 'http://unitsofmeasure.org', code: 'mm[Hg]' },
+      });
+    }
+    if (!isNaN(diastolic)) {
+      obs.component!.push({
+        code: { coding: [{ system: 'http://loinc.org', code: '8462-4', display: 'Diastolic blood pressure' }] },
+        valueQuantity: { value: diastolic, unit: 'mmHg', system: 'http://unitsofmeasure.org', code: 'mm[Hg]' },
+      });
+    }
+
+    observations.push(obs);
+  }
+
+  // Scalar vitals
+  for (const [key, meta] of Object.entries(VITAL_LOINC)) {
+    const value = (vitals as any)[key];
+    if (value == null) continue;
+
+    observations.push({
+      resourceType: 'Observation',
+      id: `${encId}-${key}`,
+      status: 'final',
+      category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'vital-signs' }] }],
+      code: { coding: [{ system: 'http://loinc.org', code: meta.code, display: meta.display }] },
+      subject: { reference: `Patient/${patientFhirId}` },
+      encounter: { reference: `Encounter/${encId}` },
+      valueQuantity: { value, unit: meta.unit, system: 'http://unitsofmeasure.org', code: meta.ucum },
+    });
+  }
+
+  return observations;
+}
+
+export function mapMedicationRequests(enc: Record<string, any>, patientFhirId: string): FhirMedicationRequest[] {
+  if (!enc.prescriptions?.length) return [];
+  const encId = String(enc._id);
+
+  return (enc.prescriptions as Prescription[]).map((rx, i) => {
+    const resource: FhirMedicationRequest = {
+      resourceType: 'MedicationRequest',
+      id: `${encId}-rx-${i}`,
+      status: 'active',
+      intent: 'order',
+      medicationCodeableConcept: {
+        text: rx.genericName ? `${rx.drugName} (${rx.genericName})` : rx.drugName,
+      },
+      subject: { reference: `Patient/${patientFhirId}` },
+      encounter: { reference: `Encounter/${encId}` },
+      dosageInstruction: [{
+        text: `${rx.dosage} ${rx.frequency} for ${rx.duration}`,
+        route: toFhirRoute(rx.route),
+      }],
+      dispenseRequest: { numberOfRepeatsAllowed: rx.refillsAllowed ?? 0 },
+    };
+
+    if (rx.prescribedAt) {
+      resource.authoredOn = new Date(rx.prescribedAt).toISOString();
+    }
+
+    return resource;
+  });
+}
+
+// ─── Bundle builder ────────────────────────────────────────────────────────
+
+export function buildFhirBundle(
+  patient: Record<string, any>,
+  encounters: Record<string, any>[]
+): FhirBundle {
+  const patientResource = mapPatient(patient);
+  const patientFhirId = patientResource.id;
+  const entries: FhirResource[] = [patientResource];
+
+  for (const enc of encounters) {
+    entries.push(mapEncounter(enc, patientFhirId));
+    entries.push(...mapConditions(enc, patientFhirId));
+    entries.push(...mapObservations(enc, patientFhirId));
+    entries.push(...mapMedicationRequests(enc, patientFhirId));
+  }
+
+  return {
+    resourceType: 'Bundle',
+    type: 'collection',
+    timestamp: new Date().toISOString(),
+    entry: entries.map((resource) => ({ resource })),
+  };
+}


### PR DESCRIPTION
Closes #598
- Add fhir-mapper.ts with Patient, Encounter, Condition, Observation, and MedicationRequest resource mappers (FHIR R4 compliant)
- Add GET /api/v1/patients/:id/fhir endpoint returning a FHIR Bundle
- Add fhir format option to existing GET /patients/:id/export endpoint
- Add 33 unit tests covering all mapper functions and edge cases

Closes #FHIR-R4-export