### PR TITLE
fix: resolve issues #599, #600, #601

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,65 +10,89 @@ env:
   NODE_VERSION: 18
 
 jobs:
+  # Stage 0: Lint workflow files
+  actionlint:
+    name: Lint GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run actionlint
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint .github/workflows/*.yml
+
   # Stage 1: Quality Checks (parallel)
   quality-checks:
     name: Quality Checks
     runs-on: ubuntu-latest
-    
+    needs: [actionlint]
+
     strategy:
       matrix:
         check: [typecheck, lint, format]
         node-version: [18, 20]
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: TypeScript type checking
         if: matrix.check == 'typecheck'
         run: npm run typecheck
-      
+
       - name: ESLint (zero-warning policy)
         if: matrix.check == 'lint'
         run: npm run lint -- --max-warnings 0
-      
+
       - name: Prettier format check
         if: matrix.check == 'format'
         run: npm run format:check
+
+      - name: Check translations
+        if: matrix.check == 'typecheck'
+        run: npx ts-node scripts/check-translations.ts
+
+      - name: Upload translation report
+        if: matrix.check == 'typecheck' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: translation-report-${{ matrix.node-version }}
+          path: scripts/translation-report.json
+          retention-days: 7
 
   # Stage 2: Security Scanning (parallel)
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: npm audit (fail on high/critical)
         run: npm audit --audit-level=high
-      
+
       - name: Check dependency licenses
         run: |
           npx license-checker --production --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;CC0-1.0;Unlicense" || echo "License check failed - review manually"
         continue-on-error: true
-      
+
       - name: Run Snyk security scan
         uses: snyk/actions/node@master
         continue-on-error: true
@@ -76,9 +100,6 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   # Stage 3: Test Suite
-      - name: Typecheck API
-        run: npm run typecheck --workspace=api
-
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -134,24 +155,24 @@ jobs:
     name: Build Applications
     runs-on: ubuntu-latest
     needs: [quality-checks, security-scan, test]
-    
+
     strategy:
       matrix:
         app: [web, api, stellar-service]
         node-version: [18, 20]
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Setup Turbo cache
         uses: actions/cache@v4
         with:
@@ -159,13 +180,13 @@ jobs:
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
-      
+
       - name: Build ${{ matrix.app }}
         run: npm run build --workspace=${{ matrix.app }}
         env:
           NEXT_PUBLIC_API_URL: http://localhost:3001
           NEXT_PUBLIC_STELLAR_NETWORK: testnet
-      
+
       - name: Upload build artifacts
         if: matrix.node-version == 18
         uses: actions/upload-artifact@v4
@@ -182,18 +203,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'push'
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      
+
       - name: Build Docker images
         run: docker-compose build
         env:
           DOCKER_BUILDKIT: 1
-      
+
       - name: Test Docker Compose
         run: |
           docker-compose up -d
@@ -201,14 +222,14 @@ jobs:
           docker-compose ps
           docker-compose logs
           docker-compose down
-      
+
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Push Docker images
         if: github.ref == 'refs/heads/main'
         run: |
@@ -302,15 +323,15 @@ jobs:
     environment:
       name: staging
       url: https://staging.health-watchers.app
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-      
+
       - name: Deploy to staging
         run: |
           echo "🚀 Deploying to staging environment..."
@@ -320,13 +341,13 @@ jobs:
           echo "  - Vercel: Use vercel-action"
           echo "  - Kubernetes: Use kubectl or helm"
           echo "  - Docker: Use docker-compose or docker stack deploy"
-      
+
       - name: Run smoke tests
         run: |
           echo "🧪 Running smoke tests against staging..."
           echo "Placeholder for smoke tests"
           echo "Example: curl https://staging.health-watchers.app/health"
-  
+
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
@@ -335,15 +356,15 @@ jobs:
     environment:
       name: production
       url: https://health-watchers.app
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-      
+
       - name: Deploy to production
         run: |
           echo "🚀 Deploying to production environment..."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,9 @@ npx lint-staged
 
 # Run secret scanning on staged files
 . "$(dirname "$0")/pre-commit-secrets"
+
+# Run actionlint on staged workflow files
+. "$(dirname "$0")/pre-commit-actionlint"
+
+# Run translation check on staged translation files
+. "$(dirname "$0")/pre-commit-translations"

--- a/.husky/pre-commit-actionlint
+++ b/.husky/pre-commit-actionlint
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Run actionlint on staged workflow files
+STAGED_WORKFLOWS=$(git diff --cached --name-only | grep '^\.github/workflows/.*\.yml$')
+if [ -n "$STAGED_WORKFLOWS" ]; then
+  if command -v actionlint >/dev/null 2>&1; then
+    echo "$STAGED_WORKFLOWS" | xargs actionlint
+  else
+    echo "⚠️  actionlint not found — skipping workflow lint (install: https://github.com/rhysd/actionlint)"
+  fi
+fi

--- a/.husky/pre-commit-translations
+++ b/.husky/pre-commit-translations
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Run translation check when en.json or fr.json are staged
+STAGED=$(git diff --cached --name-only | grep -E 'apps/web/messages/(en|fr)\.json')
+if [ -n "$STAGED" ]; then
+  echo "🌐 Running translation completeness check..."
+  npx ts-node scripts/check-translations.ts
+fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,21 @@ Health Watchers is designed with HIPAA and GDPR compliance in mind. This documen
 - Tokens stored in secure HTTP-only cookies
 - Token revocation on logout
 
+### Access Token Invalidation (Redis-backed)
+
+Access tokens are short-lived (15 min) but can be explicitly invalidated before expiry:
+
+- **Per-token denylist**: Each access token carries a `jti` (UUID v4) claim. On logout or password change, the `jti` is stored in Redis with a TTL equal to the token's remaining lifetime. `verifyAccessToken` rejects any token whose `jti` is in the denylist.
+- **Logout-all**: `POST /api/v1/auth/logout-all` stores a per-user invalidation timestamp (`user-invalidated:{userId}`) in Redis. All access tokens with an `iat` (issued-at) before that timestamp are rejected, effectively invalidating every active session for the user.
+- **Graceful degradation**: If Redis is unavailable, denylist checks are skipped and tokens remain valid until natural expiry. This is acceptable given the 15-minute access token lifetime.
+
+Redis keys used:
+
+| Key pattern | Purpose | TTL |
+|---|---|---|
+| `token-denylist:{jti}` | Single-token revocation | Token's remaining lifetime |
+| `user-invalidated:{userId}` | Logout-all timestamp | 7 days |
+
 ### Role-Based Access Control (RBAC)
 
 Roles and permissions:

--- a/apps/api/src/middlewares/auth.middleware.ts
+++ b/apps/api/src/middlewares/auth.middleware.ts
@@ -1,8 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { verifyAccessToken } from '../modules/auth/token.service';
+import { verifyAccessTokenAsync } from '../modules/auth/token.service';
 import { AppRole } from '../types/express';
 
-export function authenticate(req: Request, res: Response, next: NextFunction) {
+export async function authenticate(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({
@@ -12,7 +12,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction) {
   }
 
   const token = authHeader.slice(7);
-  const payload = verifyAccessToken(token);
+  const payload = await verifyAccessTokenAsync(token);
   if (!payload) {
     return res.status(401).json({ error: 'Unauthorized', message: 'Invalid or expired token' });
   }
@@ -23,6 +23,7 @@ export function authenticate(req: Request, res: Response, next: NextFunction) {
     clinicId: payload.clinicId,
     patientId: payload.patientId,
   };
+  req.tokenJti = payload.jti;
   return next();
 }
 

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
 import { Request, Response, Router } from 'express';
 import { validateRequest } from '@api/middlewares/validate.middleware';
 import { authenticate } from '@api/middlewares/auth.middleware';
@@ -39,6 +40,7 @@ import { totpService } from './totp.service';
 import { sendVerificationEmail, sendWelcomeEmail } from '@api/lib/email.service';
 import { encrypt, decrypt } from '@api/lib/encrypt';
 import { auditLog } from '../audit/audit.service';
+import { addToDenylist, setUserInvalidatedAt } from '@api/services/token-denylist.service';
 
 const router = Router();
 const INVALID = 'Invalid email or password';
@@ -256,17 +258,30 @@ router.post(
  * @swagger
  * /auth/logout:
  *   post:
- *     summary: Invalidate the current refresh token
+ *     summary: Invalidate the current refresh token and access token
  *     tags: [Auth]
  */
 router.post(
   '/logout',
   validateRequest({ body: refreshSchema }),
   async (req: RefreshReq, res: Response) => {
+    // Revoke refresh token
     const decoded = verifyRefreshToken(req.body.refreshToken);
     if (decoded) {
       await RefreshTokenModel.deleteOne({ jti: decoded.jti });
     }
+
+    // Denylist the current access token if present
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      const rawToken = authHeader.slice(7);
+      const tokenData = jwt.decode(rawToken) as { jti?: string; exp?: number } | null;
+      if (tokenData?.jti && tokenData?.exp) {
+        const ttl = tokenData.exp - Math.floor(Date.now() / 1000);
+        await addToDenylist(tokenData.jti, ttl);
+      }
+    }
+
     return res.json({ status: 'success', data: { loggedOut: true } });
   }
 );
@@ -275,13 +290,17 @@ router.post(
  * @swagger
  * /auth/logout-all:
  *   post:
- *     summary: Revoke all refresh tokens for the authenticated user
+ *     summary: Revoke all sessions for the authenticated user
  *     tags: [Auth]
  *     security:
  *       - bearerAuth: []
  */
 router.post('/logout-all', authenticate, async (req: Request, res: Response) => {
-  await RefreshTokenModel.deleteMany({ userId: req.user!.userId });
+  const userId = req.user!.userId;
+  // Revoke all refresh tokens
+  await RefreshTokenModel.deleteMany({ userId });
+  // Store invalidation timestamp — all access tokens issued before now are rejected
+  await setUserInvalidatedAt(userId, Math.floor(Date.now() / 1000));
   return res.json({ status: 'success', data: { loggedOut: true } });
 });
 

--- a/apps/api/src/modules/auth/token.service.test.ts
+++ b/apps/api/src/modules/auth/token.service.test.ts
@@ -21,6 +21,12 @@ jest.mock('@health-watchers/config', () => ({
   },
 }));
 
+// Mock the denylist service (not under test here)
+jest.mock('@api/services/token-denylist.service', () => ({
+  isDenylisted: jest.fn().mockResolvedValue(false),
+  isInvalidatedForUser: jest.fn().mockResolvedValue(false),
+}));
+
 describe('Token Service', () => {
   const mockPayload: TokenPayload = {
     userId: 'user123',
@@ -81,7 +87,8 @@ describe('Token Service', () => {
       const token = signAccessToken(mockPayload);
       const result = verifyAccessToken(token);
 
-      expect(result).toEqual(mockPayload);
+      expect(result).toMatchObject(mockPayload);
+      expect(result?.jti).toBeDefined();
     });
 
     it('should reject a token without issuer claim', () => {

--- a/apps/api/src/modules/auth/token.service.ts
+++ b/apps/api/src/modules/auth/token.service.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { config } from '@health-watchers/config';
+import { isDenylisted, isInvalidatedForUser } from '@api/services/token-denylist.service';
 
 export interface TokenPayload {
   userId: string;
@@ -9,11 +10,19 @@ export interface TokenPayload {
   patientId?: string;
 }
 
+export interface AccessTokenPayload extends TokenPayload {
+  jti: string;
+  iat: number;
+  exp: number;
+}
+
 interface JwtPayload extends TokenPayload {
   iss: string;
   aud: string;
   jti?: string;
   family?: string;
+  iat?: number;
+  exp?: number;
 }
 
 const JWT_ISSUER = config.jwt.issuer;
@@ -24,7 +33,8 @@ export const REFRESH_TOKEN_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 const TEMP_TOKEN_EXPIRY = '5m';
 
 export function signAccessToken(payload: TokenPayload): string {
-  return jwt.sign(payload, config.jwt.accessTokenSecret, {
+  const jti = crypto.randomUUID();
+  return jwt.sign({ ...payload, jti }, config.jwt.accessTokenSecret, {
     expiresIn: ACCESS_TOKEN_EXPIRY,
     issuer: JWT_ISSUER,
     audience: JWT_AUDIENCE,
@@ -56,7 +66,12 @@ export function signTempToken(userId: string): string {
   });
 }
 
-export function verifyAccessToken(token: string): TokenPayload | null {
+/**
+ * Synchronous verify — does NOT check the denylist.
+ * Use only where async is not possible (e.g. socket auth).
+ * Prefer verifyAccessTokenAsync for HTTP request handlers.
+ */
+export function verifyAccessToken(token: string): (TokenPayload & { jti?: string }) | null {
   try {
     const decoded = jwt.verify(token, config.jwt.accessTokenSecret, {
       issuer: JWT_ISSUER,
@@ -67,10 +82,35 @@ export function verifyAccessToken(token: string): TokenPayload | null {
       role: decoded.role,
       clinicId: decoded.clinicId,
       patientId: decoded.patientId,
+      jti: decoded.jti,
     };
-  } catch (error) {
+  } catch {
     return null;
   }
+}
+
+/**
+ * Async verify — checks signature AND the Redis denylist.
+ * Use this in the authenticate middleware.
+ */
+export async function verifyAccessTokenAsync(
+  token: string,
+): Promise<(TokenPayload & { jti?: string }) | null> {
+  const payload = verifyAccessToken(token);
+  if (!payload) return null;
+
+  if (payload.jti) {
+    if (await isDenylisted(payload.jti)) return null;
+    if (
+      await isInvalidatedForUser(
+        payload.userId,
+        (jwt.decode(token) as JwtPayload)?.iat ?? 0,
+      )
+    )
+      return null;
+  }
+
+  return payload;
 }
 
 export interface RefreshTokenPayload extends TokenPayload {
@@ -92,7 +132,7 @@ export function verifyRefreshToken(token: string): RefreshTokenPayload | null {
       jti: decoded.jti,
       family: decoded.family,
     };
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -104,7 +144,7 @@ export function verifyTempToken(token: string): string | null {
       audience: JWT_AUDIENCE,
     }) as { userId: string };
     return decoded.userId;
-  } catch (error) {
+  } catch {
     return null;
   }
 }

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -1,11 +1,13 @@
 import { Request, Response, Router } from 'express';
 import { z } from 'zod';
+import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { authenticate } from '@api/middlewares/auth.middleware';
 import { validateRequest } from '@api/middlewares/validate.middleware';
 import { UserModel } from '../auth/models/user.model';
 import { ClinicModel } from '../clinics/clinic.model';
 import { totpService } from '../auth/totp.service';
+import { addToDenylist } from '@api/services/token-denylist.service';
 
 const updateProfileSchema = z.object({
   fullName: z.string().min(1, 'Full name is required').max(100),
@@ -189,6 +191,17 @@ router.post(
 
     user.password = req.body.newPassword;
     await user.save();
+
+    // Denylist the current access token so it can't be reused after password change
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      const rawToken = authHeader.slice(7);
+      const tokenData = jwt.decode(rawToken) as { jti?: string; exp?: number } | null;
+      if (tokenData?.jti && tokenData?.exp) {
+        const ttl = tokenData.exp - Math.floor(Date.now() / 1000);
+        await addToDenylist(tokenData.jti, ttl);
+      }
+    }
 
     return res.json({
       status: 'success',

--- a/apps/api/src/services/token-denylist.service.test.ts
+++ b/apps/api/src/services/token-denylist.service.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for token-denylist.service.ts
+ */
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+const mockStore: Record<string, unknown> = {};
+
+jest.mock('@api/services/cache.service', () => ({
+  cache: {
+    get: jest.fn(async (key: string) => mockStore[key] ?? null),
+    set: jest.fn(async (key: string, value: unknown, _ttl: number) => {
+      mockStore[key] = value;
+    }),
+  },
+}));
+
+import {
+  addToDenylist,
+  isDenylisted,
+  setUserInvalidatedAt,
+  isInvalidatedForUser,
+} from './token-denylist.service';
+
+beforeEach(() => {
+  Object.keys(mockStore).forEach((k) => delete mockStore[k]);
+  jest.clearAllMocks();
+});
+
+describe('addToDenylist + isDenylisted', () => {
+  it('returns true for a denylisted jti', async () => {
+    await addToDenylist('jti-abc', 900);
+    expect(await isDenylisted('jti-abc')).toBe(true);
+  });
+
+  it('returns false for an unknown jti', async () => {
+    expect(await isDenylisted('jti-unknown')).toBe(false);
+  });
+
+  it('does not store entry when ttl <= 0 (already expired)', async () => {
+    await addToDenylist('jti-expired', 0);
+    expect(await isDenylisted('jti-expired')).toBe(false);
+  });
+
+  it('stores with correct TTL', async () => {
+    const { cache } = await import('@api/services/cache.service');
+    await addToDenylist('jti-ttl', 300);
+    expect(cache.set).toHaveBeenCalledWith('token-denylist:jti-ttl', 1, 300);
+  });
+});
+
+describe('setUserInvalidatedAt + isInvalidatedForUser', () => {
+  it('rejects tokens issued before the invalidation timestamp', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await setUserInvalidatedAt('user-1', now);
+    // Token issued 60 seconds before logout-all
+    expect(await isInvalidatedForUser('user-1', now - 60)).toBe(true);
+  });
+
+  it('accepts tokens issued after the invalidation timestamp', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await setUserInvalidatedAt('user-1', now - 300);
+    // Token issued after the invalidation
+    expect(await isInvalidatedForUser('user-1', now)).toBe(false);
+  });
+
+  it('returns false when no invalidation timestamp is set', async () => {
+    expect(await isInvalidatedForUser('user-no-logout-all', 9999999999)).toBe(false);
+  });
+
+  it('stores invalidation timestamp with 7-day TTL', async () => {
+    const { cache } = await import('@api/services/cache.service');
+    const ts = Math.floor(Date.now() / 1000);
+    await setUserInvalidatedAt('user-2', ts);
+    expect(cache.set).toHaveBeenCalledWith(
+      'user-invalidated:user-2',
+      ts,
+      7 * 24 * 60 * 60,
+    );
+  });
+});

--- a/apps/api/src/services/token-denylist.service.ts
+++ b/apps/api/src/services/token-denylist.service.ts
@@ -1,0 +1,36 @@
+import { cache } from '@api/services/cache.service';
+
+const DENYLIST_PREFIX = 'token-denylist:';
+const USER_INVALIDATED_PREFIX = 'user-invalidated:';
+
+/** Add a jti to the denylist with a TTL matching the token's remaining lifetime. */
+export async function addToDenylist(jti: string, ttlSeconds: number): Promise<void> {
+  if (ttlSeconds > 0) {
+    await cache.set(`${DENYLIST_PREFIX}${jti}`, 1, ttlSeconds);
+  }
+}
+
+/** Returns true if the jti is in the denylist. */
+export async function isDenylisted(jti: string): Promise<boolean> {
+  const val = await cache.get<number>(`${DENYLIST_PREFIX}${jti}`);
+  return val !== null;
+}
+
+/**
+ * Store a per-user invalidation timestamp (logout-all).
+ * All tokens issued before this timestamp will be rejected.
+ * TTL is set to the max access token lifetime (15 min) to auto-expire.
+ */
+export async function setUserInvalidatedAt(userId: string, timestampSecs: number): Promise<void> {
+  // Keep for 7 days (max refresh token lifetime) so re-used refresh tokens are also caught
+  await cache.set(`${USER_INVALIDATED_PREFIX}${userId}`, timestampSecs, 7 * 24 * 60 * 60);
+}
+
+/**
+ * Returns true if the token's iat is before the user's invalidation timestamp.
+ */
+export async function isInvalidatedForUser(userId: string, iat: number): Promise<boolean> {
+  const invalidatedAt = await cache.get<number>(`${USER_INVALIDATED_PREFIX}${userId}`);
+  if (invalidatedAt === null) return false;
+  return iat < invalidatedAt;
+}

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -16,6 +16,7 @@ declare global {
         clinicId: string;
         patientId?: string;
       };
+      tokenJti?: string;
     }
   }
 }

--- a/scripts/check-translations.ts
+++ b/scripts/check-translations.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+const EN_PATH = path.resolve(__dirname, '../apps/web/messages/en.json');
+const FR_PATH = path.resolve(__dirname, '../apps/web/messages/fr.json');
+const REPORT_PATH = path.resolve(__dirname, 'translation-report.json');
+
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === 'object') {
+      Object.assign(result, flatten(v as Record<string, unknown>, key));
+    } else {
+      result[key] = String(v ?? '');
+    }
+  }
+  return result;
+}
+
+const en = flatten(JSON.parse(fs.readFileSync(EN_PATH, 'utf8')));
+const fr = flatten(JSON.parse(fs.readFileSync(FR_PATH, 'utf8')));
+
+const enKeys = new Set(Object.keys(en));
+const frKeys = new Set(Object.keys(fr));
+
+const missing = [...enKeys].filter((k) => !frKeys.has(k));
+const extra = [...frKeys].filter((k) => !enKeys.has(k));
+const empty = [...enKeys].filter((k) => frKeys.has(k) && fr[k] === '');
+
+const report = { missing, extra, empty };
+fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2));
+
+console.log(`Missing keys (in en, not in fr): ${missing.length}`);
+if (missing.length) console.log(missing.map((k) => `  - ${k}`).join('\n'));
+
+console.log(`Extra keys (in fr, not in en): ${extra.length}`);
+if (extra.length) console.log(extra.map((k) => `  + ${k}`).join('\n'));
+
+console.log(`Empty values in fr.json: ${empty.length}`);
+if (empty.length) console.log(empty.map((k) => `  ! ${k}`).join('\n'));
+
+console.log(`\nReport written to ${REPORT_PATH}`);
+
+if (missing.length > 0 || empty.length > 0) {
+  console.error('\n❌ Translation check failed: missing or empty French translations.');
+  process.exit(1);
+}
+console.log('\n✅ All translations are complete.');


### PR DESCRIPTION
## Summary

Fixes three issues in a single PR.

---

### Closes #599 — Fix duplicate YAML keys in CI workflow

- Removed misplaced `Typecheck API` step that was incorrectly nested inside the `security-scan` job
- Fixed file concatenation bug that merged `ci.yml` content with `release.yml`
- Added `actionlint` job as Stage 0 — lints all `.github/workflows/*.yml` files before any other job runs
- Added `.husky/pre-commit-actionlint` hook that runs `actionlint` on staged workflow files
- Validated `release.yml`, `backup.yml`, `changeset-check.yml` — no duplicate keys found

### Closes #601 — Add French translation completeness check to CI

- Added `scripts/check-translations.ts`: recursively flattens `en.json`/`fr.json`, reports missing/extra/empty keys, writes `scripts/translation-report.json`, exits 1 on failures
- Added translation check step + artifact upload to the `quality-checks` CI job
- Added `.husky/pre-commit-translations` hook triggered when `en.json` or `fr.json` are staged
- `fr.json` was already complete — no translation fixes required

### Closes #600 — Redis-backed session invalidation for logout and password change

- **`token.service.ts`**: `signAccessToken` now includes a `jti` (UUID v4) claim; added `verifyAccessTokenAsync` which checks Redis denylist and per-user invalidation timestamp after signature verification
- **`services/token-denylist.service.ts`** (new): `addToDenylist`, `isDenylisted`, `setUserInvalidatedAt`, `isInvalidatedForUser` — backed by the existing `cache.service.ts` Redis client
- **`auth.middleware.ts`**: updated to use `verifyAccessTokenAsync`; attaches `req.tokenJti`
- **`auth.controller.ts`**: `POST /logout` denylists the current access token jti; `POST /logout-all` stores a per-user invalidation timestamp in Redis (all tokens issued before that time are rejected)
- **`users.controller.ts`**: `POST /me/password` denylists the current access token after a successful password change
- **`types/express.d.ts`**: added `tokenJti?: string` to `Request`
- **`services/token-denylist.service.test.ts`** (new): 8 unit tests covering all four denylist functions
- **`SECURITY.md`**: new section documenting the token invalidation strategy and Redis key patterns

## What was tested

- YAML validated with Python's `yaml` loader (duplicate-key detection) — no issues
- Unit tests written for `token-denylist.service.ts`
- Existing `token.service.test.ts` updated to mock the denylist service and fix the `toEqual` assertion for the jti-bearing result