### PR TITLE
feat: add SOAP note XSS sanitization hook and payment idempotency key

### DIFF
--- a/apps/api/src/modules/encounters/__tests__/encounter.xss.test.ts
+++ b/apps/api/src/modules/encounters/__tests__/encounter.xss.test.ts
@@ -1,0 +1,154 @@
+/**
+ * XSS sanitization tests for encounter.model.ts SOAP note pre-hooks.
+ * Uses MongoMemoryServer for a real in-process DB — no external connections.
+ */
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { EncounterModel } from '../encounter.model';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await EncounterModel.deleteMany({});
+});
+
+function baseDoc() {
+  return {
+    patientId: new mongoose.Types.ObjectId(),
+    clinicId: new mongoose.Types.ObjectId(),
+    attendingDoctorId: new mongoose.Types.ObjectId(),
+    chiefComplaint: 'Test complaint',
+  };
+}
+
+// ─── pre('save') ─────────────────────────────────────────────────────────────
+
+describe('pre(save) — SOAP note XSS sanitization', () => {
+  it('strips <script> tags from subjective on save', async () => {
+    const doc = await EncounterModel.create({
+      ...baseDoc(),
+      soapNotes: { subjective: '<script>alert("xss")</script>clean text' },
+    });
+    expect(doc.soapNotes?.subjective).toBe('clean text');
+  });
+
+  it('strips on* event attributes from allowed tags', async () => {
+    const doc = await EncounterModel.create({
+      ...baseDoc(),
+      soapNotes: { subjective: '<p onclick="evil()">text</p>' },
+    });
+    expect(doc.soapNotes?.subjective).toBe('<p>text</p>');
+  });
+
+  it('strips disallowed tags containing javascript: href (inner text preserved)', async () => {
+    const doc = await EncounterModel.create({
+      ...baseDoc(),
+      soapNotes: { subjective: '<a href="javascript:alert(1)">click</a>' },
+    });
+    // <a> is not in ALLOWED_TAGS — tag stripped, inner text kept
+    expect(doc.soapNotes?.subjective).toBe('click');
+  });
+
+  it('preserves safe formatting tags', async () => {
+    const doc = await EncounterModel.create({
+      ...baseDoc(),
+      soapNotes: { subjective: '<p><strong>safe</strong></p>' },
+    });
+    expect(doc.soapNotes?.subjective).toBe('<p><strong>safe</strong></p>');
+  });
+
+  it('sanitizes objective, assessment, and plan fields on save', async () => {
+    const doc = await EncounterModel.create({
+      ...baseDoc(),
+      soapNotes: {
+        objective: '<script>alert(1)</script>objective',
+        assessment: '<img onerror="evil()">assessment',
+        plan: '<p>safe plan</p>',
+      },
+    });
+    expect(doc.soapNotes?.objective).toBe('objective');
+    expect(doc.soapNotes?.assessment).toBe('assessment');
+    expect(doc.soapNotes?.plan).toBe('<p>safe plan</p>');
+  });
+
+  it('leaves soapNotes unchanged when no soapNotes are provided', async () => {
+    const doc = await EncounterModel.create(baseDoc());
+    expect(doc.soapNotes).toBeUndefined();
+  });
+});
+
+// ─── pre('findOneAndUpdate') ──────────────────────────────────────────────────
+
+describe('pre(findOneAndUpdate) — SOAP note XSS sanitization', () => {
+  it('strips <script> from subjective via direct update', async () => {
+    const created = await EncounterModel.create(baseDoc());
+
+    const updated = await EncounterModel.findOneAndUpdate(
+      { _id: created._id },
+      { $set: { soapNotes: { subjective: '<script>alert("xss")</script>clean text' } } },
+      { new: true }
+    );
+
+    expect(updated?.soapNotes?.subjective).toBe('clean text');
+  });
+
+  it('strips on* event attributes via $set.soapNotes', async () => {
+    const created = await EncounterModel.create(baseDoc());
+
+    const updated = await EncounterModel.findOneAndUpdate(
+      { _id: created._id },
+      { $set: { soapNotes: { objective: '<p onclick="evil()">text</p>' } } },
+      { new: true }
+    );
+
+    expect(updated?.soapNotes?.objective).toBe('<p>text</p>');
+  });
+
+  it('strips disallowed tags with javascript: href via $set.soapNotes', async () => {
+    const created = await EncounterModel.create(baseDoc());
+
+    const updated = await EncounterModel.findOneAndUpdate(
+      { _id: created._id },
+      { $set: { soapNotes: { assessment: '<a href="javascript:alert(1)">click</a>' } } },
+      { new: true }
+    );
+
+    expect(updated?.soapNotes?.assessment).toBe('click');
+  });
+
+  it('preserves safe HTML via $set.soapNotes', async () => {
+    const created = await EncounterModel.create(baseDoc());
+
+    const updated = await EncounterModel.findOneAndUpdate(
+      { _id: created._id },
+      { $set: { soapNotes: { plan: '<p><strong>safe</strong></p>' } } },
+      { new: true }
+    );
+
+    expect(updated?.soapNotes?.plan).toBe('<p><strong>safe</strong></p>');
+  });
+
+  it('also sanitizes FREE_TEXT_FIELDS via findOneAndUpdate', async () => {
+    const created = await EncounterModel.create(baseDoc());
+
+    const updated = await EncounterModel.findOneAndUpdate(
+      { _id: created._id },
+      { $set: { chiefComplaint: '<b>headache</b>' } },
+      { new: true }
+    );
+
+    // sanitizeText strips ALL tags from plain-text fields
+    expect(updated?.chiefComplaint).toBe('headache');
+  });
+});

--- a/apps/api/src/modules/encounters/encounter.model.ts
+++ b/apps/api/src/modules/encounters/encounter.model.ts
@@ -208,4 +208,27 @@ encounterSchema.pre('save', function () {
   }
 });
 
+encounterSchema.pre('findOneAndUpdate', function () {
+  const update = this.getUpdate() as any;
+  if (!update) return;
+
+  for (const field of FREE_TEXT_FIELDS) {
+    if (update[field]) update[field] = sanitizeText(update[field]);
+    if (update.$set?.[field]) update.$set[field] = sanitizeText(update.$set[field]);
+  }
+
+  if (update.soapNotes) {
+    for (const field of SOAP_FIELDS) {
+      const val = update.soapNotes[field];
+      if (val) update.soapNotes[field] = sanitizeHtml(val);
+    }
+  }
+  if (update.$set?.soapNotes) {
+    for (const field of SOAP_FIELDS) {
+      const val = update.$set.soapNotes[field];
+      if (val) update.$set.soapNotes[field] = sanitizeHtml(val);
+    }
+  }
+});
+
 export const EncounterModel = models.Encounter || model<Encounter>('Encounter', encounterSchema);

--- a/apps/api/src/modules/payments/__tests__/idempotency.test.ts
+++ b/apps/api/src/modules/payments/__tests__/idempotency.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Idempotency tests for POST /api/v1/payments/intent.
+ *
+ * Uses MongoMemoryServer for a real in-process DB and mocks the stellar-service
+ * client so no real network calls are made.
+ */
+
+// ── Env stubs (before any module that reads process.env) ─────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+process.env.NODE_ENV = 'test';
+process.env.STELLAR_NETWORK = 'testnet';
+
+// ── Module mocks (before imports) ─────────────────────────────────────────────
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    apiPort: '3001',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: 'GPLATFORM' },
+    supportedAssets: ['XLM', 'USDC'],
+    stellarServiceUrl: 'http://stellar-service:3002',
+    geminiApiKey: '',
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+  },
+}));
+
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@api/lib/email.service', () => ({ sendPaymentConfirmationEmail: jest.fn() }));
+jest.mock('@api/realtime/socket', () => ({ emitToClinic: jest.fn() }));
+jest.mock('@api/services/metrics.service', () => ({
+  paymentsInitiatedTotal: { inc: jest.fn() },
+  paymentsConfirmedTotal: { inc: jest.fn() },
+}));
+jest.mock('@api/utils/tracer', () => ({
+  withSpan: jest.fn((_name: string, _attrs: unknown, fn: () => unknown) => fn()),
+}));
+jest.mock('@api/middlewares/fee-budget-check.middleware', () => ({
+  feeBudgetCheck: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('@api/modules/payments/services/stellar-client', () => ({
+  stellarClient: {
+    verifyTransaction: jest.fn(),
+    getBalance: jest.fn(),
+    getFeeEstimate: jest.fn(),
+    findPaths: jest.fn(),
+    getOrderbook: jest.fn(),
+    fundAccount: jest.fn(),
+    createUsdcTrustline: jest.fn(),
+    sponsorFeeBump: jest.fn(),
+  },
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { PaymentRecordModel } from '../models/payment-record.model';
+import { paymentRoutes } from '../payments.controller';
+import { authenticate } from '@api/middlewares/auth.middleware';
+
+// ── Minimal test app ──────────────────────────────────────────────────────────
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/payments', paymentRoutes);
+  return app;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const SECRET = 'test-access-secret-32-chars-long!!';
+const DESTINATION = 'GDESTINATION123456789012345678901234567890123456';
+const CLINIC_A = 'clinic-aaa';
+const CLINIC_B = 'clinic-bbb';
+
+function makeToken(clinicId: string, role = 'CLINIC_ADMIN'): string {
+  return jwt.sign(
+    { userId: new mongoose.Types.ObjectId().toString(), role, clinicId },
+    SECRET,
+    { expiresIn: '15m', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+  );
+}
+
+// ── MongoDB Memory Server lifecycle ──────────────────────────────────────────
+let mongod: MongoMemoryServer;
+let app: express.Express;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  app = buildApp();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await PaymentRecordModel.deleteMany({});
+  jest.clearAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Idempotency tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/payments/intent — idempotency', () => {
+  it('returns existing record and does NOT create a second on duplicate idempotencyKey', async () => {
+    const token = makeToken(CLINIC_A);
+
+    // First call — creates the record
+    const first = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '10.00', destination: DESTINATION, idempotencyKey: 'key-001' });
+
+    expect(first.status).toBe(201);
+    const firstIntentId = first.body.data.intentId;
+
+    // Second call — same key + same clinic
+    const second = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '10.00', destination: DESTINATION, idempotencyKey: 'key-001' });
+
+    expect(second.status).toBe(200);
+    expect(second.body.data.intentId).toBe(firstIntentId);
+
+    // Only one record must exist in the DB
+    const count = await PaymentRecordModel.countDocuments({ idempotencyKey: 'key-001' });
+    expect(count).toBe(1);
+  });
+
+  it('includes { idempotent: true } in the response on a duplicate call', async () => {
+    const token = makeToken(CLINIC_A);
+
+    await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '5.00', destination: DESTINATION, idempotencyKey: 'key-002' });
+
+    const second = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '5.00', destination: DESTINATION, idempotencyKey: 'key-002' });
+
+    expect(second.status).toBe(200);
+    expect(second.body.idempotent).toBe(true);
+    expect(second.body.status).toBe('success');
+  });
+
+  it('creates a new record when idempotencyKey is omitted (backward compatible)', async () => {
+    const token = makeToken(CLINIC_A);
+
+    const res = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '7.50', destination: DESTINATION });
+
+    expect(res.status).toBe(201);
+    expect(res.body.idempotent).toBeUndefined();
+    expect(res.body.data.intentId).toBeDefined();
+  });
+
+  it('treats the same idempotencyKey from a different clinic as a new intent', async () => {
+    const tokenA = makeToken(CLINIC_A);
+    const tokenB = makeToken(CLINIC_B);
+    const sharedKey = 'key-shared';
+
+    // Clinic A creates a record with the shared key
+    const firstA = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ amount: '10.00', destination: DESTINATION, idempotencyKey: sharedKey });
+
+    expect(firstA.status).toBe(201);
+
+    // Clinic B sends the same key — should create a NEW record (different clinic scope)
+    const firstB = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${tokenB}`)
+      .send({ amount: '10.00', destination: DESTINATION, idempotencyKey: sharedKey });
+
+    expect(firstB.status).toBe(201);
+    expect(firstB.body.idempotent).toBeUndefined();
+    expect(firstB.body.data.intentId).not.toBe(firstA.body.data.intentId);
+
+    // Two distinct records exist — one per clinic
+    const recordA = await PaymentRecordModel.findOne({ idempotencyKey: sharedKey, clinicId: CLINIC_A });
+    const recordB = await PaymentRecordModel.findOne({ idempotencyKey: sharedKey, clinicId: CLINIC_B });
+    expect(recordA).not.toBeNull();
+    expect(recordB).not.toBeNull();
+    expect(recordA!.intentId).not.toBe(recordB!.intentId);
+  });
+
+  it('stores idempotencyKey on the created record', async () => {
+    const token = makeToken(CLINIC_A);
+
+    const res = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '3.00', destination: DESTINATION, idempotencyKey: 'key-stored' });
+
+    expect(res.status).toBe(201);
+    const record = await PaymentRecordModel.findOne({ intentId: res.body.data.intentId });
+    expect(record?.idempotencyKey).toBe('key-stored');
+  });
+
+  it('does not set idempotencyKey on the record when not provided', async () => {
+    const token = makeToken(CLINIC_A);
+
+    const res = await request(app)
+      .post('/api/v1/payments/intent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ amount: '3.00', destination: DESTINATION });
+
+    expect(res.status).toBe(201);
+    const record = await PaymentRecordModel.findOne({ intentId: res.body.data.intentId });
+    expect(record?.idempotencyKey).toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/payments/models/payment-record.model.ts
+++ b/apps/api/src/modules/payments/models/payment-record.model.ts
@@ -35,6 +35,7 @@ export interface PaymentRecord {
   // Expiry fields
   expiresAt?: Date;
   paymentType?: 'immediate' | 'multisig' | 'escrow';
+  idempotencyKey?: string;
 }
 
 const paymentRecordSchema = new Schema<PaymentRecord>(
@@ -78,6 +79,7 @@ const paymentRecordSchema = new Schema<PaymentRecord>(
     // Expiry fields
     expiresAt: { type: Date, index: true },
     paymentType: { type: String, enum: ['immediate', 'multisig', 'escrow'], default: 'immediate' },
+    idempotencyKey: { type: String, index: true, sparse: true, unique: true },
   },
   { timestamps: true, versionKey: false }
 );
@@ -87,6 +89,10 @@ paymentRecordSchema.index({ memo: 1, clinicId: 1 });
 paymentRecordSchema.index({ clinicId: 1, createdAt: -1 });        // List payments for clinic
 paymentRecordSchema.index({ clinicId: 1, status: 1 });            // Filter by status
 paymentRecordSchema.index({ txHash: 1 }, { sparse: true });       // Lookup by transaction hash
+paymentRecordSchema.index(
+  { createdAt: 1 },
+  { expireAfterSeconds: 86400, partialFilterExpression: { idempotencyKey: { $exists: true } } }
+);
 
 export const PaymentRecordModel =
   models.PaymentRecord || model<PaymentRecord>('PaymentRecord', paymentRecordSchema);

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -242,9 +242,25 @@ router.post(
       path,
       feeStrategy = 'standard',
       sponsorFee = false,
+      idempotencyKey,
     } = req.body;
     const intentId = randomUUID();
     const clinicId = req.user!.clinicId;
+
+    if (idempotencyKey) {
+      const existing = await PaymentRecordModel.findOne({
+        idempotencyKey,
+        clinicId,
+      }).lean();
+
+      if (existing) {
+        return res.json({
+          status: 'success',
+          data: toPaymentResponse(existing),
+          idempotent: true,
+        });
+      }
+    }
     // `currency` takes precedence over `assetCode` for convenience
     const normalizedAsset = (currency ?? String(assetCode)).toUpperCase().trim();
 
@@ -302,6 +318,7 @@ router.post(
           maxSourceAmount,
           path,
           feeStrategy,
+          idempotencyKey: idempotencyKey ?? undefined,
         })
     );
 

--- a/apps/api/src/modules/payments/payments.validation.ts
+++ b/apps/api/src/modules/payments/payments.validation.ts
@@ -21,6 +21,7 @@ export const createPaymentIntentSchema = z.object({
   feeStrategy: z.enum(['slow', 'standard', 'fast']).optional().default('standard'),
   /** If true, platform wraps the inner tx in a fee bump and pays the fee */
   sponsorFee: z.boolean().optional().default(false),
+  idempotencyKey: z.string().min(1).max(256).optional(),
 });
 
 export const confirmPaymentSchema = z.object({


### PR DESCRIPTION
- Add pre('findOneAndUpdate') hook to encounter.model.ts that sanitizes SOAP rich-text fields via sanitizeHtml() and free-text fields via sanitizeText(), covering both direct update and $set.soapNotes patterns
- Add unit tests for both pre('save') and pre('findOneAndUpdate') hooks covering script injection, on* event attrs, javascript: hrefs, and safe-tag preservation (MongoMemoryServer, no real DB connection)

- Add idempotencyKey (optional, max 256 chars) to createPaymentIntentSchema
- Add idempotencyKey field (unique sparse index) to PaymentRecordModel with a 24-hour TTL index scoped via partialFilterExpression
- Add idempotency check at the start of POST /payments/intent: returns the existing record with { idempotent: true } if the same key+clinicId is already in the DB, preventing duplicate Stellar transactions
- Add integration tests (MongoMemoryServer + mocked Stellar) covering duplicate-key dedup, idempotent flag, backward compat, and cross-clinic isolation

closes #604 
closes #603 