### PR TITLE
feat(payments): add claimable balance expiry notifications (#660)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -71,6 +71,10 @@ import {
   startAppointmentReminderJob,
   stopAppointmentReminderJob,
 } from './modules/appointments/appointment-reminder-job';
+import {
+  startClaimableExpiryNotificationJob,
+  stopClaimableExpiryNotificationJob,
+} from './modules/payments/services/claimable-expiry-notification-job';
 import { getCacheMetrics } from './services/cache.service';
 import {
   mongodbConnectionPoolSize,
@@ -304,6 +308,7 @@ async function startServer() {
   startBalanceMonitoringJob();
   startWaitlistExpiryJob();
   startAppointmentReminderJob();
+  startClaimableExpiryNotificationJob();
 
   // Track MongoDB connection pool metrics for Prometheus
   setInterval(() => {
@@ -330,6 +335,7 @@ async function startServer() {
         stopBalanceMonitoringJob();
         stopWaitlistExpiryJob();
         stopAppointmentReminderJob();
+        stopClaimableExpiryNotificationJob();
         logger.info('All background jobs stopped');
 
         // Close database connection

--- a/apps/api/src/docs/swagger.ts
+++ b/apps/api/src/docs/swagger.ts
@@ -45,6 +45,11 @@ const options: swaggerJsdoc.Options = {
             patientId: { type: 'string', nullable: true },
             createdAt: { type: 'string', format: 'date-time' },
             confirmedAt: { type: 'string', format: 'date-time', nullable: true },
+            claimableBalanceId: { type: 'string', nullable: true },
+            claimableAfter: { type: 'string', format: 'date-time', nullable: true },
+            claimableUntil: { type: 'string', format: 'date-time', nullable: true },
+            claimed: { type: 'boolean', nullable: true },
+            claimableExpiryNotificationSent: { type: 'boolean', default: false },
           },
         },
         CreatePaymentIntentRequest: {

--- a/apps/api/src/lib/email.service.ts
+++ b/apps/api/src/lib/email.service.ts
@@ -342,3 +342,29 @@ export function sendOutcomeNotificationEmail(
   `;
   enqueue(to, `Referral Outcome Recorded — Health Watchers`, text, html);
 }
+
+/** Claimable balance expiry notification sent to patient */
+export function sendClaimableExpiryEmail(
+  to: string,
+  patientName: string,
+  amount: string,
+  claimableUntil: Date
+): void {
+  const portalUrl = `${APP_BASE_URL()}/portal/payments`;
+  const expiryStr = claimableUntil.toLocaleString('en-US', { timeZone: 'UTC', dateStyle: 'medium', timeStyle: 'short' }) + ' UTC';
+  const text = `Your claimable payment of ${amount} XLM is expiring soon (${expiryStr}). Please claim it before it expires or the funds will be returned to the clinic.\n\nClaim now: ${portalUrl}`;
+  const html = `
+    <h3>⏰ Claimable Payment Expiring Soon</h3>
+    <p>Hello <strong>${patientName}</strong>,</p>
+    <p>You have a claimable payment that is expiring within 24 hours. Please claim it before it expires.</p>
+    <table style="border-collapse:collapse;width:100%;margin:16px 0">
+      <tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr>
+      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Expires At</td><td style="padding:8px;color:#dc2626">${expiryStr}</td></tr>
+    </table>
+    <p>If you do not claim this payment before the expiry date, the funds will be returned to the clinic.</p>
+    <p><a href="${portalUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Claim Payment Now</a></p>
+    <hr style="margin-top:32px">
+    <small style="color:#6b7280">Health Watchers</small>
+  `;
+  enqueue(to, '⏰ Your Claimable Payment is Expiring Soon — Health Watchers', text, html);
+}

--- a/apps/api/src/migrations/20260528_add_claimable_expiry_notification.ts
+++ b/apps/api/src/migrations/20260528_add_claimable_expiry_notification.ts
@@ -1,0 +1,27 @@
+import { Db } from 'mongodb';
+
+export async function up(db: Db): Promise<void> {
+  // Add claimableExpiryNotificationSent field to existing records
+  await db.collection('paymentrecords').updateMany(
+    { claimableBalanceId: { $exists: true }, claimableExpiryNotificationSent: { $exists: false } },
+    { $set: { claimableExpiryNotificationSent: false } }
+  );
+
+  // Index for efficient job queries
+  await db.collection('paymentrecords').createIndex(
+    { claimableUntil: 1, claimed: 1, claimableExpiryNotificationSent: 1 },
+    { background: true, name: 'claimableUntil_1_claimed_1_notificationSent_1' }
+  );
+}
+
+export async function down(db: Db): Promise<void> {
+  await db
+    .collection('paymentrecords')
+    .dropIndex('claimableUntil_1_claimed_1_notificationSent_1')
+    .catch(() => {});
+
+  await db.collection('paymentrecords').updateMany(
+    {},
+    { $unset: { claimableExpiryNotificationSent: '' } }
+  );
+}

--- a/apps/api/src/modules/notifications/notification.model.ts
+++ b/apps/api/src/modules/notifications/notification.model.ts
@@ -13,6 +13,7 @@ export const NOTIFICATION_TYPES = [
   'large_transaction',
   'unrecognized_transaction',
   'waitlist_available',
+  'claimable_expiring',
 ] as const;
 
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number];

--- a/apps/api/src/modules/payments/__tests__/claimable-expiry-notification-job.test.ts
+++ b/apps/api/src/modules/payments/__tests__/claimable-expiry-notification-job.test.ts
@@ -1,0 +1,263 @@
+// ── Module mocks (hoisted before imports) ────────────────────────────────────
+
+jest.mock('@api/modules/payments/models/payment-record.model', () => ({
+  PaymentRecordModel: {
+    find: jest.fn(),
+    updateOne: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/auth/models/user.model', () => ({
+  UserModel: {
+    findById: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/notifications/notification.service', () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock('@api/lib/email.service', () => ({
+  sendClaimableExpiryEmail: jest.fn(),
+}));
+
+jest.mock('@api/realtime/socket', () => ({
+  emitToUser: jest.fn(),
+}));
+
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { PaymentRecordModel } from '../models/payment-record.model';
+import { UserModel } from '../../auth/models/user.model';
+import { createNotification } from '../../notifications/notification.service';
+import { sendClaimableExpiryEmail } from '@api/lib/email.service';
+import { emitToUser } from '@api/realtime/socket';
+import logger from '@api/utils/logger';
+import { sendClaimableExpiryNotifications } from '../services/claimable-expiry-notification-job';
+
+const findMock = PaymentRecordModel.find as jest.Mock;
+const updateOneMock = PaymentRecordModel.updateOne as jest.Mock;
+const findByIdMock = UserModel.findById as jest.Mock;
+const createNotificationMock = createNotification as jest.Mock;
+const sendEmailMock = sendClaimableExpiryEmail as jest.Mock;
+const emitToUserMock = emitToUser as jest.Mock;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'pay_1',
+    intentId: 'intent_1',
+    clinicId: 'clinic_1',
+    patientId: 'patient_1',
+    amount: '50',
+    claimableBalanceId: 'cb_abc',
+    claimableUntil: new Date(Date.now() + 12 * 60 * 60 * 1000), // 12h from now
+    ...overrides,
+  };
+}
+
+function makePatient(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: 'patient_1',
+    email: 'patient@example.com',
+    fullName: 'Jane Doe',
+    ...overrides,
+  };
+}
+
+// lean() chain helper
+function mockFind(records: unknown[]) {
+  findMock.mockReturnValue({ lean: () => Promise.resolve(records) });
+}
+
+function mockFindById(patient: unknown) {
+  findByIdMock.mockReturnValue({ lean: () => Promise.resolve(patient) });
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updateOneMock.mockResolvedValue({ modifiedCount: 1 });
+  createNotificationMock.mockResolvedValue({});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sendClaimableExpiryNotifications — no records
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('sendClaimableExpiryNotifications — no records', () => {
+  it('returns 0 when no expiring balances found', async () => {
+    mockFind([]);
+    const count = await sendClaimableExpiryNotifications();
+    expect(count).toBe(0);
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does not send email when no records', async () => {
+    mockFind([]);
+    await sendClaimableExpiryNotifications();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sendClaimableExpiryNotifications — happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('sendClaimableExpiryNotifications — happy path', () => {
+  it('returns the count of notified records', async () => {
+    mockFind([makeRecord()]);
+    mockFindById(makePatient());
+
+    const count = await sendClaimableExpiryNotifications();
+    expect(count).toBe(1);
+  });
+
+  it('creates an in-app notification with correct type', async () => {
+    mockFind([makeRecord()]);
+    mockFindById(makePatient());
+
+    await sendClaimableExpiryNotifications();
+
+    expect(createNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'claimable_expiring',
+        userId: 'patient_1',
+        clinicId: 'clinic_1',
+      })
+    );
+  });
+
+  it('emits payment:claimable_expiring socket event', async () => {
+    const record = makeRecord();
+    mockFind([record]);
+    mockFindById(makePatient());
+
+    await sendClaimableExpiryNotifications();
+
+    expect(emitToUserMock).toHaveBeenCalledWith(
+      'patient_1',
+      'payment:claimable_expiring',
+      expect.objectContaining({ claimableBalanceId: 'cb_abc', amount: '50' })
+    );
+  });
+
+  it('sends email to patient', async () => {
+    const record = makeRecord();
+    mockFind([record]);
+    mockFindById(makePatient());
+
+    await sendClaimableExpiryNotifications();
+
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      'patient@example.com',
+      'Jane Doe',
+      '50',
+      record.claimableUntil
+    );
+  });
+
+  it('marks claimableExpiryNotificationSent=true after notifying', async () => {
+    mockFind([makeRecord()]);
+    mockFindById(makePatient());
+
+    await sendClaimableExpiryNotifications();
+
+    expect(updateOneMock).toHaveBeenCalledWith(
+      { _id: 'pay_1' },
+      { claimableExpiryNotificationSent: true }
+    );
+  });
+
+  it('handles multiple records', async () => {
+    mockFind([makeRecord({ _id: 'pay_1' }), makeRecord({ _id: 'pay_2', patientId: 'patient_2' })]);
+    findByIdMock
+      .mockReturnValueOnce({ lean: () => Promise.resolve(makePatient()) })
+      .mockReturnValueOnce({ lean: () => Promise.resolve(makePatient({ _id: 'patient_2', email: 'p2@example.com', fullName: 'John Smith' })) });
+
+    const count = await sendClaimableExpiryNotifications();
+    expect(count).toBe(2);
+    expect(createNotificationMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sendClaimableExpiryNotifications — edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('sendClaimableExpiryNotifications — edge cases', () => {
+  it('skips records with no patientId', async () => {
+    mockFind([makeRecord({ patientId: undefined })]);
+
+    const count = await sendClaimableExpiryNotifications();
+    expect(count).toBe(0);
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('skips records when patient not found in DB', async () => {
+    mockFind([makeRecord()]);
+    findByIdMock.mockReturnValue({ lean: () => Promise.resolve(null) });
+
+    const count = await sendClaimableExpiryNotifications();
+    expect(count).toBe(0);
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does not send email when patient has no email', async () => {
+    mockFind([makeRecord()]);
+    mockFindById(makePatient({ email: undefined }));
+
+    await sendClaimableExpiryNotifications();
+
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    // But in-app notification should still be sent
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues processing other records when one fails', async () => {
+    mockFind([makeRecord({ _id: 'pay_1' }), makeRecord({ _id: 'pay_2' })]);
+    findByIdMock
+      .mockReturnValueOnce({ lean: () => Promise.reject(new Error('DB error')) })
+      .mockReturnValueOnce({ lean: () => Promise.resolve(makePatient()) });
+
+    const count = await sendClaimableExpiryNotifications();
+    // First record failed, second succeeded
+    expect(count).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentId: 'pay_1' }),
+      expect.any(String)
+    );
+  });
+
+  it('does not throw when socket emit fails', async () => {
+    mockFind([makeRecord()]);
+    mockFindById(makePatient());
+    emitToUserMock.mockImplementation(() => { throw new Error('Socket not initialised'); });
+
+    await expect(sendClaimableExpiryNotifications()).resolves.toBe(1);
+    // Notification and email should still be sent
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses fallback name "Patient" when fullName is missing', async () => {
+    mockFind([makeRecord()]);
+    mockFindById(makePatient({ fullName: undefined }));
+
+    await sendClaimableExpiryNotifications();
+
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      'patient@example.com',
+      'Patient',
+      expect.any(String),
+      expect.any(Date)
+    );
+  });
+});

--- a/apps/api/src/modules/payments/models/payment-record.model.ts
+++ b/apps/api/src/modules/payments/models/payment-record.model.ts
@@ -39,6 +39,8 @@ export interface PaymentRecord {
   // Expiry fields
   expiresAt?: Date;
   paymentType?: 'immediate' | 'multisig' | 'escrow';
+  // Claimable balance expiry notification flag
+  claimableExpiryNotificationSent?: boolean;
   idempotencyKey?: string;
 }
 
@@ -87,6 +89,8 @@ const paymentRecordSchema = new Schema<PaymentRecord>(
     // Expiry fields
     expiresAt: { type: Date, index: true },
     paymentType: { type: String, enum: ['immediate', 'multisig', 'escrow'], default: 'immediate' },
+    // Claimable balance expiry notification flag
+    claimableExpiryNotificationSent: { type: Boolean, default: false, index: true },
     idempotencyKey: { type: String, index: true, sparse: true, unique: true },
   },
   { timestamps: true, versionKey: false }

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -11,6 +11,7 @@ import {
   ListPaymentsQuery,
 } from './payments.validation';
 import { asyncHandler } from '@api/middlewares/async.handler';
+import { authorize } from '@api/middlewares/rbac.middleware';
 import { toPaymentResponse } from './payments.transformer';
 import { stellarClient } from './services/stellar-client';
 import logger from '@api/utils/logger';
@@ -1868,6 +1869,58 @@ router.get(
     } catch (err: any) {
       return res.status(400).json({ error: 'Error', message: err.message });
     }
+  })
+);
+
+/**
+ * @swagger
+ * /payments/expiring-claimable:
+ *   get:
+ *     summary: List claimable balances expiring within 24 hours
+ *     tags: [Payments]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of expiring claimable balances for the clinic
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: success }
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       intentId: { type: string }
+ *                       claimableBalanceId: { type: string }
+ *                       amount: { type: string }
+ *                       patientId: { type: string }
+ *                       claimableUntil: { type: string, format: date-time }
+ *                       claimableExpiryNotificationSent: { type: boolean }
+ *       403:
+ *         description: Forbidden — CLINIC_ADMIN only
+ */
+// GET /payments/expiring-claimable — list claimable balances expiring within 24h (CLINIC_ADMIN)
+router.get(
+  '/expiring-claimable',
+  authorize(['CLINIC_ADMIN', 'SUPER_ADMIN']),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clinicId } = req.user!;
+    const now = new Date();
+    const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+    const records = await PaymentRecordModel.find({
+      clinicId,
+      claimableUntil: { $gte: now, $lte: in24h },
+      claimed: { $ne: true },
+    })
+      .select('intentId claimableBalanceId amount patientId claimableUntil claimableExpiryNotificationSent')
+      .lean();
+
+    return res.json({ status: 'success', data: records });
   })
 );
 

--- a/apps/api/src/modules/payments/services/claimable-expiry-notification-job.ts
+++ b/apps/api/src/modules/payments/services/claimable-expiry-notification-job.ts
@@ -1,0 +1,126 @@
+import { PaymentRecordModel } from '../models/payment-record.model';
+import { UserModel } from '../../auth/models/user.model';
+import { createNotification } from '../../notifications/notification.service';
+import { sendClaimableExpiryEmail } from '@api/lib/email.service';
+import { emitToUser } from '@api/realtime/socket';
+import logger from '@api/utils/logger';
+
+export const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+let jobInterval: NodeJS.Timeout | null = null;
+
+/**
+ * Find claimable balances expiring within the next 24 hours that haven't
+ * had a notification sent yet, notify the patient, and mark the flag.
+ */
+export async function sendClaimableExpiryNotifications(): Promise<number> {
+  const now = new Date();
+  const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+  const expiring = await PaymentRecordModel.find({
+    claimableUntil: { $gte: now, $lte: in24h },
+    claimed: { $ne: true },
+    claimableExpiryNotificationSent: { $ne: true },
+  }).lean();
+
+  if (expiring.length === 0) return 0;
+
+  let notified = 0;
+
+  for (const record of expiring) {
+    try {
+      if (!record.patientId) continue;
+
+      const patient = await UserModel.findById(record.patientId).lean<{
+        _id: unknown;
+        email?: string;
+        fullName?: string;
+      }>();
+
+      if (!patient) continue;
+
+      const patientName = patient.fullName?.trim() || 'Patient';
+
+      // In-app notification
+      await createNotification({
+        userId: record.patientId,
+        clinicId: record.clinicId,
+        type: 'claimable_expiring',
+        title: 'Claimable Payment Expiring Soon',
+        message: `Your claimable payment of ${record.amount} XLM expires on ${record.claimableUntil!.toUTCString()}. Claim it before it expires.`,
+        link: '/portal/payments',
+        metadata: {
+          claimableBalanceId: record.claimableBalanceId,
+          amount: record.amount,
+          claimableUntil: record.claimableUntil,
+        },
+      });
+
+      // Socket.IO event
+      try {
+        emitToUser(String(record.patientId), 'payment:claimable_expiring', {
+          claimableBalanceId: record.claimableBalanceId,
+          amount: record.amount,
+          claimableUntil: record.claimableUntil,
+        });
+      } catch {
+        // Non-fatal — socket may not be initialised
+      }
+
+      // Email notification
+      if (patient.email) {
+        sendClaimableExpiryEmail(patient.email, patientName, record.amount, record.claimableUntil!);
+      }
+
+      // Mark notification sent
+      await PaymentRecordModel.updateOne(
+        { _id: record._id },
+        { claimableExpiryNotificationSent: true }
+      );
+
+      notified++;
+    } catch (err) {
+      logger.error(
+        { err, paymentId: record._id },
+        '[claimable-expiry-job] failed to notify for payment'
+      );
+    }
+  }
+
+  if (notified > 0) {
+    logger.info({ count: notified }, '[claimable-expiry-job] sent expiry notifications');
+  }
+
+  return notified;
+}
+
+export function startClaimableExpiryNotificationJob(): void {
+  if (jobInterval) {
+    logger.warn('[claimable-expiry-job] already running');
+    return;
+  }
+
+  logger.info(`[claimable-expiry-job] starting (interval=${CHECK_INTERVAL_MS / 60000}m)`);
+
+  sendClaimableExpiryNotifications().catch((err) =>
+    logger.error({ err }, '[claimable-expiry-job] initial run failed')
+  );
+
+  jobInterval = setInterval(() => {
+    sendClaimableExpiryNotifications().catch((err) =>
+      logger.error({ err }, '[claimable-expiry-job] tick failed')
+    );
+  }, CHECK_INTERVAL_MS);
+}
+
+export function stopClaimableExpiryNotificationJob(): void {
+  if (jobInterval) {
+    clearInterval(jobInterval);
+    jobInterval = null;
+    logger.info('[claimable-expiry-job] stopped');
+  }
+}
+
+export function isClaimableExpiryNotificationJobRunning(): boolean {
+  return jobInterval !== null;
+}


### PR DESCRIPTION
- Add claimableExpiryNotificationSent flag to PaymentRecordModel
- Add scheduled job checking for balances expiring within 24h
- Send in-app notification, email, and Socket.IO event per expiry
- Add GET /api/v1/payments/expiring-claimable endpoint (CLINIC_ADMIN)
- Add migration for new field and compound index
- Add claimable_expiring to NotificationModel types
- Write tests for the expiration notification job
- Update Swagger docs

closes #660  