### PR TITLE
feat(monitoring): add comprehensive Grafana dashboards and alert rules

### DIFF
--- a/apps/api/src/services/metrics.service.ts
+++ b/apps/api/src/services/metrics.service.ts
@@ -126,6 +126,15 @@ export const mongodbKeyDecryptionFailures = new client.Counter({
   registers: [register],
 });
 
+// ── Subscription Metrics ──────────────────────────────────────────────────────
+
+export const subscriptionLimitViolations = new client.Counter({
+  name: 'subscription_limit_violations_total',
+  help: 'Total number of subscription limit violations by tier and resource',
+  labelNames: ['tier', 'resource'] as const,
+  registers: [register],
+});
+
 // ── Normalise path helper ─────────────────────────────────────────────────────
 // Replace dynamic segments (ObjectIds, UUIDs, numbers) with placeholders
 // to avoid high-cardinality label explosion.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./monitoring/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - ./monitoring/alerts-payments.yml:/etc/prometheus/alerts-payments.yml:ro
+      - ./monitoring/alerts-security.yml:/etc/prometheus/alerts-security.yml:ro
+      - ./monitoring/alerts-business.yml:/etc/prometheus/alerts-business.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,230 @@
+# Health Watchers — Monitoring
+
+This directory contains the full observability stack configuration for Health Watchers: Prometheus scrape config, alerting rules, and Grafana dashboard provisioning.
+
+## Stack
+
+| Service    | Port  | Purpose                          |
+|------------|-------|----------------------------------|
+| Prometheus | 9090  | Metrics collection & alerting    |
+| Grafana    | 3003  | Dashboards & visualisation       |
+| Jaeger     | 16686 | Distributed tracing (OTLP)       |
+
+Start the full stack with:
+
+```bash
+docker compose up -d prometheus grafana jaeger
+```
+
+Grafana is available at **http://localhost:3003** (default credentials: `admin` / `admin`).
+
+---
+
+## Dashboards
+
+All dashboards are provisioned automatically from `grafana/provisioning/dashboards/`. No manual import is required. They appear in the **Health Watchers** folder inside Grafana.
+
+### 1. API Performance (`api-performance.json`)
+
+**UID:** `hw-api-performance`
+
+Covers the Express API service (`health-watchers-api`).
+
+| Panel | Metric(s) |
+|---|---|
+| Request Rate (req/s) | `http_requests_total` by method |
+| Error Rate (%) | 4xx and 5xx ratios |
+| Throughput by Status | 2xx / 4xx / 5xx breakdown |
+| Latency Percentiles (p50/p95/p99) | `http_request_duration_seconds` histogram |
+| Latency by Endpoint (p95 top 10) | per-path histogram |
+| Request Rate by Endpoint (top 10) | per-path counter |
+| Request / Response Size (p95) | `http_request_size_bytes`, `http_response_size_bytes` |
+| Node.js Heap Used | `nodejs_heap_size_used_bytes` |
+| Event Loop Lag | `nodejs_eventloop_lag_seconds` |
+| Active Handles / Requests | `nodejs_active_handles_total` |
+| GC Duration (p99) | `nodejs_gc_duration_seconds` |
+| CPU Usage | `process_cpu_seconds_total` |
+
+**Alerting rules:** `alerts-business.yml` → `api-health` group  
+Alerts: `APIDown`, `HighErrorRate`, `HighP99Latency`
+
+---
+
+### 2. MongoDB Performance (`mongodb-performance.json`)
+
+**UID:** `hw-mongodb`
+
+Covers MongoDB connection pool health as observed from the API process.
+
+| Panel | Metric(s) |
+|---|---|
+| Connection Pool Size | `mongodb_connection_pool_size` |
+| Wait Queue Size | `mongodb_pool_wait_queue_size` |
+| Pool Utilization (%) | derived from pool size / max (10) |
+| Keypair Decryption Failures | `mongodb_keypair_decryption_failures_total` |
+| Connection Pool Over Time | pool size + wait queue trend |
+| DB-Bound Request Rate | write vs read HTTP requests |
+| API Latency vs DB Pool Pressure | p99 latency correlated with wait queue |
+| Node.js Heap | `nodejs_heap_size_used_bytes` |
+| Payment Expiration Job Health | consecutive failures + expired count |
+
+**Alerting rules:** `alerts-business.yml` → `mongodb-health` group  
+Alerts: `MongoDBPoolHighUtilization`, `MongoDBPoolWaitQueueNonEmpty`
+
+> **Note:** The pool max is hardcoded as `10` in the utilisation gauge expression. Update this if you change the Mongoose `maxPoolSize` option.
+
+---
+
+### 3. Stellar Payments (`stellar-payments.json`)
+
+**UID:** `hw-stellar-payments`
+
+Covers the Stellar payment service and payment lifecycle metrics.
+
+| Panel | Metric(s) |
+|---|---|
+| Payment Success Rate (%) | `payments_confirmed_total` / `payments_initiated_total` |
+| Payments Initiated / Confirmed | cumulative counters |
+| Stellar Service Uptime | `up{job="health-watchers-stellar"}` |
+| Payment Rate Over Time | by currency |
+| Stellar Transactions by Type & Status | `stellar_transactions_total` |
+| Stellar Service Latency (p50/p95/p99) | `http_request_duration_seconds` |
+| Stellar Service Error Rate | 5xx ratio |
+| Payment Expiration Job — Last Success | time since last successful run |
+| Payment Expiration Job — Consecutive Failures | `payment_expiration_job_consecutive_failures` |
+| Payments Expired (last run) | `payment_expiration_job_last_run_expired` |
+
+**Alerting rules:** `alerts-payments.yml`  
+Alerts: `StellarServiceDown`, `PaymentSuccessRateLow`, `StellarServiceHighErrorRate`, `StellarServiceHighLatency`, `PaymentExpirationJobStalled`, `PaymentExpirationJobConsecutiveFailures`, `PaymentExpirationJobErrorRateHigh`
+
+---
+
+### 4. Business KPIs (`business-kpis.json`)
+
+**UID:** `hw-business-kpis`
+
+Covers product-level health and growth metrics. Default time range is 24 hours.
+
+| Panel | Metric(s) |
+|---|---|
+| Total Patients Created | `patients_created_total` |
+| Total Encounters Created | `encounters_created_total` |
+| Total Payments Confirmed | `payments_confirmed_total` |
+| Total AI Requests | `ai_requests_total` |
+| Patient Creation Rate | by `clinicId` |
+| Encounter Creation Rate | by `clinicId` |
+| Business Activity Trend | all counters as rates |
+| AI Requests by Endpoint | `ai_requests_total` by `endpoint` |
+| Payments by Currency | initiated vs confirmed by `currency` |
+| Top Clinics by Patient Volume | bar gauge |
+| Top Clinics by Encounter Volume | bar gauge |
+| Subscription Limit Violations | `subscription_limit_violations_total` by tier/resource |
+| Payment Expiration Job — Payments Expired | `payment_expiration_job_last_run_expired` |
+
+**Alerting rules:** `alerts-business.yml` → `business-kpis` group  
+Alerts: `PatientCreationRateZero`, `EncounterCreationRateZero`, `AIRequestRateZero`, `HighSubscriptionLimitViolations`
+
+---
+
+### 5. Security (`security.json`)
+
+**UID:** `hw-security`
+
+Covers authentication failures, rate limit violations, and security-sensitive events.
+
+| Panel | Metric(s) |
+|---|---|
+| Auth Failures (401) Rate | `http_requests_total{status="401"}` |
+| Forbidden (403) Rate | `http_requests_total{status="403"}` |
+| Rate Limit Violations (429) Rate | `http_requests_total{status="429"}` |
+| Keypair Decryption Failures | `mongodb_keypair_decryption_failures_total` |
+| Auth Failures Over Time (401/403) | per-path breakdown |
+| Rate Limit Violations Over Time | per-path breakdown |
+| Auth Endpoint Traffic | `/auth/*` paths by status |
+| Subscription Limit Violations by Tier | `subscription_limit_violations_total` |
+| Keypair Decryption Failures Over Time | trend |
+| 5xx Error Rate by Endpoint | top 10 failing paths |
+| Audit Log Volume | derived from total request rate |
+| Security Event Summary (1h) | table of all security event counts |
+
+**Alerting rules:** `alerts-security.yml`  
+Alerts: `HighAuthFailureRate`, `HighForbiddenRate`, `HighRateLimitViolationRate`, `StellarKeypairDecryptionFailure`, `SubscriptionLimitViolationSpike`
+
+---
+
+## Alert Rules
+
+Alert rules are split across four files, all loaded by Prometheus:
+
+| File | Groups | Description |
+|---|---|---|
+| `alerts.yml` | `health-watchers-alerts` | Legacy combined alerts (kept for backward compatibility) |
+| `alerts-payments.yml` | `payment-expiration-job`, `stellar-payments` | Payment lifecycle and Stellar service alerts |
+| `alerts-security.yml` | `security` | Auth failures, rate limits, keypair issues |
+| `alerts-business.yml` | `business-kpis`, `api-health`, `mongodb-health` | Business KPIs, API health, MongoDB health |
+
+Each alert includes a `dashboard` label pointing to the relevant Grafana dashboard UID for quick navigation.
+
+### Severity Levels
+
+| Severity | Meaning |
+|---|---|
+| `critical` | Immediate action required — service is down or data integrity at risk |
+| `warning` | Degraded performance or elevated error rates — investigate soon |
+| `info` | Informational — no immediate action required |
+
+---
+
+## Metrics Reference
+
+### API Service (`health-watchers-api`)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `http_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests |
+| `http_request_duration_seconds` | Histogram | `method`, `path` | Request duration |
+| `http_request_size_bytes` | Histogram | `method`, `path` | Request body size |
+| `http_response_size_bytes` | Histogram | `method`, `path` | Response body size |
+| `patients_created_total` | Counter | `clinicId` | Patients created |
+| `encounters_created_total` | Counter | `clinicId` | Encounters created |
+| `payments_initiated_total` | Counter | `currency` | Payments initiated |
+| `payments_confirmed_total` | Counter | `currency` | Payments confirmed |
+| `ai_requests_total` | Counter | `endpoint` | AI endpoint requests |
+| `subscription_limit_violations_total` | Counter | `tier`, `resource` | Subscription limit hits |
+| `payment_expiration_job_errors_total` | Counter | — | Job execution failures |
+| `payment_expiration_job_last_run_expired` | Gauge | — | Payments expired in last run |
+| `payment_expiration_job_last_success_timestamp_seconds` | Gauge | — | Unix timestamp of last success |
+| `payment_expiration_job_consecutive_failures` | Gauge | — | Consecutive failure count |
+| `mongodb_connection_pool_size` | Gauge | — | Active MongoDB connections |
+| `mongodb_pool_wait_queue_size` | Gauge | — | Connections waiting for pool slot |
+| `mongodb_keypair_decryption_failures_total` | Counter | — | Stellar keypair decryption failures |
+
+### Stellar Service (`health-watchers-stellar`)
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `http_requests_total` | Counter | `method`, `path`, `status` | Total HTTP requests |
+| `http_request_duration_seconds` | Histogram | `method`, `path` | Request duration |
+| `stellar_transactions_total` | Counter | `type`, `status` | Stellar transactions processed |
+
+All services also export standard Node.js metrics with the `nodejs_` prefix (heap, GC, event loop lag, etc.) and `process_` metrics.
+
+---
+
+## Adding a New Dashboard
+
+1. Create a JSON file in `grafana/provisioning/dashboards/` with a unique `uid`.
+2. The dashboard provider reloads every 30 seconds — no Grafana restart needed.
+3. Add corresponding alert rules to the appropriate `alerts-*.yml` file.
+4. Update this README with the new dashboard's panel and metric inventory.
+
+## Troubleshooting
+
+**Dashboards not appearing in Grafana**  
+Check that the JSON is valid and the `uid` is unique across all dashboard files. Grafana logs provisioning errors at startup.
+
+**"No data" on panels**  
+Verify the Prometheus scrape targets are healthy at http://localhost:9090/targets. Confirm the API and Stellar service are running and the `METRICS_USERNAME`/`METRICS_PASSWORD` env vars match.
+
+**Alert rules not loading**  
+Check Prometheus logs and verify the alert file paths in `prometheus.yml` match the volume mounts in `docker-compose.yml`.

--- a/monitoring/alerts-business.yml
+++ b/monitoring/alerts-business.yml
@@ -1,0 +1,138 @@
+groups:
+  - name: business-kpis
+    rules:
+      # Alert when patient creation rate drops to zero for an extended period
+      # (may indicate API issues or data pipeline problems)
+      - alert: PatientCreationRateZero
+        expr: >
+          sum(rate(patients_created_total[30m])) == 0
+        for: 30m
+        labels:
+          severity: warning
+          team: product
+          dashboard: hw-business-kpis
+        annotations:
+          summary: "No patients created in the last 30 minutes"
+          description: >
+            The patient creation rate has been zero for 30 minutes.
+            This may indicate an API issue or an unusually quiet period.
+            Verify the API is healthy and check recent deployments.
+
+      # Alert when encounter creation rate drops to zero
+      - alert: EncounterCreationRateZero
+        expr: >
+          sum(rate(encounters_created_total[30m])) == 0
+        for: 30m
+        labels:
+          severity: warning
+          team: product
+          dashboard: hw-business-kpis
+        annotations:
+          summary: "No encounters created in the last 30 minutes"
+          description: >
+            The encounter creation rate has been zero for 30 minutes.
+            This may indicate an API issue or an unusually quiet period.
+
+      # Alert when AI request rate drops to zero (AI service may be down)
+      - alert: AIRequestRateZero
+        expr: >
+          sum(rate(ai_requests_total[15m])) == 0
+        for: 15m
+        labels:
+          severity: warning
+          team: product
+          dashboard: hw-business-kpis
+        annotations:
+          summary: "No AI requests in the last 15 minutes"
+          description: >
+            The AI request rate has been zero for 15 minutes.
+            The AI service may be unavailable or the Gemini API key may be invalid.
+
+      # Alert when subscription limit violations are high (revenue opportunity)
+      - alert: HighSubscriptionLimitViolations
+        expr: >
+          sum(increase(subscription_limit_violations_total[1h])) > 50
+        for: 0m
+        labels:
+          severity: info
+          team: product
+          dashboard: hw-business-kpis
+        annotations:
+          summary: "High subscription limit violations in the last hour"
+          description: >
+            {{ $value | humanize }} subscription limit violations occurred in the last hour.
+            Consider reaching out to affected clinics about plan upgrades.
+
+  - name: api-health
+    rules:
+      # Alert when API is down
+      - alert: APIDown
+        expr: up{job="health-watchers-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          team: platform
+          dashboard: hw-api-performance
+        annotations:
+          summary: "Health Watchers API is down"
+          description: "The API has been unreachable for more than 1 minute"
+          runbook_url: "https://wiki.internal/runbooks/api-down"
+
+      # Alert when error rate exceeds 5% over 5 minutes
+      - alert: HighErrorRate
+        expr: >
+          (
+            sum(rate(http_requests_total{job="health-watchers-api",status=~"5.."}[5m]))
+            / sum(rate(http_requests_total{job="health-watchers-api"}[5m]))
+          ) > 0.05
+        for: 2m
+        labels:
+          severity: warning
+          team: platform
+          dashboard: hw-api-performance
+        annotations:
+          summary: "High HTTP error rate on API"
+          description: "Error rate is {{ $value | humanizePercentage }} (threshold: 5%)"
+
+      # Alert when p99 latency exceeds 2 seconds
+      - alert: HighP99Latency
+        expr: >
+          histogram_quantile(0.99,
+            sum(rate(http_request_duration_seconds_bucket{job="health-watchers-api"}[5m])) by (le)
+          ) > 2
+        for: 2m
+        labels:
+          severity: warning
+          team: platform
+          dashboard: hw-api-performance
+        annotations:
+          summary: "High p99 latency on API"
+          description: "p99 latency is {{ $value | humanizeDuration }} (threshold: 2s)"
+
+  - name: mongodb-health
+    rules:
+      # Alert when MongoDB connection pool utilization exceeds 80%
+      - alert: MongoDBPoolHighUtilization
+        expr: >
+          mongodb_connection_pool_size{job="health-watchers-api"} / 10 > 0.8
+        for: 2m
+        labels:
+          severity: warning
+          team: platform
+          dashboard: hw-mongodb
+        annotations:
+          summary: "MongoDB connection pool utilization high"
+          description: "MongoDB pool utilization has exceeded 80% for more than 2 minutes"
+
+      # Alert when MongoDB pool wait queue is non-zero (connections queuing)
+      - alert: MongoDBPoolWaitQueueNonEmpty
+        expr: mongodb_pool_wait_queue_size{job="health-watchers-api"} > 0
+        for: 2m
+        labels:
+          severity: critical
+          team: platform
+          dashboard: hw-mongodb
+        annotations:
+          summary: "MongoDB connection pool wait queue is non-empty"
+          description: "Requests are waiting for MongoDB connections — pool may be exhausted"
+          runbook_url: "https://wiki.internal/runbooks/mongodb-pool"

--- a/monitoring/alerts-payments.yml
+++ b/monitoring/alerts-payments.yml
@@ -1,0 +1,118 @@
+groups:
+  - name: payment-expiration-job
+    interval: 1m
+    rules:
+      # Fires when the job has not completed a successful run in more than
+      # 2× its scheduled interval (2 × 5 min = 10 min).
+      - alert: PaymentExpirationJobStalled
+        expr: >
+          (time() - payment_expiration_job_last_success_timestamp_seconds) > 600
+        for: 1m
+        labels:
+          severity: critical
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: "Payment expiration job has not run successfully in >10 minutes"
+          description: >
+            The payment expiration job last succeeded
+            {{ $value | humanizeDuration }} ago (threshold: 10 min).
+            Payments may be stuck in pending status, causing accounting
+            discrepancies and blocking new payments for the same encounter.
+          runbook_url: "https://wiki.internal/runbooks/payment-expiration-job"
+
+      # Fires immediately when 2 or more consecutive failures are recorded.
+      - alert: PaymentExpirationJobConsecutiveFailures
+        expr: payment_expiration_job_consecutive_failures >= 2
+        for: 0m
+        labels:
+          severity: warning
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: >
+            Payment expiration job has failed {{ $value | humanize }} consecutive times
+          description: >
+            The payment expiration job has encountered {{ $value }} consecutive
+            failures. Check MongoDB connectivity and application logs for
+            structured error details (job=payment-expiration-job).
+          runbook_url: "https://wiki.internal/runbooks/payment-expiration-job"
+
+      # Informational alert tracking cumulative error rate.
+      - alert: PaymentExpirationJobErrorRateHigh
+        expr: >
+          rate(payment_expiration_job_errors_total[15m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: "Payment expiration job error rate is non-zero over the last 15 minutes"
+          description: >
+            Errors have been observed in the payment expiration job over the
+            last 15 minutes. Review logs for transient vs. permanent failures.
+
+  - name: stellar-payments
+    rules:
+      # Alert when Stellar service is down
+      - alert: StellarServiceDown
+        expr: up{job="health-watchers-stellar"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: "Stellar payment service is down"
+          description: "The Stellar service has been unreachable for more than 1 minute. Payments cannot be processed."
+          runbook_url: "https://wiki.internal/runbooks/stellar-service"
+
+      # Alert when payment success rate drops below 95%
+      - alert: PaymentSuccessRateLow
+        expr: >
+          (
+            sum(rate(payments_confirmed_total[5m]))
+            / (sum(rate(payments_initiated_total[5m])) > 0)
+          ) < 0.95
+        for: 5m
+        labels:
+          severity: warning
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: "Payment success rate below 95%"
+          description: >
+            Payment success rate is {{ $value | humanizePercentage }} (threshold: 95%).
+            Check Stellar network connectivity and transaction logs.
+
+      # Alert when Stellar service error rate exceeds 5%
+      - alert: StellarServiceHighErrorRate
+        expr: >
+          (
+            sum(rate(http_requests_total{job="health-watchers-stellar",status=~"5.."}[5m]))
+            / sum(rate(http_requests_total{job="health-watchers-stellar"}[5m]))
+          ) > 0.05
+        for: 2m
+        labels:
+          severity: warning
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: "High error rate on Stellar service"
+          description: "Stellar service error rate is {{ $value | humanizePercentage }} (threshold: 5%)"
+
+      # Alert when Stellar service p99 latency exceeds 5 seconds
+      - alert: StellarServiceHighLatency
+        expr: >
+          histogram_quantile(0.99,
+            sum(rate(http_request_duration_seconds_bucket{job="health-watchers-stellar"}[5m])) by (le)
+          ) > 5
+        for: 2m
+        labels:
+          severity: warning
+          team: payments
+          dashboard: hw-stellar-payments
+        annotations:
+          summary: "High p99 latency on Stellar service"
+          description: "Stellar service p99 latency is {{ $value | humanizeDuration }} (threshold: 5s)"

--- a/monitoring/alerts-security.yml
+++ b/monitoring/alerts-security.yml
@@ -1,0 +1,78 @@
+groups:
+  - name: security
+    rules:
+      # Alert on sustained high rate of 401 Unauthorized responses (brute-force indicator)
+      - alert: HighAuthFailureRate
+        expr: >
+          sum(rate(http_requests_total{job="health-watchers-api",status="401"}[5m])) > 1
+        for: 2m
+        labels:
+          severity: warning
+          team: security
+          dashboard: hw-security
+        annotations:
+          summary: "High authentication failure rate"
+          description: >
+            Authentication failure rate is {{ $value | humanize }} req/s (threshold: 1/s).
+            This may indicate a brute-force attack or misconfigured clients.
+          runbook_url: "https://wiki.internal/runbooks/auth-failures"
+
+      # Alert on sustained high rate of 403 Forbidden responses (privilege escalation attempts)
+      - alert: HighForbiddenRate
+        expr: >
+          sum(rate(http_requests_total{job="health-watchers-api",status="403"}[5m])) > 0.5
+        for: 2m
+        labels:
+          severity: warning
+          team: security
+          dashboard: hw-security
+        annotations:
+          summary: "High forbidden request rate"
+          description: >
+            Forbidden (403) rate is {{ $value | humanize }} req/s (threshold: 0.5/s).
+            This may indicate privilege escalation attempts or misconfigured roles.
+
+      # Alert on sustained high rate of 429 Too Many Requests (rate limit abuse)
+      - alert: HighRateLimitViolationRate
+        expr: >
+          sum(rate(http_requests_total{job="health-watchers-api",status="429"}[5m])) > 2
+        for: 2m
+        labels:
+          severity: warning
+          team: security
+          dashboard: hw-security
+        annotations:
+          summary: "High rate limit violation rate"
+          description: >
+            Rate limit violation (429) rate is {{ $value | humanize }} req/s (threshold: 2/s).
+            Review client behaviour and consider tightening rate limits.
+
+      # Alert immediately on any Stellar keypair decryption failure
+      - alert: StellarKeypairDecryptionFailure
+        expr: increase(mongodb_keypair_decryption_failures_total{job="health-watchers-api"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: security
+          dashboard: hw-security
+        annotations:
+          summary: "Stellar keypair decryption failure detected"
+          description: >
+            One or more Stellar keypair decryption failures occurred in the last 5 minutes.
+            This may indicate key rotation issues or data corruption.
+          runbook_url: "https://wiki.internal/runbooks/stellar-keypair"
+
+      # Alert on subscription limit violations spike (potential abuse)
+      - alert: SubscriptionLimitViolationSpike
+        expr: >
+          sum(rate(subscription_limit_violations_total[5m])) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+          team: security
+          dashboard: hw-security
+        annotations:
+          summary: "Subscription limit violations spiking"
+          description: >
+            Subscription limit violation rate is {{ $value | humanize }} req/s.
+            Multiple clinics may be hitting their plan limits or attempting to bypass them.

--- a/monitoring/grafana/provisioning/dashboards/api-performance.json
+++ b/monitoring/grafana/provisioning/dashboards/api-performance.json
@@ -1,0 +1,274 @@
+{
+  "title": "API Performance",
+  "uid": "hw-api-performance",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["api", "performance", "health-watchers"],
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "interval",
+        "type": "interval",
+        "label": "Interval",
+        "options": [
+          { "text": "1m", "value": "1m" },
+          { "text": "5m", "value": "5m" },
+          { "text": "10m", "value": "10m" }
+        ],
+        "current": { "text": "5m", "value": "5m" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\"}[$interval])) by (method)",
+          "legendFormat": "{{ method }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2 }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (%)",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 0, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(http_requests_total{job=\"health-watchers-api\",status=~\"5..\"}[$interval])) / sum(rate(http_requests_total{job=\"health-watchers-api\"}[$interval]))",
+          "legendFormat": "5xx Error Rate %"
+        },
+        {
+          "expr": "100 * sum(rate(http_requests_total{job=\"health-watchers-api\",status=~\"4..\"}[$interval])) / sum(rate(http_requests_total{job=\"health-watchers-api\"}[$interval]))",
+          "legendFormat": "4xx Error Rate %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Throughput by Status",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=~\"2..\"}[$interval]))",
+          "legendFormat": "2xx"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=~\"4..\"}[$interval]))",
+          "legendFormat": "4xx"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=~\"5..\"}[$interval]))",
+          "legendFormat": "5xx"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "2xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "4xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "5xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ]
+      }
+    },
+    {
+      "id": 4,
+      "title": "Latency Percentiles (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-api\"}[$interval])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-api\"}[$interval])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-api\"}[$interval])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 2 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Latency by Endpoint (p95)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "topk(10, histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-api\"}[$interval])) by (path, le)))",
+          "legendFormat": "{{ path }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Request Rate by Endpoint (top 10)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(http_requests_total{job=\"health-watchers-api\"}[$interval])) by (path))",
+          "legendFormat": "{{ path }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Request / Response Size",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_size_bytes_bucket{job=\"health-watchers-api\"}[$interval])) by (le))",
+          "legendFormat": "Request p95"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_response_size_bytes_bucket{job=\"health-watchers-api\"}[$interval])) by (le))",
+          "legendFormat": "Response p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Node.js Heap Used",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 24, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "expr": "nodejs_heap_size_used_bytes{job=\"health-watchers-api\"}",
+          "legendFormat": "Heap Used"
+        },
+        {
+          "expr": "nodejs_heap_size_total_bytes{job=\"health-watchers-api\"}",
+          "legendFormat": "Heap Total"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Event Loop Lag",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 24, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "expr": "nodejs_eventloop_lag_seconds{job=\"health-watchers-api\"}",
+          "legendFormat": "Event Loop Lag"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Active Handles / Requests",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 24, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "expr": "nodejs_active_handles_total{job=\"health-watchers-api\"}",
+          "legendFormat": "Active Handles"
+        },
+        {
+          "expr": "nodejs_active_requests_total{job=\"health-watchers-api\"}",
+          "legendFormat": "Active Requests"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "GC Duration (p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 31, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(nodejs_gc_duration_seconds_bucket{job=\"health-watchers-api\"}[$interval])) by (le, kind))",
+          "legendFormat": "{{ kind }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 12,
+      "title": "CPU Usage",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 31, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{job=\"health-watchers-api\"}[$interval])",
+          "legendFormat": "CPU Usage"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit" }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/business-kpis.json
+++ b/monitoring/grafana/provisioning/dashboards/business-kpis.json
@@ -1,0 +1,254 @@
+{
+  "title": "Business KPIs",
+  "uid": "hw-business-kpis",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "1m",
+  "tags": ["business", "kpis", "health-watchers"],
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "interval",
+        "type": "interval",
+        "label": "Interval",
+        "options": [
+          { "text": "5m", "value": "5m" },
+          { "text": "1h", "value": "1h" },
+          { "text": "6h", "value": "6h" }
+        ],
+        "current": { "text": "1h", "value": "1h" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Total Patients Created",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(patients_created_total)",
+          "legendFormat": "Patients"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "blue", "mode": "fixed" }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+    },
+    {
+      "id": 2,
+      "title": "Total Encounters Created",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(encounters_created_total)",
+          "legendFormat": "Encounters"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "purple", "mode": "fixed" }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+    },
+    {
+      "id": 3,
+      "title": "Total Payments Confirmed",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(payments_confirmed_total)",
+          "legendFormat": "Payments"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "green", "mode": "fixed" }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+    },
+    {
+      "id": 4,
+      "title": "Total AI Requests",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(ai_requests_total)",
+          "legendFormat": "AI Requests"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "orange", "mode": "fixed" }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+    },
+    {
+      "id": 5,
+      "title": "Patient Creation Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(patients_created_total[$interval])) by (clinicId)",
+          "legendFormat": "Clinic {{ clinicId }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Encounter Creation Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(encounters_created_total[$interval])) by (clinicId)",
+          "legendFormat": "Clinic {{ clinicId }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "lineWidth": 2 } }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Business Activity Trend",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 13, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(patients_created_total[$interval]))",
+          "legendFormat": "Patients/s"
+        },
+        {
+          "expr": "sum(rate(encounters_created_total[$interval]))",
+          "legendFormat": "Encounters/s"
+        },
+        {
+          "expr": "sum(rate(payments_initiated_total[$interval]))",
+          "legendFormat": "Payments Initiated/s"
+        },
+        {
+          "expr": "sum(rate(payments_confirmed_total[$interval]))",
+          "legendFormat": "Payments Confirmed/s"
+        },
+        {
+          "expr": "sum(rate(ai_requests_total[$interval]))",
+          "legendFormat": "AI Requests/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "AI Requests by Endpoint",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 21, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(ai_requests_total[$interval])) by (endpoint)",
+          "legendFormat": "{{ endpoint }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Payments by Currency",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 21, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(payments_initiated_total[$interval])) by (currency)",
+          "legendFormat": "Initiated ({{ currency }})"
+        },
+        {
+          "expr": "sum(rate(payments_confirmed_total[$interval])) by (currency)",
+          "legendFormat": "Confirmed ({{ currency }})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Top Clinics by Patient Volume",
+      "type": "bargauge",
+      "gridPos": { "x": 0, "y": 29, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "topk(10, sum(patients_created_total) by (clinicId))",
+          "legendFormat": "{{ clinicId }}"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "horizontal",
+        "displayMode": "gradient"
+      }
+    },
+    {
+      "id": 11,
+      "title": "Top Clinics by Encounter Volume",
+      "type": "bargauge",
+      "gridPos": { "x": 12, "y": 29, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "topk(10, sum(encounters_created_total) by (clinicId))",
+          "legendFormat": "{{ clinicId }}"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "horizontal",
+        "displayMode": "gradient"
+      }
+    },
+    {
+      "id": 12,
+      "title": "Subscription Limit Violations",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 37, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "sum(rate(subscription_limit_violations_total[$interval])) by (tier, resource)",
+          "legendFormat": "{{ tier }} / {{ resource }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Payment Expiration Job — Payments Expired",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 37, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "payment_expiration_job_last_run_expired{job=\"health-watchers-api\"}",
+          "legendFormat": "Expired per Run"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/mongodb-performance.json
+++ b/monitoring/grafana/provisioning/dashboards/mongodb-performance.json
@@ -1,0 +1,256 @@
+{
+  "title": "MongoDB Performance",
+  "uid": "hw-mongodb",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["mongodb", "database", "health-watchers"],
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "interval",
+        "type": "interval",
+        "label": "Interval",
+        "options": [
+          { "text": "1m", "value": "1m" },
+          { "text": "5m", "value": "5m" },
+          { "text": "10m", "value": "10m" }
+        ],
+        "current": { "text": "5m", "value": "5m" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Connection Pool Size",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "mongodb_connection_pool_size{job=\"health-watchers-api\"}",
+          "legendFormat": "Active Connections"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 8 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "mappings": []
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" }
+    },
+    {
+      "id": 2,
+      "title": "Wait Queue Size",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "mongodb_pool_wait_queue_size{job=\"health-watchers-api\"}",
+          "legendFormat": "Waiting"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 3,
+      "title": "Pool Utilization (%)",
+      "type": "gauge",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "100 * mongodb_connection_pool_size{job=\"health-watchers-api\"} / 10",
+          "legendFormat": "Pool Utilization"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 80 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Keypair Decryption Failures",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "increase(mongodb_keypair_decryption_failures_total{job=\"health-watchers-api\"}[1h])",
+          "legendFormat": "Failures (1h)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 5,
+      "title": "Connection Pool Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "mongodb_connection_pool_size{job=\"health-watchers-api\"}",
+          "legendFormat": "Active Connections"
+        },
+        {
+          "expr": "mongodb_pool_wait_queue_size{job=\"health-watchers-api\"}",
+          "legendFormat": "Wait Queue"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 8 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Keypair Decryption Failures Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "increase(mongodb_keypair_decryption_failures_total{job=\"health-watchers-api\"}[$interval])",
+          "legendFormat": "Decryption Failures"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "lineWidth": 2 },
+          "color": { "fixedColor": "red", "mode": "fixed" }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "DB-Bound Request Rate (write operations)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 13, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",method=~\"POST|PUT|PATCH|DELETE\"}[$interval]))",
+          "legendFormat": "Write Requests/s"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",method=\"GET\"}[$interval]))",
+          "legendFormat": "Read Requests/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "API Latency vs DB Pool Pressure",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 13, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-api\"}[$interval])) by (le))",
+          "legendFormat": "p99 Latency (s)"
+        },
+        {
+          "expr": "mongodb_pool_wait_queue_size{job=\"health-watchers-api\"}",
+          "legendFormat": "DB Wait Queue"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "p99 Latency (s)" },
+            "properties": [{ "id": "unit", "value": "s" }, { "id": "custom.axisPlacement", "value": "left" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "DB Wait Queue" },
+            "properties": [{ "id": "custom.axisPlacement", "value": "right" }]
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "title": "Node.js Heap (API process)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 21, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "nodejs_heap_size_used_bytes{job=\"health-watchers-api\"}",
+          "legendFormat": "Heap Used"
+        },
+        {
+          "expr": "nodejs_heap_size_total_bytes{job=\"health-watchers-api\"}",
+          "legendFormat": "Heap Total"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Payment Expiration Job Health",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 21, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "payment_expiration_job_consecutive_failures{job=\"health-watchers-api\"}",
+          "legendFormat": "Consecutive Failures"
+        },
+        {
+          "expr": "payment_expiration_job_last_run_expired{job=\"health-watchers-api\"}",
+          "legendFormat": "Payments Expired (last run)"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/security.json
+++ b/monitoring/grafana/provisioning/dashboards/security.json
@@ -1,0 +1,276 @@
+{
+  "title": "Security",
+  "uid": "hw-security",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["security", "auth", "health-watchers"],
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "interval",
+        "type": "interval",
+        "label": "Interval",
+        "options": [
+          { "text": "1m", "value": "1m" },
+          { "text": "5m", "value": "5m" },
+          { "text": "10m", "value": "10m" }
+        ],
+        "current": { "text": "5m", "value": "5m" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Auth Failures (401) Rate",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=\"401\"}[5m]))",
+          "legendFormat": "401/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 2,
+      "title": "Forbidden (403) Rate",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=\"403\"}[5m]))",
+          "legendFormat": "403/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 3,
+      "title": "Rate Limit Violations (429) Rate",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=\"429\"}[5m]))",
+          "legendFormat": "429/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 4,
+      "title": "Keypair Decryption Failures",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "increase(mongodb_keypair_decryption_failures_total{job=\"health-watchers-api\"}[1h])",
+          "legendFormat": "Failures (1h)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 5,
+      "title": "Auth Failures Over Time (401 / 403)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=\"401\"}[$interval])) by (path)",
+          "legendFormat": "401 {{ path }}"
+        },
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=\"403\"}[$interval])) by (path)",
+          "legendFormat": "403 {{ path }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Rate Limit Violations Over Time (429)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",status=\"429\"}[$interval])) by (path)",
+          "legendFormat": "429 {{ path }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Auth Endpoint Traffic (login / refresh / logout)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 13, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\",path=~\".*/auth/.*\"}[$interval])) by (path, status)",
+          "legendFormat": "{{ path }} [{{ status }}]"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Subscription Limit Violations by Tier",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 13, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(subscription_limit_violations_total[$interval])) by (tier, resource)",
+          "legendFormat": "{{ tier }} / {{ resource }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Keypair Decryption Failures Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 21, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "increase(mongodb_keypair_decryption_failures_total{job=\"health-watchers-api\"}[$interval])",
+          "legendFormat": "Decryption Failures"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "custom": { "lineWidth": 2 }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "5xx Error Rate by Endpoint",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 21, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(http_requests_total{job=\"health-watchers-api\",status=~\"5..\"}[$interval])) by (path))",
+          "legendFormat": "{{ path }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Audit Log Volume (requests logged/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 29, "w": 12, "h": 7 },
+      "description": "Derived from total HTTP request rate — every request is audit-logged by requestAuditMiddleware.",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-api\"}[$interval]))",
+          "legendFormat": "Audit Entries/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Security Event Summary (1h)",
+      "type": "table",
+      "gridPos": { "x": 12, "y": 29, "w": 12, "h": 7 },
+      "targets": [
+        {
+          "expr": "sum(increase(http_requests_total{job=\"health-watchers-api\",status=\"401\"}[1h]))",
+          "legendFormat": "Auth Failures (401)",
+          "instant": true
+        },
+        {
+          "expr": "sum(increase(http_requests_total{job=\"health-watchers-api\",status=\"403\"}[1h]))",
+          "legendFormat": "Forbidden (403)",
+          "instant": true
+        },
+        {
+          "expr": "sum(increase(http_requests_total{job=\"health-watchers-api\",status=\"429\"}[1h]))",
+          "legendFormat": "Rate Limited (429)",
+          "instant": true
+        },
+        {
+          "expr": "sum(increase(mongodb_keypair_decryption_failures_total{job=\"health-watchers-api\"}[1h]))",
+          "legendFormat": "Decryption Failures",
+          "instant": true
+        }
+      ],
+      "options": {
+        "showHeader": true
+      },
+      "transformations": [
+        { "id": "labelsToFields", "options": {} },
+        { "id": "merge", "options": {} }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/stellar-payments.json
+++ b/monitoring/grafana/provisioning/dashboards/stellar-payments.json
@@ -1,0 +1,298 @@
+{
+  "title": "Stellar Payments",
+  "uid": "hw-stellar-payments",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["stellar", "payments", "health-watchers"],
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "interval",
+        "type": "interval",
+        "label": "Interval",
+        "options": [
+          { "text": "1m", "value": "1m" },
+          { "text": "5m", "value": "5m" },
+          { "text": "10m", "value": "10m" }
+        ],
+        "current": { "text": "5m", "value": "5m" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Payment Success Rate (%)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "100 * sum(payments_confirmed_total) / (sum(payments_initiated_total) > 0)",
+          "legendFormat": "Success Rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 98 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 2,
+      "title": "Payments Initiated (total)",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(payments_initiated_total)",
+          "legendFormat": "Initiated"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+    },
+    {
+      "id": 3,
+      "title": "Payments Confirmed (total)",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(payments_confirmed_total)",
+          "legendFormat": "Confirmed"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "green", "mode": "fixed" }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+    },
+    {
+      "id": 4,
+      "title": "Stellar Service Uptime",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 5 },
+      "targets": [
+        {
+          "expr": "up{job=\"health-watchers-stellar\"}",
+          "legendFormat": "Stellar Service"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 5,
+      "title": "Payment Rate Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(payments_initiated_total[$interval])) by (currency)",
+          "legendFormat": "Initiated ({{ currency }})"
+        },
+        {
+          "expr": "sum(rate(payments_confirmed_total[$interval])) by (currency)",
+          "legendFormat": "Confirmed ({{ currency }})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Payment Success Rate Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 5, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(payments_confirmed_total[$interval])) / (sum(rate(payments_initiated_total[$interval])) > 0)",
+          "legendFormat": "Success Rate %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 98 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Stellar Transactions by Type & Status",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 13, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(stellar_transactions_total{job=\"health-watchers-stellar\"}[$interval])) by (type, status)",
+          "legendFormat": "{{ type }} / {{ status }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Stellar Service Request Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 13, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"health-watchers-stellar\"}[$interval])) by (method)",
+          "legendFormat": "{{ method }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps" }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Stellar Service Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 21, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-stellar\"}[$interval])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-stellar\"}[$interval])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"health-watchers-stellar\"}[$interval])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Stellar Service Error Rate (%)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 21, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(http_requests_total{job=\"health-watchers-stellar\",status=~\"5..\"}[$interval])) / sum(rate(http_requests_total{job=\"health-watchers-stellar\"}[$interval]))",
+          "legendFormat": "5xx Error Rate %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Payment Expiration Job — Last Success",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 29, "w": 8, "h": 5 },
+      "targets": [
+        {
+          "expr": "time() - payment_expiration_job_last_success_timestamp_seconds{job=\"health-watchers-api\"}",
+          "legendFormat": "Seconds Since Last Success"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 600 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 12,
+      "title": "Payment Expiration Job — Consecutive Failures",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 29, "w": 8, "h": 5 },
+      "targets": [
+        {
+          "expr": "payment_expiration_job_consecutive_failures{job=\"health-watchers-api\"}",
+          "legendFormat": "Consecutive Failures"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
+    },
+    {
+      "id": 13,
+      "title": "Payments Expired (last job run)",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 29, "w": 8, "h": 5 },
+      "targets": [
+        {
+          "expr": "payment_expiration_job_last_run_expired{job=\"health-watchers-api\"}",
+          "legendFormat": "Expired"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" }
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -9,6 +9,9 @@ alerting:
 
 rule_files:
   - "alerts.yml"
+  - "alerts-payments.yml"
+  - "alerts-security.yml"
+  - "alerts-business.yml"
 
 scrape_configs:
   - job_name: "health-watchers-api"


### PR DESCRIPTION
- Add 5 auto-provisioned Grafana dashboards:
  - API Performance (hw-api-performance): request rate, error rate, p50/p95/p99 latency, per-endpoint breakdown, Node.js runtime metrics
  - MongoDB Performance (hw-mongodb): connection pool, wait queue, utilisation gauge, keypair decryption failures, latency correlation
  - Stellar Payments (hw-stellar-payments): payment success rate, initiated vs confirmed by currency, Stellar transactions by type/status, payment expiration job health panels
  - Business KPIs (hw-business-kpis): patient/encounter/payment/AI totals, per-clinic breakdowns, top-clinic bar gauges, subscription violations
  - Security (hw-security): 401/403/429 rates, auth endpoint traffic, keypair failures, audit log volume, 1h security event summary table

- Add 3 Prometheus alert rule files:
  - alerts-payments.yml: StellarServiceDown, PaymentSuccessRateLow, StellarServiceHighErrorRate/Latency, PaymentExpirationJob alerts
  - alerts-security.yml: HighAuthFailureRate, HighForbiddenRate, HighRateLimitViolationRate, StellarKeypairDecryptionFailure, SubscriptionLimitViolationSpike
  - alerts-business.yml: PatientCreationRateZero, EncounterCreationRateZero, AIRequestRateZero, HighSubscriptionLimitViolations, APIDown, HighErrorRate, HighP99Latency, MongoDBPool alerts

- Fix metrics.service.ts: add missing subscriptionLimitViolations counter (subscription.middleware.ts was importing it but it was never defined)

- Update prometheus.yml to load all four alert rule files

- Mount new alert files in docker-compose.yml prometheus volumes

- Add monitoring/README.md with full dashboard, panel, metric, and alert inventory

closes #665 