### PR TITLE
feat: patient duplicate detection, per-user rate limiting, vitals dashboard, onboarding wizard (#638 #639 #640 #641)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,9 @@ import {
   aiLimiter,
   paymentLimiter,
   generalLimiter,
+  bulkExportLimiter,
+  patientSearchLimiter,
+  reportGenerationLimiter,
 } from './middlewares/rate-limit.middleware';
 import { appointmentRoutes } from './modules/appointments/appointments.controller';
 import { waitlistRoutes } from './modules/appointments/waitlist.controller';
@@ -242,6 +245,7 @@ app.use('/api/v1/clinics', clinicRoutes);
 app.use('/api/v1/users', userManagementRoutes); // User management endpoints
 app.use('/api/v1/users', userRoutes); // User profile endpoints
 app.use('/api/v1/patients', patientRoutes);
+app.use('/api/v1/patients/search', patientSearchLimiter);
 app.use('/api/v1/patients', medicalHistoryRoutes);
 app.use('/api/v1/patients', patientPhotoRoutes);
 app.use('/api/v1/encounters', encounterRoutes);
@@ -263,7 +267,7 @@ app.use('/api/v1/referrals', referralRoutes);
 app.use('/api/v1/invoices', invoiceRoutes);
 app.use('/api/v1/care-plans', carePlanRoutes);
 app.use('/api/v1/portal', portalRoutes);
-app.use('/api/v1/reports', reportRoutes);
+app.use('/api/v1/reports', reportGenerationLimiter, reportRoutes);
 app.use('/api/v1', consentRoutes);
 app.use('/api/v1/subscriptions', subscriptionRoutes);
 app.use('/api/v1/schedules', scheduleRoutes);

--- a/apps/api/src/middlewares/rate-limit.middleware.ts
+++ b/apps/api/src/middlewares/rate-limit.middleware.ts
@@ -116,3 +116,42 @@ export const generalLimiter: RateLimitRequestHandler = make(15 * 60 * 1000, 300,
   error: 'TooManyRequests',
   message: 'Too many requests. Try again in 15 minutes.',
 });
+
+// ── Per-user limiters (keyed by userId from JWT) ──────────────────────────────
+function makeUserLimiter(
+  windowMs: number,
+  max: number,
+  message: object
+): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req: Request) => req.user?.userId ?? req.ip ?? 'unknown',
+    message,
+    handler: makeHandler(windowMs, message),
+    store: redisStore,
+  });
+}
+
+// Bulk export: 5 req / 1 hour per user
+export const bulkExportLimiter: RateLimitRequestHandler = makeUserLimiter(
+  60 * 60 * 1000,
+  5,
+  { error: 'TooManyRequests', message: 'Bulk export limit: 5 per hour. Try again later.' }
+);
+
+// Patient search: 100 req / 1 min per user
+export const patientSearchLimiter: RateLimitRequestHandler = makeUserLimiter(
+  60 * 1000,
+  100,
+  { error: 'TooManyRequests', message: 'Search rate limit exceeded. Try again in 1 minute.' }
+);
+
+// Report generation: 10 req / 1 hour per user
+export const reportGenerationLimiter: RateLimitRequestHandler = makeUserLimiter(
+  60 * 60 * 1000,
+  10,
+  { error: 'TooManyRequests', message: 'Report generation limit: 10 per hour. Try again later.' }
+);

--- a/apps/api/src/modules/export/export.routes.ts
+++ b/apps/api/src/modules/export/export.routes.ts
@@ -3,6 +3,7 @@ import { Types } from 'mongoose';
 import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
 import { auditLog } from '@api/modules/audit/audit.service';
 import logger from '@api/utils/logger';
+import { bulkExportLimiter } from '@api/middlewares/rate-limit.middleware';
 import {
   buildPatientRecord,
   sendPatientJson,
@@ -27,7 +28,7 @@ const router = Router();
  *     security:
  *       - bearerAuth: []
  */
-router.get('/patients/:id/export', authenticate, async (req: Request, res: Response) => {
+router.get('/patients/:id/export', authenticate, bulkExportLimiter, async (req: Request, res: Response) => {
   const { id } = req.params;
   const format = ((req.query.format as string) || '').toLowerCase();
 
@@ -92,6 +93,7 @@ router.get(
   '/clinics/:id/export',
   authenticate,
   requireRoles('SUPER_ADMIN'),
+  bulkExportLimiter,
   async (req: Request, res: Response) => {
     const { id } = req.params;
 

--- a/apps/api/src/modules/patients/duplicate-detection.service.test.ts
+++ b/apps/api/src/modules/patients/duplicate-detection.service.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for duplicate-detection fuzzy matching algorithms — Issue #641
+ */
+import { jaroWinkler, soundex, normalizePhone, DuplicateDetectionService } from './duplicate-detection.service';
+
+// ── jaroWinkler ───────────────────────────────────────────────────────────────
+describe('jaroWinkler', () => {
+  it('returns 1 for identical strings', () => {
+    expect(jaroWinkler('john', 'john')).toBe(1);
+  });
+
+  it('returns 0 for empty strings', () => {
+    expect(jaroWinkler('', '')).toBe(0);
+    expect(jaroWinkler('john', '')).toBe(0);
+    expect(jaroWinkler('', 'john')).toBe(0);
+  });
+
+  it('detects John vs Jon as highly similar (>= 0.9)', () => {
+    expect(jaroWinkler('john', 'jon')).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('detects Smyth vs Smith as highly similar (>= 0.85)', () => {
+    expect(jaroWinkler('smyth', 'smith')).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('returns low similarity for completely different names', () => {
+    expect(jaroWinkler('alice', 'robert')).toBeLessThan(0.6);
+  });
+
+  it('is case-sensitive (caller should lowercase)', () => {
+    expect(jaroWinkler('John', 'john')).toBeLessThan(1);
+    expect(jaroWinkler('john', 'john')).toBe(1);
+  });
+
+  it('detects Catherine vs Katherine as similar (>= 0.85)', () => {
+    expect(jaroWinkler('catherine', 'katherine')).toBeGreaterThanOrEqual(0.85);
+  });
+});
+
+// ── soundex ───────────────────────────────────────────────────────────────────
+describe('soundex', () => {
+  it('returns 4-character code', () => {
+    expect(soundex('Smith')).toHaveLength(4);
+    expect(soundex('Johnson')).toHaveLength(4);
+  });
+
+  it('Smith and Smyth share the same soundex code', () => {
+    expect(soundex('Smith')).toBe(soundex('Smyth'));
+  });
+
+  it('Robert and Rupert share the same soundex code', () => {
+    expect(soundex('Robert')).toBe(soundex('Rupert'));
+  });
+
+  it('returns 0000 for empty/non-alpha input', () => {
+    expect(soundex('')).toBe('0000');
+    expect(soundex('123')).toBe('0000');
+  });
+
+  it('different names produce different codes', () => {
+    expect(soundex('Smith')).not.toBe(soundex('Jones'));
+  });
+});
+
+// ── normalizePhone ────────────────────────────────────────────────────────────
+describe('normalizePhone', () => {
+  it('strips dashes, spaces, and parentheses', () => {
+    expect(normalizePhone('(555) 123-4567')).toBe('5551234567');
+  });
+
+  it('strips dots', () => {
+    expect(normalizePhone('555.123.4567')).toBe('5551234567');
+  });
+
+  it('strips country code prefix', () => {
+    expect(normalizePhone('+1-555-123-4567')).toBe('15551234567');
+  });
+
+  it('leaves digits-only string unchanged', () => {
+    expect(normalizePhone('5551234567')).toBe('5551234567');
+  });
+
+  it('two differently formatted same numbers are equal after normalization', () => {
+    expect(normalizePhone('(555) 123-4567')).toBe(normalizePhone('555-123-4567'));
+  });
+});
+
+// ── DuplicateDetectionService.checkDuplicates (unit, mocked DB) ───────────────
+jest.mock('./models/patient.model', () => ({
+  PatientModel: {
+    find: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  },
+}));
+
+import { PatientModel } from './models/patient.model';
+import { Types } from 'mongoose';
+
+const CLINIC_ID = new Types.ObjectId().toString();
+
+function makePatient(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: new Types.ObjectId(),
+    firstName: 'John',
+    lastName: 'Smith',
+    dateOfBirth: '1990-05-15',
+    contactNumber: '555-1234',
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe('DuplicateDetectionService.checkDuplicates', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('detects exact match with confidence 100', async () => {
+    const patient = makePatient();
+    (PatientModel.find as jest.Mock).mockReturnValue({ lean: () => Promise.resolve([patient]) });
+
+    const results = await DuplicateDetectionService.checkDuplicates(
+      'John', 'Smith', '1990-05-15', CLINIC_ID
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].matchType).toBe('exact');
+    expect(results[0].confidence).toBe(100);
+  });
+
+  it('detects Jon Smyth as duplicate of John Smith (fuzzy)', async () => {
+    const patient = makePatient({ firstName: 'John', lastName: 'Smith' });
+    (PatientModel.find as jest.Mock).mockReturnValue({ lean: () => Promise.resolve([patient]) });
+
+    const results = await DuplicateDetectionService.checkDuplicates(
+      'Jon', 'Smyth', '1990-05-15', CLINIC_ID
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].confidence).toBeGreaterThanOrEqual(60);
+  });
+
+  it('returns empty array when no candidates share DOB ±1 day', async () => {
+    (PatientModel.find as jest.Mock).mockReturnValue({ lean: () => Promise.resolve([]) });
+
+    const results = await DuplicateDetectionService.checkDuplicates(
+      'John', 'Smith', '1990-05-15', CLINIC_ID
+    );
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('includes DOB ±1 day candidates', async () => {
+    // Patient has DOB one day off
+    const patient = makePatient({ dateOfBirth: '1990-05-14' });
+    (PatientModel.find as jest.Mock).mockReturnValue({ lean: () => Promise.resolve([patient]) });
+
+    const results = await DuplicateDetectionService.checkDuplicates(
+      'John', 'Smith', '1990-05-15', CLINIC_ID
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].matchReasons.some((r) => r.includes('±1 day'))).toBe(true);
+  });
+
+  it('results are sorted by confidence descending', async () => {
+    const patients = [
+      makePatient({ firstName: 'Jon', lastName: 'Smyth' }),   // lower similarity
+      makePatient({ firstName: 'John', lastName: 'Smith' }),  // exact
+    ];
+    (PatientModel.find as jest.Mock).mockReturnValue({ lean: () => Promise.resolve(patients) });
+
+    const results = await DuplicateDetectionService.checkDuplicates(
+      'John', 'Smith', '1990-05-15', CLINIC_ID
+    );
+
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].confidence).toBeGreaterThanOrEqual(results[i].confidence);
+    }
+  });
+
+  it('excludes candidates with very different names', async () => {
+    const patient = makePatient({ firstName: 'Alice', lastName: 'Johnson' });
+    (PatientModel.find as jest.Mock).mockReturnValue({ lean: () => Promise.resolve([patient]) });
+
+    const results = await DuplicateDetectionService.checkDuplicates(
+      'John', 'Smith', '1990-05-15', CLINIC_ID
+    );
+
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ── DuplicateDetectionService.findPotentialDuplicates ─────────────────────────
+describe('DuplicateDetectionService.findPotentialDuplicates', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns a pair for John Smith / Jon Smyth with same DOB', async () => {
+    const patients = [
+      makePatient({ _id: new Types.ObjectId(), firstName: 'John', lastName: 'Smith', dateOfBirth: '1990-05-15' }),
+      makePatient({ _id: new Types.ObjectId(), firstName: 'Jon', lastName: 'Smyth', dateOfBirth: '1990-05-15' }),
+    ];
+    (PatientModel.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: () => Promise.resolve(patients),
+    });
+
+    const pairs = await DuplicateDetectionService.findPotentialDuplicates(CLINIC_ID, 50);
+
+    expect(pairs.length).toBeGreaterThan(0);
+    expect(pairs[0].confidence).toBeGreaterThanOrEqual(50);
+  });
+
+  it('returns empty array when no patients share similar names + DOB', async () => {
+    const patients = [
+      makePatient({ _id: new Types.ObjectId(), firstName: 'Alice', lastName: 'Brown', dateOfBirth: '1985-01-01' }),
+      makePatient({ _id: new Types.ObjectId(), firstName: 'Robert', lastName: 'Jones', dateOfBirth: '1990-05-15' }),
+    ];
+    (PatientModel.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: () => Promise.resolve(patients),
+    });
+
+    const pairs = await DuplicateDetectionService.findPotentialDuplicates(CLINIC_ID, 60);
+
+    expect(pairs).toHaveLength(0);
+  });
+
+  it('boosts confidence when phone numbers match', async () => {
+    const patients = [
+      makePatient({ _id: new Types.ObjectId(), firstName: 'John', lastName: 'Smith', dateOfBirth: '1990-05-15', contactNumber: '555-1234' }),
+      makePatient({ _id: new Types.ObjectId(), firstName: 'Jon', lastName: 'Smyth', dateOfBirth: '1990-05-15', contactNumber: '(555) 1234' }),
+    ];
+    (PatientModel.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: () => Promise.resolve(patients),
+    });
+
+    const pairs = await DuplicateDetectionService.findPotentialDuplicates(CLINIC_ID, 50);
+
+    expect(pairs.length).toBeGreaterThan(0);
+    expect(pairs[0].matchReasons).toContain('matching phone number');
+  });
+
+  it('pairs are sorted by confidence descending', async () => {
+    const patients = [
+      makePatient({ _id: new Types.ObjectId(), firstName: 'John', lastName: 'Smith', dateOfBirth: '1990-05-15' }),
+      makePatient({ _id: new Types.ObjectId(), firstName: 'Jon', lastName: 'Smyth', dateOfBirth: '1990-05-15' }),
+      makePatient({ _id: new Types.ObjectId(), firstName: 'John', lastName: 'Smith', dateOfBirth: '1990-05-15' }),
+    ];
+    (PatientModel.find as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      lean: () => Promise.resolve(patients),
+    });
+
+    const pairs = await DuplicateDetectionService.findPotentialDuplicates(CLINIC_ID, 50);
+
+    for (let i = 1; i < pairs.length; i++) {
+      expect(pairs[i - 1].confidence).toBeGreaterThanOrEqual(pairs[i].confidence);
+    }
+  });
+});

--- a/apps/api/src/modules/patients/duplicate-detection.service.ts
+++ b/apps/api/src/modules/patients/duplicate-detection.service.ts
@@ -1,178 +1,282 @@
 import { PatientModel } from './models/patient.model';
 import { Types } from 'mongoose';
 
-// Levenshtein distance for fuzzy matching
-function levenshteinDistance(str1: string, str2: string): number {
-  const matrix: number[][] = [];
-  
-  for (let i = 0; i <= str2.length; i++) {
-    matrix[i] = [i];
-  }
-  
-  for (let j = 0; j <= str1.length; j++) {
-    matrix[0][j] = j;
-  }
-  
-  for (let i = 1; i <= str2.length; i++) {
-    for (let j = 1; j <= str1.length; j++) {
-      if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
-        matrix[i][j] = matrix[i - 1][j - 1];
-      } else {
-        matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1,
-          matrix[i][j - 1] + 1,
-          matrix[i - 1][j] + 1
-        );
-      }
+// ── Levenshtein distance ──────────────────────────────────────────────────────
+function levenshteinDistance(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1][j - 1]
+        : 1 + Math.min(dp[i - 1][j - 1], dp[i][j - 1], dp[i - 1][j]);
     }
   }
-  
-  return matrix[str2.length][str1.length];
+  return dp[m][n];
 }
 
-// Soundex algorithm for phonetic matching
-function soundex(str: string): string {
-  const code = str.toUpperCase().replace(/[^A-Z]/g, '');
-  if (!code) return '0000';
-  
-  const firstLetter = code[0];
-  const mapping: Record<string, string> = {
-    B: '1', F: '1', P: '1', V: '1',
-    C: '2', G: '2', J: '2', K: '2', Q: '2', S: '2', X: '2', Z: '2',
-    D: '3', T: '3',
-    L: '4',
-    M: '5', N: '5',
-    R: '6',
-  };
-  
-  let soundexCode = firstLetter;
-  for (let i = 1; i < code.length; i++) {
-    const digit = mapping[code[i]] || '0';
-    if (digit !== '0' && digit !== soundexCode[soundexCode.length - 1]) {
-      soundexCode += digit;
+// ── Jaro-Winkler similarity (0–1) ─────────────────────────────────────────────
+export function jaroWinkler(s1: string, s2: string): number {
+  if (s1 === s2) return 1;
+  const len1 = s1.length, len2 = s2.length;
+  if (len1 === 0 || len2 === 0) return 0;
+
+  const matchDist = Math.max(Math.floor(Math.max(len1, len2) / 2) - 1, 0);
+  const s1Matches = new Array(len1).fill(false);
+  const s2Matches = new Array(len2).fill(false);
+
+  let matches = 0, transpositions = 0;
+  for (let i = 0; i < len1; i++) {
+    const start = Math.max(0, i - matchDist);
+    const end = Math.min(i + matchDist + 1, len2);
+    for (let j = start; j < end; j++) {
+      if (s2Matches[j] || s1[i] !== s2[j]) continue;
+      s1Matches[i] = s2Matches[j] = true;
+      matches++;
+      break;
     }
   }
-  
-  return (soundexCode + '0000').substring(0, 4);
+  if (matches === 0) return 0;
+
+  let k = 0;
+  for (let i = 0; i < len1; i++) {
+    if (!s1Matches[i]) continue;
+    while (!s2Matches[k]) k++;
+    if (s1[i] !== s2[k]) transpositions++;
+    k++;
+  }
+
+  const jaro = (matches / len1 + matches / len2 + (matches - transpositions / 2) / matches) / 3;
+  // Winkler prefix bonus (up to 4 chars)
+  let prefix = 0;
+  for (let i = 0; i < Math.min(4, len1, len2); i++) {
+    if (s1[i] === s2[i]) prefix++; else break;
+  }
+  return jaro + prefix * 0.1 * (1 - jaro);
+}
+
+// ── Soundex ───────────────────────────────────────────────────────────────────
+export function soundex(str: string): string {
+  const code = str.toUpperCase().replace(/[^A-Z]/g, '');
+  if (!code) return '0000';
+  const map: Record<string, string> = {
+    B: '1', F: '1', P: '1', V: '1',
+    C: '2', G: '2', J: '2', K: '2', Q: '2', S: '2', X: '2', Z: '2',
+    D: '3', T: '3', L: '4', M: '5', N: '5', R: '6',
+  };
+  let result = code[0];
+  for (let i = 1; i < code.length; i++) {
+    const d = map[code[i]] ?? '0';
+    if (d !== '0' && d !== result[result.length - 1]) result += d;
+  }
+  return (result + '0000').slice(0, 4);
+}
+
+// ── Phone normalization ───────────────────────────────────────────────────────
+export function normalizePhone(phone: string): string {
+  return phone.replace(/\D/g, '');
+}
+
+// ── DOB ±1 day candidates ─────────────────────────────────────────────────────
+function dobCandidates(dob: string): string[] {
+  const d = new Date(dob);
+  if (isNaN(d.getTime())) return [dob];
+  const fmt = (dt: Date) => dt.toISOString().slice(0, 10);
+  const prev = new Date(d); prev.setDate(d.getDate() - 1);
+  const next = new Date(d); next.setDate(d.getDate() + 1);
+  return [fmt(prev), dob, fmt(next)];
+}
+
+// ── Confidence score ──────────────────────────────────────────────────────────
+function computeConfidence(
+  firstSim: number,
+  lastSim: number,
+  dobExact: boolean,
+  phoneMatch: boolean | null
+): number {
+  // Weighted: name 60%, DOB 30%, phone 10%
+  const nameSim = (firstSim * 0.4 + lastSim * 0.6);
+  let score = nameSim * 60 + (dobExact ? 30 : 20);
+  if (phoneMatch === true) score += 10;
+  else if (phoneMatch === false) score -= 10;
+  return Math.round(Math.min(100, Math.max(0, score)));
 }
 
 export interface DuplicateMatch {
   patient: any;
   similarityScore: number;
+  confidence: number;
   matchType: 'exact' | 'fuzzy' | 'phonetic';
+  matchReasons: string[];
+}
+
+export interface DuplicatePair {
+  patientA: any;
+  patientB: any;
+  confidence: number;
+  matchReasons: string[];
 }
 
 export class DuplicateDetectionService {
   /**
-   * Check for potential duplicates
+   * Check for potential duplicates of a given patient (used at registration time).
    */
   static async checkDuplicates(
     firstName: string,
     lastName: string,
     dateOfBirth: string,
     clinicId: string,
-    threshold: number = 3
+    _threshold: number = 3
   ): Promise<DuplicateMatch[]> {
-    const matches: DuplicateMatch[] = [];
-    
-    // Exact match
-    const exactMatches = await PatientModel.find({
-      firstName: { $regex: new RegExp(`^${firstName}$`, 'i') },
-      lastName: { $regex: new RegExp(`^${lastName}$`, 'i') },
-      dateOfBirth,
+    const fn = firstName.toLowerCase();
+    const ln = lastName.toLowerCase();
+    const fnSdx = soundex(firstName);
+    const lnSdx = soundex(lastName);
+    const dobRange = dobCandidates(dateOfBirth);
+
+    // Fetch candidates: same DOB ±1 day in this clinic
+    const candidates = await PatientModel.find({
+      dateOfBirth: { $in: dobRange },
       clinicId: new Types.ObjectId(clinicId),
       isActive: true,
       isDuplicate: { $ne: true },
     }).lean();
-    
-    for (const match of exactMatches) {
-      matches.push({
-        patient: match,
-        similarityScore: 100,
-        matchType: 'exact',
+
+    const results: DuplicateMatch[] = [];
+
+    for (const p of candidates) {
+      const pfn = (p.firstName as string).toLowerCase();
+      const pln = (p.lastName as string).toLowerCase();
+
+      const firstSim = jaroWinkler(fn, pfn);
+      const lastSim = jaroWinkler(ln, pln);
+      const dobExact = p.dateOfBirth === dateOfBirth;
+
+      // Phone comparison (if both present)
+      let phoneMatch: boolean | null = null;
+      if (p.contactNumber && firstName) {
+        // We don't have the incoming phone here — skip phone scoring at check time
+        phoneMatch = null;
+      }
+
+      const reasons: string[] = [];
+      let matchType: DuplicateMatch['matchType'] = 'fuzzy';
+
+      if (firstSim === 1 && lastSim === 1 && dobExact) {
+        matchType = 'exact';
+        reasons.push('exact name and DOB match');
+      } else {
+        if (firstSim >= 0.85) reasons.push(`first name similarity ${(firstSim * 100).toFixed(0)}%`);
+        if (lastSim >= 0.85) reasons.push(`last name similarity ${(lastSim * 100).toFixed(0)}%`);
+        if (soundex(p.firstName) === fnSdx && soundex(p.lastName) === lnSdx) {
+          matchType = 'phonetic';
+          reasons.push('phonetic name match');
+        }
+        if (!dobExact) reasons.push('DOB within ±1 day');
+        else reasons.push('exact DOB match');
+      }
+
+      // Only include if names are sufficiently similar
+      if (firstSim < 0.7 && lastSim < 0.7) continue;
+
+      const confidence = computeConfidence(firstSim, lastSim, dobExact, phoneMatch);
+      if (confidence < 40) continue;
+
+      results.push({
+        patient: p,
+        similarityScore: Math.round((firstSim * 0.4 + lastSim * 0.6) * 100),
+        confidence,
+        matchType,
+        matchReasons: reasons,
       });
     }
-    
-    // Fuzzy match (same DOB, similar name)
-    const sameDOBPatients = await PatientModel.find({
-      dateOfBirth,
-      clinicId: new Types.ObjectId(clinicId),
-      isActive: true,
-      isDuplicate: { $ne: true },
-    }).lean();
-    
-    for (const patient of sameDOBPatients) {
-      const firstNameDist = levenshteinDistance(
-        firstName.toLowerCase(),
-        patient.firstName.toLowerCase()
-      );
-      const lastNameDist = levenshteinDistance(
-        lastName.toLowerCase(),
-        patient.lastName.toLowerCase()
-      );
-      
-      if (firstNameDist <= threshold && lastNameDist <= threshold) {
-        const alreadyMatched = matches.some(m => 
-          m.patient._id.toString() === patient._id.toString()
-        );
-        
-        if (!alreadyMatched) {
-          const score = 100 - ((firstNameDist + lastNameDist) * 10);
-          matches.push({
-            patient,
-            similarityScore: Math.max(score, 0),
-            matchType: 'fuzzy',
-          });
-        }
-      }
-    }
-    
-    // Phonetic match (soundex)
-    const firstNameSoundex = soundex(firstName);
-    const lastNameSoundex = soundex(lastName);
-    
-    const allPatients = await PatientModel.find({
-      dateOfBirth,
-      clinicId: new Types.ObjectId(clinicId),
-      isActive: true,
-      isDuplicate: { $ne: true },
-    }).lean();
-    
-    for (const patient of allPatients) {
-      const patientFirstSoundex = soundex(patient.firstName);
-      const patientLastSoundex = soundex(patient.lastName);
-      
-      if (
-        patientFirstSoundex === firstNameSoundex &&
-        patientLastSoundex === lastNameSoundex
-      ) {
-        const alreadyMatched = matches.some(m => 
-          m.patient._id.toString() === patient._id.toString()
-        );
-        
-        if (!alreadyMatched) {
-          matches.push({
-            patient,
-            similarityScore: 75,
-            matchType: 'phonetic',
-          });
-        }
-      }
-    }
-    
-    // Sort by similarity score (highest first)
-    return matches.sort((a, b) => b.similarityScore - a.similarityScore);
+
+    return results.sort((a, b) => b.confidence - a.confidence);
   }
 
   /**
-   * Mark patient as potential duplicate
+   * Scan all active patients in a clinic and return ranked duplicate pairs.
+   * Used by GET /api/v1/patients/potential-duplicates.
+   */
+  static async findPotentialDuplicates(
+    clinicId: string,
+    minConfidence: number = 60
+  ): Promise<DuplicatePair[]> {
+    const patients = await PatientModel.find({
+      clinicId: new Types.ObjectId(clinicId),
+      isActive: true,
+      isDuplicate: { $ne: true },
+    })
+      .select('firstName lastName dateOfBirth contactNumber _id systemId')
+      .lean();
+
+    const pairs: DuplicatePair[] = [];
+
+    for (let i = 0; i < patients.length; i++) {
+      for (let j = i + 1; j < patients.length; j++) {
+        const a = patients[i];
+        const b = patients[j];
+
+        const dobA = typeof a.dateOfBirth === 'string'
+          ? a.dateOfBirth
+          : (a.dateOfBirth as Date).toISOString().slice(0, 10);
+        const dobB = typeof b.dateOfBirth === 'string'
+          ? b.dateOfBirth
+          : (b.dateOfBirth as Date).toISOString().slice(0, 10);
+
+        const dobExact = dobA === dobB;
+        const dobClose = !dobExact && dobCandidates(dobA).includes(dobB);
+        if (!dobExact && !dobClose) continue; // skip if DOB not within ±1 day
+
+        const firstSim = jaroWinkler(
+          (a.firstName as string).toLowerCase(),
+          (b.firstName as string).toLowerCase()
+        );
+        const lastSim = jaroWinkler(
+          (a.lastName as string).toLowerCase(),
+          (b.lastName as string).toLowerCase()
+        );
+
+        if (firstSim < 0.7 && lastSim < 0.7) continue;
+
+        // Phone comparison
+        let phoneMatch: boolean | null = null;
+        if (a.contactNumber && b.contactNumber) {
+          phoneMatch = normalizePhone(a.contactNumber as string) === normalizePhone(b.contactNumber as string);
+        }
+
+        const confidence = computeConfidence(firstSim, lastSim, dobExact, phoneMatch);
+        if (confidence < minConfidence) continue;
+
+        const reasons: string[] = [];
+        if (firstSim >= 0.85) reasons.push(`first name ${(firstSim * 100).toFixed(0)}% similar`);
+        if (lastSim >= 0.85) reasons.push(`last name ${(lastSim * 100).toFixed(0)}% similar`);
+        if (soundex(a.firstName as string) === soundex(b.firstName as string) &&
+            soundex(a.lastName as string) === soundex(b.lastName as string)) {
+          reasons.push('phonetic name match');
+        }
+        if (dobExact) reasons.push('exact DOB match');
+        else reasons.push('DOB within ±1 day');
+        if (phoneMatch === true) reasons.push('matching phone number');
+
+        pairs.push({ patientA: a, patientB: b, confidence, matchReasons: reasons });
+      }
+    }
+
+    return pairs.sort((a, b) => b.confidence - a.confidence);
+  }
+
+  /**
+   * Mark patient as potential duplicate.
    */
   static async markPotentialDuplicate(
     patientId: string,
     duplicateIds: string[]
   ): Promise<void> {
     await PatientModel.findByIdAndUpdate(patientId, {
-      $addToSet: { potentialDuplicates: { $each: duplicateIds.map(id => new Types.ObjectId(id)) } },
+      $addToSet: { potentialDuplicates: { $each: duplicateIds.map((id) => new Types.ObjectId(id)) } },
     });
   }
 }

--- a/apps/api/src/modules/patients/patients.controller.ts
+++ b/apps/api/src/modules/patients/patients.controller.ts
@@ -19,6 +19,7 @@ import {
   patientQuerySchema,
   patientSearchQuerySchema,
 } from './patients.validation';
+import { DuplicateDetectionService } from './duplicate-detection.service';
 import { createAllergySchema, updateAllergySchema } from './allergy.validation';
 import { patientsCreatedTotal } from '../../services/metrics.service';
 import {
@@ -171,6 +172,23 @@ router.get(
       data: data.map(toPatientResponse),
       meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
     });
+  })
+);
+
+// GET /patients/potential-duplicates — ranked duplicate pairs for admin review
+router.get(
+  '/potential-duplicates',
+  ADMIN_ROLES,
+  asyncHandler(async (req: Request, res: Response) => {
+    const minConfidence = Math.min(
+      100,
+      Math.max(0, parseInt(String(req.query.minConfidence ?? '60'), 10) || 60)
+    );
+    const pairs = await DuplicateDetectionService.findPotentialDuplicates(
+      req.user!.clinicId.toString(),
+      minConfidence
+    );
+    return res.json({ status: 'success', data: pairs, count: pairs.length });
   })
 );
 

--- a/apps/web/src/app/patients/duplicates/DuplicatesClient.tsx
+++ b/apps/web/src/app/patients/duplicates/DuplicatesClient.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchWithAuth } from '@/lib/auth';
+import { API_V1 } from '@/lib/api';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { Spinner } from '@/components/ui/Spinner';
+
+interface PatientSummary {
+  _id: string;
+  systemId: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  contactNumber?: string;
+}
+
+interface DuplicatePair {
+  patientA: PatientSummary;
+  patientB: PatientSummary;
+  confidence: number;
+  matchReasons: string[];
+}
+
+function confidenceVariant(score: number): 'danger' | 'warning' | 'success' {
+  if (score >= 85) return 'danger';
+  if (score >= 70) return 'warning';
+  return 'success';
+}
+
+async function fetchPairs(minConfidence: number): Promise<DuplicatePair[]> {
+  const res = await fetchWithAuth(
+    `${API_V1}/patients/potential-duplicates?minConfidence=${minConfidence}`
+  );
+  if (!res.ok) throw new Error(`Failed to load duplicates (${res.status})`);
+  const json = await res.json();
+  return json.data ?? [];
+}
+
+async function mergePair(primaryId: string, duplicateId: string): Promise<void> {
+  const res = await fetchWithAuth(`${API_V1}/patients/${primaryId}/merge/${duplicateId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message ?? `Merge failed (${res.status})`);
+  }
+}
+
+function PatientCard({ patient }: { patient: PatientSummary }) {
+  return (
+    <div className="rounded border border-gray-200 p-3 text-sm">
+      <p className="font-semibold text-gray-900">
+        {patient.firstName} {patient.lastName}
+      </p>
+      <p className="text-gray-500 text-xs">{patient.systemId}</p>
+      <p className="text-gray-600">DOB: {patient.dateOfBirth}</p>
+      {patient.contactNumber && (
+        <p className="text-gray-600">Phone: {patient.contactNumber}</p>
+      )}
+      <Link
+        href={`/patients/${patient._id}`}
+        className="mt-1 inline-block text-blue-600 hover:underline text-xs"
+        target="_blank"
+      >
+        View record ↗
+      </Link>
+    </div>
+  );
+}
+
+export default function DuplicatesClient() {
+  const qc = useQueryClient();
+  const [minConfidence, setMinConfidence] = useState(60);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [mergeError, setMergeError] = useState<string | null>(null);
+
+  const { data: pairs = [], isLoading, error, refetch } = useQuery({
+    queryKey: ['potential-duplicates', minConfidence],
+    queryFn: () => fetchPairs(minConfidence),
+  });
+
+  const { mutate: doMerge, isPending: merging } = useMutation({
+    mutationFn: ({ primaryId, dupId }: { primaryId: string; dupId: string }) =>
+      mergePair(primaryId, dupId),
+    onSuccess: () => {
+      setMergeError(null);
+      qc.invalidateQueries({ queryKey: ['potential-duplicates'] });
+    },
+    onError: (e: Error) => setMergeError(e.message),
+  });
+
+  const visible = pairs.filter(
+    (p) => !dismissed.has(`${p.patientA._id}-${p.patientB._id}`)
+  );
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Potential Duplicate Patients</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Review and resolve duplicate patient records. Merging keeps the primary record and
+            redirects the duplicate.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="min-confidence" className="text-sm text-gray-600 whitespace-nowrap">
+            Min confidence:
+          </label>
+          <select
+            id="min-confidence"
+            value={minConfidence}
+            onChange={(e) => setMinConfidence(Number(e.target.value))}
+            className="rounded border border-gray-300 px-2 py-1 text-sm"
+          >
+            {[50, 60, 70, 80, 90].map((v) => (
+              <option key={v} value={v}>{v}%</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {mergeError && (
+        <div role="alert" className="mb-4 rounded bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {mergeError}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex justify-center py-16"><Spinner /></div>
+      ) : error ? (
+        <div className="rounded bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          Failed to load duplicates.{' '}
+          <button onClick={() => refetch()} className="underline">Retry</button>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="rounded border border-gray-200 bg-gray-50 px-6 py-12 text-center text-gray-500">
+          No potential duplicates found at {minConfidence}% confidence threshold.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-500">{visible.length} pair(s) found</p>
+          {visible.map((pair) => {
+            const key = `${pair.patientA._id}-${pair.patientB._id}`;
+            return (
+              <div
+                key={key}
+                className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <Badge variant={confidenceVariant(pair.confidence)}>
+                    {pair.confidence}% confidence
+                  </Badge>
+                  <span className="text-xs text-gray-400">
+                    {pair.matchReasons.join(' · ')}
+                  </span>
+                </div>
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+                      Patient A (keep as primary)
+                    </p>
+                    <PatientCard patient={pair.patientA} />
+                  </div>
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+                      Patient B (will be merged)
+                    </p>
+                    <PatientCard patient={pair.patientB} />
+                  </div>
+                </div>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={merging}
+                    onClick={() =>
+                      doMerge({ primaryId: pair.patientA._id, dupId: pair.patientB._id })
+                    }
+                  >
+                    Merge B → A
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={merging}
+                    onClick={() =>
+                      doMerge({ primaryId: pair.patientB._id, dupId: pair.patientA._id })
+                    }
+                  >
+                    Merge A → B
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setDismissed((prev) => new Set([...prev, key]))}
+                  >
+                    Dismiss
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/patients/duplicates/page.tsx
+++ b/apps/web/src/app/patients/duplicates/page.tsx
@@ -1,0 +1,7 @@
+import DuplicatesClient from './DuplicatesClient';
+
+export const metadata = { title: 'Potential Duplicate Patients' };
+
+export default function DuplicatesPage() {
+  return <DuplicatesClient />;
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -54,5 +54,20 @@ export async function fetchWithAuth(url: string, options: RequestInit = {}): Pro
     }
   }
 
+  if (res.status === 429) {
+    const retryAfter = res.headers.get('Retry-After');
+    const body = await res.json().catch(() => ({}));
+    const message = body.message ?? 'Too many requests. Please slow down and try again.';
+    const detail = retryAfter ? ` Retry after ${retryAfter}s.` : '';
+    throw new RateLimitError(message + detail, retryAfter ? Number(retryAfter) : undefined);
+  }
+
   return res;
+}
+
+export class RateLimitError extends Error {
+  constructor(message: string, public readonly retryAfterSeconds?: number) {
+    super(message);
+    this.name = 'RateLimitError';
+  }
 }


### PR DESCRIPTION
## Summary

Implements four enhancements across the API and frontend.

## Changes

### #641 — Patient Duplicate Detection Improvements
- Replaced basic Levenshtein matching with **Jaro-Winkler similarity** for better typo/variation detection (e.g. "John" vs "Jon", "Smith" vs "Smyth")
- Added **DOB ±1 day** fuzzy matching to catch data entry errors
- Added **phone number normalization** before comparison
- Added **weighted confidence scores** (name 60%, DOB 30%, phone 10%)
- New `GET /api/v1/patients/potential-duplicates` endpoint (CLINIC_ADMIN only) returning ranked pairs
- New `/patients/duplicates` bulk review UI — admins can confirm merges or dismiss pairs
- Unit tests for `jaroWinkler`, `soundex`, `normalizePhone`, `checkDuplicates`, `findPotentialDuplicates`

### #640 — Comprehensive API Rate Limiting Per User Role
- Added per-user limiters keyed by `userId` (independent of IP):
  - `bulkExportLimiter`: 5 req/hour on patient and clinic export endpoints
  - `patientSearchLimiter`: 100 req/min on `/api/v1/patients/search`
  - `reportGenerationLimiter`: 10 req/hour on `/api/v1/reports`
- `fetchWithAuth` now throws `RateLimitError` on 429 with retry-after duration for graceful frontend handling

### #639 — Real-time Vital Signs Monitoring Dashboard
- Already implemented: `GET /api/v1/patients/:id/vitals` (time-series), `GET /api/v1/patients/:id/analytics` (trends), `VitalSignsCharts` frontend component

### #638 — Clinic Onboarding Wizard
- Already implemented: 5-step wizard at `/onboarding`, `GET /onboarding/status`, `PUT /onboarding/step/:step`, `onboardingCompleted` flag on `ClinicModel`

## Testing
- Unit tests added for all fuzzy matching algorithms
- Rate limit middleware exports are typed and wired into existing route registration
Closes #638 
Closes #639 
Closes #640 
Closes #641 