### PR TITLE
feat: add localized emails, patient summaries, and security header ch…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,15 @@ jobs:
           NODE_ENV: test
           API_PORT: 3001
 
+      - name: Verify API security headers
+        run: npm test --workspace=api -- --runInBand src/__tests__/security-headers.test.ts
+        env:
+          JWT_ACCESS_TOKEN_SECRET: test-access-secret-32-chars-long!!
+          JWT_REFRESH_TOKEN_SECRET: test-refresh-secret-32-chars-long!
+          STELLAR_NETWORK: testnet
+          NODE_ENV: test
+          API_PORT: 3001
+
       - name: Generate coverage report
         run: npm run test:coverage --workspace=api
         continue-on-error: true

--- a/apps/api/docs/security-headers.md
+++ b/apps/api/docs/security-headers.md
@@ -33,3 +33,13 @@ frame-ancestors 'none'
 ## Body Size Limit
 
 `express.json()` is configured with a size limit (default `50kb`, overridable via `MAX_REQUEST_BODY_SIZE`) to prevent payload-based DoS attacks. AI routes use a separate higher limit (`500kb`, overridable via `AI_REQUEST_BODY_SIZE`) to accommodate summarization payloads.
+
+## Automated Testing
+
+- API coverage: [apps/api/src/__tests__/security-headers.test.ts](../src/__tests__/security-headers.test.ts)
+- Frontend E2E coverage: [apps/web/e2e/security-headers.spec.ts](../../web/e2e/security-headers.spec.ts)
+- CI runs the API header check explicitly as part of the API test job.
+
+## Prometheus Metric
+
+The API exposes `security_header_violations_total` for responses that are missing a required security header. The metric is labeled by header name and normalized route path.

--- a/apps/api/src/__tests__/security-headers.test.ts
+++ b/apps/api/src/__tests__/security-headers.test.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import app from '../app';
+
+describe('Security headers', () => {
+  it('sets Helmet security headers on API responses', async () => {
+    const response = await request(app).get('/health');
+
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['x-frame-options']).toBe('DENY');
+    expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    expect(response.headers['strict-transport-security']).toContain('max-age=31536000');
+    expect(response.headers['strict-transport-security']).toContain('includeSubDomains');
+    expect(response.headers['content-security-policy']).toContain("default-src 'self'");
+    expect(response.headers['content-security-policy']).toContain("frame-ancestors 'none'");
+    expect(response.headers['x-powered-by']).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/email.service.ts
+++ b/apps/api/src/lib/email.service.ts
@@ -18,6 +18,153 @@ const transporter = nodemailer.createTransport({
 
 const APP_BASE_URL = () => process.env.APP_BASE_URL || 'http://localhost:3000';
 
+type EmailLanguage = 'en' | 'fr';
+
+type EmailContent = {
+  subject: string;
+  text: string;
+  html: string;
+};
+
+type EmailRenderer = (...args: any[]) => EmailContent;
+
+const emailPlugins = new Map<string, Record<string, EmailRenderer>>();
+
+export function registerEmailTemplatePlugin(language: string, templates: Record<string, EmailRenderer>): void {
+  emailPlugins.set(language.toLowerCase(), templates);
+}
+
+function resolveLanguage(language?: string): EmailLanguage {
+  return language?.toLowerCase().startsWith('fr') ? 'fr' : 'en';
+}
+
+function renderTemplate(
+  key: string,
+  language: string | undefined,
+  fallback: EmailRenderer,
+  ...args: any[]
+): EmailContent {
+  const locale = resolveLanguage(language);
+  const plugin = emailPlugins.get(locale)?.[key];
+  return plugin ? plugin(...args) : fallback(...args);
+}
+
+function buildVerificationEmail(token: string, language?: string): EmailContent {
+  const verifyUrl = `${APP_BASE_URL()}/verify-email?token=${token}`;
+  if (resolveLanguage(language) === 'fr') {
+    return {
+      subject: 'Vérifiez votre adresse e-mail',
+      text: `Bonjour,\n\nVeuillez vérifier votre adresse e-mail en utilisant le lien suivant : ${verifyUrl}`,
+      html: `<h3>Vérification de l'adresse e-mail</h3><p>Veuillez vérifier votre adresse e-mail en cliquant sur le lien ci-dessous :</p><p><a href="${verifyUrl}">Vérifier mon adresse e-mail</a></p>`,
+    };
+  }
+
+  return {
+    subject: 'Verify your email address',
+    text: `Please verify your email address using the following link: ${verifyUrl}`,
+    html: `<h3>Email Verification</h3><p>Please verify your email address by clicking the link below:</p><p><a href="${verifyUrl}">Verify Email Address</a></p>`,
+  };
+}
+
+function buildWelcomeEmail(name: string, language?: string): EmailContent {
+  if (resolveLanguage(language) === 'fr') {
+    return {
+      subject: 'Bienvenue chez Health Watchers',
+      text: `Bonjour ${name},\n\nBienvenue chez Health Watchers ! Votre compte a été créé avec succès.`,
+      html: `<h3>Bienvenue chez Health Watchers</h3><p>Bonjour <strong>${name}</strong>,</p><p>Votre compte a été créé avec succès. Vous pouvez maintenant vous connecter au portail.</p>`,
+    };
+  }
+
+  return {
+    subject: 'Welcome to Health Watchers',
+    text: `Hi ${name},\n\nWelcome to Health Watchers! Your account has been successfully created.`,
+    html: `<h3>Welcome to Health Watchers</h3><p>Hi <strong>${name}</strong>,</p><p>Your account has been successfully created. You can now log in to the portal.</p>`,
+  };
+}
+
+function buildPasswordResetEmail(token: string, language?: string): EmailContent {
+  const resetUrl = `${APP_BASE_URL()}/reset-password?token=${token}`;
+  if (resolveLanguage(language) === 'fr') {
+    return {
+      subject: 'Demande de réinitialisation du mot de passe',
+      text: `Vous avez demandé la réinitialisation de votre mot de passe. Utilisez le lien suivant : ${resetUrl}`,
+      html: `<h3>Réinitialisation du mot de passe</h3><p>Vous avez demandé la réinitialisation de votre mot de passe. Cliquez sur le lien ci-dessous pour définir un nouveau mot de passe :</p><p><a href="${resetUrl}">Réinitialiser le mot de passe</a></p><p>Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail en toute sécurité.</p>`,
+    };
+  }
+
+  return {
+    subject: 'Password Reset Request',
+    text: `You requested a password reset. Please use the following link: ${resetUrl}`,
+    html: `<h3>Password Reset</h3><p>You requested a password reset. Please click the link below to set a new password:</p><p><a href="${resetUrl}">Reset Password</a></p><p>If you didn't request this, you can safely ignore this email.</p>`,
+  };
+}
+
+function buildAppointmentReminderEmail(
+  patientName: string,
+  date: Date,
+  doctorName: string,
+  language?: string
+): EmailContent {
+  const locale = resolveLanguage(language);
+  const dateStr = date.toLocaleString(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    dateStyle: 'full',
+    timeStyle: 'short',
+  });
+
+  if (locale === 'fr') {
+    return {
+      subject: 'Rappel de rendez-vous',
+      text: `Ceci est un rappel pour votre rendez-vous avec le Dr ${doctorName} le ${dateStr} pour le patient ${patientName}.`,
+      html: `<h3>Rappel de rendez-vous</h3><p>Voici un rappel pour votre prochain rendez-vous :</p><ul><li><strong>Médecin :</strong> Dr ${doctorName}</li><li><strong>Patient :</strong> ${patientName}</li><li><strong>Heure :</strong> ${dateStr}</li></ul>`,
+    };
+  }
+
+  return {
+    subject: 'Appointment Reminder',
+    text: `This is a reminder for your appointment with Dr. ${doctorName} on ${dateStr} for patient ${patientName}.`,
+    html: `<h3>Appointment Reminder</h3><p>This is a reminder for your upcoming appointment:</p><ul><li><strong>Doctor:</strong> Dr. ${doctorName}</li><li><strong>Patient:</strong> ${patientName}</li><li><strong>Time:</strong> ${dateStr}</li></ul>`,
+  };
+}
+
+function buildPaymentConfirmationEmail(
+  amount: string,
+  assetCode: string,
+  txHash: string,
+  language?: string
+): EmailContent {
+  const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+  if (resolveLanguage(language) === 'fr') {
+    return {
+      subject: `Paiement confirmé — ${amount} ${assetCode}`,
+      text: `Votre paiement de ${amount} ${assetCode} a été confirmé.\n\nTransaction : ${txHash}\nVoir sur l'explorateur : ${explorerUrl}`,
+      html: `<h3>Paiement confirmé</h3><p>Votre paiement de <strong>${amount} ${assetCode}</strong> a été confirmé sur le réseau Stellar.</p><p><strong>Hachage de transaction :</strong> <code>${txHash}</code></p><p><a href="${explorerUrl}">Voir sur Stellar Explorer</a></p>`,
+    };
+  }
+
+  return {
+    subject: `Payment Confirmed — ${amount} ${assetCode}`,
+    text: `Your payment of ${amount} ${assetCode} has been confirmed.\n\nTransaction: ${txHash}\nView on explorer: ${explorerUrl}`,
+    html: `<h3>Payment Confirmed</h3><p>Your payment of <strong>${amount} ${assetCode}</strong> has been confirmed on the Stellar network.</p><p><strong>Transaction hash:</strong> <code>${txHash}</code></p><p><a href="${explorerUrl}">View on Stellar Explorer</a></p>`,
+  };
+}
+
+function buildAiSummaryReadyEmail(patientName: string, encounterId: string, language?: string): EmailContent {
+  const encounterUrl = `${APP_BASE_URL()}/encounters/${encounterId}`;
+  if (resolveLanguage(language) === 'fr') {
+    return {
+      subject: 'Résumé clinique IA prêt — Health Watchers',
+      text: `Le résumé clinique IA pour la rencontre de ${patientName} est prêt.\n\nVoir ici : ${encounterUrl}`,
+      html: `<h3>Résumé clinique IA prêt</h3><p>Le résumé clinique généré par l'IA pour la rencontre de <strong>${patientName}</strong> est maintenant disponible.</p><p><a href="${encounterUrl}">Voir le résumé de la rencontre</a></p>`,
+    };
+  }
+
+  return {
+    subject: 'AI Clinical Summary Ready — Health Watchers',
+    text: `The AI clinical summary for ${patientName}'s encounter is ready.\n\nView it here: ${encounterUrl}`,
+    html: `<h3>AI Clinical Summary Ready</h3><p>The AI-generated clinical summary for <strong>${patientName}</strong>'s encounter is now available.</p><p><a href="${encounterUrl}">View Encounter Summary</a></p>`,
+  };
+}
+
 /**
  * Enqueue an email to be sent.
  * Currently sends synchronously, but could be moved to a background job queue (e.g. BullMQ).
@@ -39,45 +186,44 @@ export async function enqueue(to: string, subject: string, text: string, html?: 
   }
 }
 
-export function sendWelcomeEmail(to: string, name: string): void {
-  const subject = 'Welcome to Health Watchers';
-  const text = `Hi ${name},\n\nWelcome to Health Watchers! Your account has been successfully created.`;
-  const html = `<h3>Welcome to Health Watchers</h3><p>Hi <strong>${name}</strong>,</p><p>Your account has been successfully created. You can now log in to the portal.</p>`;
-  enqueue(to, subject, text, html);
+export const sendMail = enqueue;
+
+export function sendVerificationEmail(to: string, token: string, language?: string): void {
+  const rendered = renderTemplate('verification', language, buildVerificationEmail, token, language);
+  enqueue(to, rendered.subject, rendered.text, rendered.html);
 }
 
-export function sendPasswordResetEmail(to: string, token: string) {
-  const resetUrl = `${APP_BASE_URL()}/reset-password?token=${token}`;
-  const subject = 'Password Reset Request';
-  const text = `You requested a password reset. Please use the following link: ${resetUrl}`;
-  const html = `<h3>Password Reset</h3><p>You requested a password reset. Please click the link below to set a new password:</p><p><a href="${resetUrl}">Reset Password</a></p><p>If you didn't request this, you can safely ignore this email.</p>`;
-  enqueue(to, subject, text, html);
+export function sendWelcomeEmail(to: string, name: string, language?: string): void {
+  const rendered = renderTemplate('welcome', language, buildWelcomeEmail, name, language);
+  enqueue(to, rendered.subject, rendered.text, rendered.html);
+}
+
+export function sendPasswordResetEmail(to: string, token: string, language?: string) {
+  const rendered = renderTemplate('passwordReset', language, buildPasswordResetEmail, token, language);
+  enqueue(to, rendered.subject, rendered.text, rendered.html);
 }
 
 export function sendAppointmentReminderEmail(
   to: string,
   patientName: string,
   date: Date,
-  doctorName: string
+  doctorName: string,
+  language?: string
 ): void {
-  const dateStr = date.toLocaleString('en-US', { dateStyle: 'full', timeStyle: 'short' });
-  const subject = 'Appointment Reminder';
-  const text = `This is a reminder for your appointment with Dr. ${doctorName} on ${dateStr} for patient ${patientName}.`;
-  const html = `<h3>Appointment Reminder</h3><p>This is a reminder for your upcoming appointment:</p><ul><li><strong>Doctor:</strong> Dr. ${doctorName}</li><li><strong>Patient:</strong> ${patientName}</li><li><strong>Time:</strong> ${dateStr}</li></ul>`;
-  enqueue(to, subject, text, html);
+  const rendered = renderTemplate('appointmentReminder', language, buildAppointmentReminderEmail, patientName, date, doctorName, language);
+  enqueue(to, rendered.subject, rendered.text, rendered.html);
 }
 
 /** Payment confirmation email sent when Stellar transaction confirms */
-export function sendPaymentConfirmationEmail(to: string, amount: string, assetCode: string, txHash: string): void {
-  const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${txHash}`;
-  const text = `Your payment of ${amount} ${assetCode} has been confirmed.\n\nTransaction: ${txHash}\nView on explorer: ${explorerUrl}`;
-  const html = `
-    <h3>Payment Confirmed</h3>
-    <p>Your payment of <strong>${amount} ${assetCode}</strong> has been confirmed on the Stellar network.</p>
-    <p><strong>Transaction hash:</strong> <code>${txHash}</code></p>
-    <p><a href="${explorerUrl}">View on Stellar Explorer</a></p>
-  `;
-  enqueue(to, `Payment Confirmed — ${amount} ${assetCode}`, text, html);
+export function sendPaymentConfirmationEmail(
+  to: string,
+  amount: string,
+  assetCode: string,
+  txHash: string,
+  language?: string
+): void {
+  const rendered = renderTemplate('paymentConfirmation', language, buildPaymentConfirmationEmail, amount, assetCode, txHash, language);
+  enqueue(to, rendered.subject, rendered.text, rendered.html);
 }
 
 /** Invoice email sent to patient with QR code and payment link */
@@ -90,84 +236,91 @@ export function sendInvoiceEmail(
     dueDate: Date;
     stellarPayURI: string;
     qrCodeDataUrl: string;
-  }
+  },
+  language?: string
 ): void {
-  const dueDateStr = invoice.dueDate.toLocaleDateString('en-US', {
+  const isFrench = resolveLanguage(language) === 'fr';
+  const dueDateStr = invoice.dueDate.toLocaleDateString(isFrench ? 'fr-FR' : 'en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   });
-  const text = `Invoice ${invoice.invoiceNumber}\n\nAmount due: ${invoice.total} ${invoice.currency}\nDue date: ${dueDateStr}\n\nPay via Stellar: ${invoice.stellarPayURI}`;
-  const html = `
-    <h2>Invoice ${invoice.invoiceNumber}</h2>
-    <p><strong>Amount due:</strong> ${invoice.total} ${invoice.currency}</p>
-    <p><strong>Due date:</strong> ${dueDateStr}</p>
-    <p><a href="${invoice.stellarPayURI}">Pay with Stellar Wallet</a></p>
-    <p>Or scan the QR code below:</p>
-    <img src="${invoice.qrCodeDataUrl}" alt="Stellar payment QR code" width="200" height="200" />
-  `;
-  enqueue(to, `Invoice ${invoice.invoiceNumber} — Health Watchers`, text, html);
+  const subject = isFrench
+    ? `Facture ${invoice.invoiceNumber} — Health Watchers`
+    : `Invoice ${invoice.invoiceNumber} — Health Watchers`;
+  const text = isFrench
+    ? `Facture ${invoice.invoiceNumber}\n\nMontant dû : ${invoice.total} ${invoice.currency}\nDate d'échéance : ${dueDateStr}\n\nPaiement via Stellar : ${invoice.stellarPayURI}`
+    : `Invoice ${invoice.invoiceNumber}\n\nAmount due: ${invoice.total} ${invoice.currency}\nDue date: ${dueDateStr}\n\nPay via Stellar: ${invoice.stellarPayURI}`;
+  const html = isFrench
+    ? `<h2>Facture ${invoice.invoiceNumber}</h2><p><strong>Montant dû :</strong> ${invoice.total} ${invoice.currency}</p><p><strong>Date d'échéance :</strong> ${dueDateStr}</p><p><a href="${invoice.stellarPayURI}">Payer avec Stellar Wallet</a></p><p>Ou scannez le code QR ci-dessous :</p><img src="${invoice.qrCodeDataUrl}" alt="Code QR de paiement Stellar" width="200" height="200" />`
+    : `<h2>Invoice ${invoice.invoiceNumber}</h2><p><strong>Amount due:</strong> ${invoice.total} ${invoice.currency}</p><p><strong>Due date:</strong> ${dueDateStr}</p><p><a href="${invoice.stellarPayURI}">Pay with Stellar Wallet</a></p><p>Or scan the QR code below:</p><img src="${invoice.qrCodeDataUrl}" alt="Stellar payment QR code" width="200" height="200" />`;
+  enqueue(to, subject, text, html);
 }
 
 /** Referral notification sent to receiving clinic admin */
 export function sendReferralNotificationEmail(
   to: string,
   adminName: string,
-  referral: { patientName: string; urgency: string; reason: string; referralId: string }
+  referral: { patientName: string; urgency: string; reason: string; referralId: string },
+  language?: string
 ): void {
   const referralUrl = `${APP_BASE_URL()}/referrals/incoming`;
   const urgencyLabel = referral.urgency.toUpperCase();
-  const text = `A new ${urgencyLabel} referral has been received for patient ${referral.patientName}.\n\nReason: ${referral.reason}\n\nView referral: ${referralUrl}`;
-  const html = `
-    <h3>New Patient Referral Received</h3>
-    <p>Hello ${adminName},</p>
-    <p>A new <strong>${urgencyLabel}</strong> referral has been received for patient <strong>${referral.patientName}</strong>.</p>
-    <p><strong>Reason:</strong> ${referral.reason}</p>
-    <p><a href="${referralUrl}">View Incoming Referrals</a></p>
-  `;
-  enqueue(to, `New ${urgencyLabel} Referral — Health Watchers`, text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench
+    ? `Nouvelle orientation ${urgencyLabel} — Health Watchers`
+    : `New ${urgencyLabel} Referral — Health Watchers`;
+  const text = isFrench
+    ? `Une nouvelle orientation ${urgencyLabel} a été reçue pour le patient ${referral.patientName}.\n\nMotif : ${referral.reason}\n\nVoir l'orientation : ${referralUrl}`
+    : `A new ${urgencyLabel} referral has been received for patient ${referral.patientName}.\n\nReason: ${referral.reason}\n\nView referral: ${referralUrl}`;
+  const html = isFrench
+    ? `<h3>Nouvelle orientation de patient reçue</h3><p>Bonjour ${adminName},</p><p>Une nouvelle orientation <strong>${urgencyLabel}</strong> a été reçue pour le patient <strong>${referral.patientName}</strong>.</p><p><strong>Motif :</strong> ${referral.reason}</p><p><a href="${referralUrl}">Voir les orientations entrantes</a></p>`
+    : `<h3>New Patient Referral Received</h3><p>Hello ${adminName},</p><p>A new <strong>${urgencyLabel}</strong> referral has been received for patient <strong>${referral.patientName}</strong>.</p><p><strong>Reason:</strong> ${referral.reason}</p><p><a href="${referralUrl}">View Incoming Referrals</a></p>`;
+  enqueue(to, subject, text, html);
 }
 
 /** AI summary ready notification sent when clinical summary is generated */
-export function sendAiSummaryReadyEmail(to: string, patientName: string, encounterId: string): void {
-  const encounterUrl = `${APP_BASE_URL()}/encounters/${encounterId}`;
-  const text = `The AI clinical summary for ${patientName}'s encounter is ready.\n\nView it here: ${encounterUrl}`;
-  const html = `
-    <h3>AI Clinical Summary Ready</h3>
-    <p>The AI-generated clinical summary for <strong>${patientName}</strong>'s encounter is now available.</p>
-    <p><a href="${encounterUrl}">View Encounter Summary</a></p>
-  `;
-  enqueue(to, 'AI Clinical Summary Ready — Health Watchers', text, html);
+export function sendAiSummaryReadyEmail(to: string, patientName: string, encounterId: string, language?: string): void {
+  const rendered = renderTemplate('aiSummaryReady', language, buildAiSummaryReadyEmail, patientName, encounterId, language);
+  enqueue(to, rendered.subject, rendered.text, rendered.html);
 }
 
 /** @deprecated Use sendAiSummaryReadyEmail instead */
-export function sendAISummaryNotification(to: string, patientName: string, encounterId: string): void {
-  sendAiSummaryReadyEmail(to, patientName, encounterId);
+export function sendAISummaryNotification(to: string, patientName: string, encounterId: string, language?: string): void {
+  sendAiSummaryReadyEmail(to, patientName, encounterId, language);
 }
 
 /** Dispute opened notification sent to clinic admin */
-export function sendDisputeOpenedEmail(to: string, disputeId: string, paymentIntentId: string, reason: string): void {
+export function sendDisputeOpenedEmail(to: string, disputeId: string, paymentIntentId: string, reason: string, language?: string): void {
   const disputeUrl = `${APP_BASE_URL()}/disputes`;
-  const text = `A new payment dispute has been opened.\n\nDispute ID: ${disputeId}\nPayment: ${paymentIntentId}\nReason: ${reason}\n\nView disputes: ${disputeUrl}`;
-  const html = `
-    <h3>Payment Dispute Opened</h3>
-    <p>A new dispute has been opened for payment <strong>${paymentIntentId}</strong>.</p>
-    <p><strong>Reason:</strong> ${reason.replace(/_/g, ' ')}</p>
-    <p><a href="${disputeUrl}">View Disputes</a></p>
-  `;
-  enqueue(to, 'Payment Dispute Opened — Health Watchers', text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? 'Litige de paiement ouvert — Health Watchers' : 'Payment Dispute Opened — Health Watchers';
+  const text = isFrench
+    ? `Un nouveau litige de paiement a été ouvert.\n\nID du litige : ${disputeId}\nPaiement : ${paymentIntentId}\nMotif : ${reason}\n\nVoir les litiges : ${disputeUrl}`
+    : `A new payment dispute has been opened.\n\nDispute ID: ${disputeId}\nPayment: ${paymentIntentId}\nReason: ${reason}\n\nView disputes: ${disputeUrl}`;
+  const html = isFrench
+    ? `<h3>Litige de paiement ouvert</h3><p>Un nouveau litige a été ouvert pour le paiement <strong>${paymentIntentId}</strong>.</p><p><strong>Motif :</strong> ${reason.replace(/_/g, ' ')}</p><p><a href="${disputeUrl}">Voir les litiges</a></p>`
+    : `<h3>Payment Dispute Opened</h3><p>A new dispute has been opened for payment <strong>${paymentIntentId}</strong>.</p><p><strong>Reason:</strong> ${reason.replace(/_/g, ' ')}</p><p><a href="${disputeUrl}">View Disputes</a></p>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Dispute resolved notification */
-export function sendDisputeResolvedEmail(to: string, disputeId: string, status: string, resolutionNotes?: string): void {
-  const text = `Dispute ${disputeId} has been resolved with status: ${status}.${resolutionNotes ? `\n\nNotes: ${resolutionNotes}` : ''}`;
-  const html = `
-    <h3>Payment Dispute Resolved</h3>
-    <p>Dispute <strong>${disputeId}</strong> has been resolved.</p>
-    <p><strong>Status:</strong> ${status.replace(/_/g, ' ')}</p>
-    ${resolutionNotes ? `<p><strong>Notes:</strong> ${resolutionNotes}</p>` : ''}
-  `;
-  enqueue(to, 'Payment Dispute Resolved — Health Watchers', text, html);
+export function sendDisputeResolvedEmail(
+  to: string,
+  disputeId: string,
+  status: string,
+  resolutionNotes?: string,
+  language?: string
+): void {
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? 'Litige de paiement résolu — Health Watchers' : 'Payment Dispute Resolved — Health Watchers';
+  const text = isFrench
+    ? `Le litige ${disputeId} a été résolu avec le statut : ${status}.${resolutionNotes ? `\n\nNotes : ${resolutionNotes}` : ''}`
+    : `Dispute ${disputeId} has been resolved with status: ${status}.${resolutionNotes ? `\n\nNotes: ${resolutionNotes}` : ''}`;
+  const html = isFrench
+    ? `<h3>Litige de paiement résolu</h3><p>Le litige <strong>${disputeId}</strong> a été résolu.</p><p><strong>Statut :</strong> ${status.replace(/_/g, ' ')}</p>${resolutionNotes ? `<p><strong>Notes :</strong> ${resolutionNotes}</p>` : ''}`
+    : `<h3>Payment Dispute Resolved</h3><p>Dispute <strong>${disputeId}</strong> has been resolved.</p><p><strong>Status:</strong> ${status.replace(/_/g, ' ')}</p>${resolutionNotes ? `<p><strong>Notes:</strong> ${resolutionNotes}</p>` : ''}`;
+  enqueue(to, subject, text, html);
 }
 
 /** Low balance warning sent when XLM balance drops below the warning threshold */
@@ -175,23 +328,19 @@ export function sendLowBalanceWarningEmail(
   to: string,
   clinicName: string,
   xlmBalance: string,
-  threshold: number
+  threshold: number,
+  language?: string
 ): void {
   const walletUrl = `${APP_BASE_URL()}/wallet`;
-  const text = `Warning: Your clinic's Stellar account balance (${xlmBalance} XLM) has dropped below the warning threshold of ${threshold} XLM.\n\nPlease top up your account to avoid payment failures.\n\nManage wallet: ${walletUrl}`;
-  const html = `
-    <h3>⚠️ Low Balance Warning — ${clinicName}</h3>
-    <p>Your clinic's Stellar account balance has dropped below the warning threshold.</p>
-    <table style="border-collapse:collapse;width:100%;margin:16px 0">
-      <tr><td style="padding:8px;font-weight:bold">Current Balance</td><td style="padding:8px;color:#d97706">${xlmBalance} XLM</td></tr>
-      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Warning Threshold</td><td style="padding:8px">${threshold} XLM</td></tr>
-    </table>
-    <p>Please top up your account to avoid payment failures.</p>
-    <p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Manage Wallet</a></p>
-    <hr style="margin-top:32px">
-    <small style="color:#6b7280">Health Watchers</small>
-  `;
-  enqueue(to, `⚠️ Low Balance Warning — ${clinicName}`, text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? `Alerte de solde faible — ${clinicName}` : `⚠️ Low Balance Warning — ${clinicName}`;
+  const text = isFrench
+    ? `Avertissement : le solde de votre compte Stellar (${xlmBalance} XLM) est passé sous le seuil d'alerte de ${threshold} XLM.\n\nVeuillez recharger votre compte pour éviter les échecs de paiement.\n\nGérer le portefeuille : ${walletUrl}`
+    : `Warning: Your clinic's Stellar account balance (${xlmBalance} XLM) has dropped below the warning threshold of ${threshold} XLM.\n\nPlease top up your account to avoid payment failures.\n\nManage wallet: ${walletUrl}`;
+  const html = isFrench
+    ? `<h3>⚠️ Alerte de solde faible — ${clinicName}</h3><p>Le solde de votre compte Stellar est passé sous le seuil d'alerte.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Solde actuel</td><td style="padding:8px;color:#d97706">${xlmBalance} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Seuil d'alerte</td><td style="padding:8px">${threshold} XLM</td></tr></table><p>Veuillez recharger votre compte pour éviter les échecs de paiement.</p><p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Gérer le portefeuille</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`
+    : `<h3>⚠️ Low Balance Warning — ${clinicName}</h3><p>Your clinic's Stellar account balance has dropped below the warning threshold.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Current Balance</td><td style="padding:8px;color:#d97706">${xlmBalance} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Warning Threshold</td><td style="padding:8px">${threshold} XLM</td></tr></table><p>Please top up your account to avoid payment failures.</p><p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Manage Wallet</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Critical balance alert sent when XLM balance drops below the critical threshold */
@@ -199,22 +348,19 @@ export function sendCriticalBalanceEmail(
   to: string,
   clinicName: string,
   xlmBalance: string,
-  threshold: number
+  threshold: number,
+  language?: string
 ): void {
   const walletUrl = `${APP_BASE_URL()}/wallet`;
-  const text = `CRITICAL: Your clinic's Stellar account balance (${xlmBalance} XLM) is critically low (below ${threshold} XLM). Payments may fail immediately.\n\nManage wallet: ${walletUrl}`;
-  const html = `
-    <h3>🚨 Critical Balance Alert — ${clinicName}</h3>
-    <p><strong>Your clinic's Stellar account balance is critically low. Payments may fail immediately.</strong></p>
-    <table style="border-collapse:collapse;width:100%;margin:16px 0">
-      <tr><td style="padding:8px;font-weight:bold">Current Balance</td><td style="padding:8px;color:#dc2626">${xlmBalance} XLM</td></tr>
-      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Critical Threshold</td><td style="padding:8px">${threshold} XLM</td></tr>
-    </table>
-    <p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px">Top Up Now</a></p>
-    <hr style="margin-top:32px">
-    <small style="color:#6b7280">Health Watchers</small>
-  `;
-  enqueue(to, `🚨 Critical Balance Alert — ${clinicName}`, text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? `Alerte critique de solde — ${clinicName}` : `🚨 Critical Balance Alert — ${clinicName}`;
+  const text = isFrench
+    ? `CRITIQUE : le solde de votre compte Stellar (${xlmBalance} XLM) est très faible (en dessous de ${threshold} XLM). Les paiements peuvent échouer immédiatement.\n\nGérer le portefeuille : ${walletUrl}`
+    : `CRITICAL: Your clinic's Stellar account balance (${xlmBalance} XLM) is critically low (below ${threshold} XLM). Payments may fail immediately.\n\nManage wallet: ${walletUrl}`;
+  const html = isFrench
+    ? `<h3>🚨 Alerte critique de solde — ${clinicName}</h3><p><strong>Le solde de votre compte Stellar est très faible. Les paiements peuvent échouer immédiatement.</strong></p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Solde actuel</td><td style="padding:8px;color:#dc2626">${xlmBalance} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Seuil critique</td><td style="padding:8px">${threshold} XLM</td></tr></table><p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px">Recharger maintenant</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`
+    : `<h3>🚨 Critical Balance Alert — ${clinicName}</h3><p><strong>Your clinic's Stellar account balance is critically low. Payments may fail immediately.</strong></p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Current Balance</td><td style="padding:8px;color:#dc2626">${xlmBalance} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Critical Threshold</td><td style="padding:8px">${threshold} XLM</td></tr></table><p><a href="${walletUrl}" style="display:inline-block;padding:10px 20px;background:#dc2626;color:#fff;text-decoration:none;border-radius:6px">Top Up Now</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Large transaction alert sent when a transaction exceeds the configured threshold */
@@ -224,24 +370,20 @@ export function sendLargeTransactionEmail(
   amount: string,
   txHash: string,
   direction: 'incoming' | 'outgoing',
-  threshold: number
+  threshold: number,
+  language?: string
 ): void {
   const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${txHash}`;
   const walletUrl = `${APP_BASE_URL()}/wallet`;
-  const text = `A large ${direction} transaction of ${amount} XLM (threshold: ${threshold} XLM) was detected on your clinic's Stellar account.\n\nTransaction: ${txHash}\nView: ${explorerUrl}`;
-  const html = `
-    <h3>💸 Large Transaction Detected — ${clinicName}</h3>
-    <p>A large <strong>${direction}</strong> transaction was detected on your clinic's Stellar account.</p>
-    <table style="border-collapse:collapse;width:100%;margin:16px 0">
-      <tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr>
-      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Direction</td><td style="padding:8px;text-transform:capitalize">${direction}</td></tr>
-      <tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr>
-    </table>
-    <p><a href="${explorerUrl}">View on Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">View Wallet</a></p>
-    <hr style="margin-top:32px">
-    <small style="color:#6b7280">Health Watchers</small>
-  `;
-  enqueue(to, `💸 Large Transaction Detected — ${clinicName}`, text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? `Transaction importante détectée — ${clinicName}` : `💸 Large Transaction Detected — ${clinicName}`;
+  const text = isFrench
+    ? `Une transaction ${direction} importante de ${amount} XLM (seuil : ${threshold} XLM) a été détectée sur le compte Stellar de votre clinique.\n\nTransaction : ${txHash}\nVoir : ${explorerUrl}`
+    : `A large ${direction} transaction of ${amount} XLM (threshold: ${threshold} XLM) was detected on your clinic's Stellar account.\n\nTransaction: ${txHash}\nView: ${explorerUrl}`;
+  const html = isFrench
+    ? `<h3>💸 Transaction importante détectée — ${clinicName}</h3><p>Une transaction <strong>${direction}</strong> importante a été détectée sur le compte Stellar de votre clinique.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Montant</td><td style="padding:8px">${amount} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Direction</td><td style="padding:8px;text-transform:capitalize">${direction}</td></tr><tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr></table><p><a href="${explorerUrl}">Voir sur Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">Voir le portefeuille</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`
+    : `<h3>💸 Large Transaction Detected — ${clinicName}</h3><p>A large <strong>${direction}</strong> transaction was detected on your clinic's Stellar account.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Direction</td><td style="padding:8px;text-transform:capitalize">${direction}</td></tr><tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr></table><p><a href="${explorerUrl}">View on Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">View Wallet</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Unrecognized transaction alert sent when a transaction is not matched to a known payment intent */
@@ -250,97 +392,89 @@ export function sendUnrecognizedTransactionEmail(
   clinicName: string,
   amount: string,
   txHash: string,
-  from: string
+  from: string,
+  language?: string
 ): void {
   const explorerUrl = `https://stellar.expert/explorer/testnet/tx/${txHash}`;
   const walletUrl = `${APP_BASE_URL()}/wallet`;
-  const text = `An unrecognized transaction of ${amount} XLM from ${from} was detected on your clinic's Stellar account. This transaction was not initiated through Health Watchers.\n\nTransaction: ${txHash}\nView: ${explorerUrl}`;
-  const html = `
-    <h3>🔍 Unrecognized Transaction — ${clinicName}</h3>
-    <p>An unrecognized transaction was detected on your clinic's Stellar account. This transaction was <strong>not initiated through Health Watchers</strong>.</p>
-    <table style="border-collapse:collapse;width:100%;margin:16px 0">
-      <tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr>
-      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">From</td><td style="padding:8px;font-family:monospace;font-size:12px">${from}</td></tr>
-      <tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr>
-    </table>
-    <p>Please review this transaction and contact support if you did not authorize it.</p>
-    <p><a href="${explorerUrl}">View on Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">View Wallet</a></p>
-    <hr style="margin-top:32px">
-    <small style="color:#6b7280">Health Watchers</small>
-  `;
-  enqueue(to, `🔍 Unrecognized Transaction Detected — ${clinicName}`, text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? `Transaction non reconnue détectée — ${clinicName}` : `🔍 Unrecognized Transaction Detected — ${clinicName}`;
+  const text = isFrench
+    ? `Une transaction non reconnue de ${amount} XLM provenant de ${from} a été détectée sur le compte Stellar de votre clinique. Cette transaction n'a pas été initiée via Health Watchers.\n\nTransaction : ${txHash}\nVoir : ${explorerUrl}`
+    : `An unrecognized transaction of ${amount} XLM from ${from} was detected on your clinic's Stellar account. This transaction was not initiated through Health Watchers.\n\nTransaction: ${txHash}\nView: ${explorerUrl}`;
+  const html = isFrench
+    ? `<h3>🔍 Transaction non reconnue — ${clinicName}</h3><p>Une transaction non reconnue a été détectée sur le compte Stellar de votre clinique. Cette transaction <strong>n'a pas été initiée via Health Watchers</strong>.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Montant</td><td style="padding:8px">${amount} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Origine</td><td style="padding:8px;font-family:monospace;font-size:12px">${from}</td></tr><tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr></table><p>Veuillez examiner cette transaction et contacter le support si vous n'êtes pas à l'origine de celle-ci.</p><p><a href="${explorerUrl}">Voir sur Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">Voir le portefeuille</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`
+    : `<h3>🔍 Unrecognized Transaction — ${clinicName}</h3><p>An unrecognized transaction was detected on your clinic's Stellar account. This transaction was <strong>not initiated through Health Watchers</strong>.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">From</td><td style="padding:8px;font-family:monospace;font-size:12px">${from}</td></tr><tr><td style="padding:8px;font-weight:bold">Transaction</td><td style="padding:8px;font-family:monospace;font-size:12px">${txHash}</td></tr></table><p>Please review this transaction and contact support if you did not authorize it.</p><p><a href="${explorerUrl}">View on Stellar Explorer</a> &nbsp;|&nbsp; <a href="${walletUrl}">View Wallet</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`;
+  enqueue(to, subject, text, html);
 }
 
 
 /** Portal MFA enabled notification sent to patient */
-export function sendPortalMfaEnabledEmail(to: string, patientName: string, method: 'totp' | 'sms'): void {
+export function sendPortalMfaEnabledEmail(to: string, patientName: string, method: 'totp' | 'sms', language?: string): void {
   const methodLabel = method === 'totp' ? 'authenticator app' : 'SMS';
   const portalUrl = `${APP_BASE_URL()}/portal/settings/security`;
-  const text = `Two-factor authentication (${methodLabel}) has been enabled on your Health Watchers patient portal account.\n\nIf you did not enable this, please contact support immediately.\n\nManage security settings: ${portalUrl}`;
-  const html = `
-    <h3>Portal Two-Factor Authentication Enabled</h3>
-    <p>Hello <strong>${patientName}</strong>,</p>
-    <p>Two-factor authentication using <strong>${methodLabel}</strong> has been enabled on your Health Watchers patient portal account.</p>
-    <p>You will be required to provide a verification code when logging in to your portal.</p>
-    <p style="color:#dc2626"><strong>If you did not enable this, please contact support immediately.</strong></p>
-    <p><a href="${portalUrl}">Manage Security Settings</a></p>
-  `;
-  enqueue(to, 'Portal Two-Factor Authentication Enabled — Health Watchers', text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench
+    ? 'Authentification à deux facteurs activée — Health Watchers'
+    : 'Portal Two-Factor Authentication Enabled — Health Watchers';
+  const text = isFrench
+    ? `L'authentification à deux facteurs (${methodLabel}) a été activée sur votre compte du portail patient Health Watchers.\n\nSi vous n'avez pas effectué cette action, contactez immédiatement le support.\n\nGérer les paramètres de sécurité : ${portalUrl}`
+    : `Two-factor authentication (${methodLabel}) has been enabled on your Health Watchers patient portal account.\n\nIf you did not enable this, please contact support immediately.\n\nManage security settings: ${portalUrl}`;
+  const html = isFrench
+    ? `<h3>Authentification à deux facteurs du portail activée</h3><p>Bonjour <strong>${patientName}</strong>,</p><p>L'authentification à deux facteurs utilisant <strong>${methodLabel}</strong> a été activée sur votre compte du portail patient Health Watchers.</p><p>Vous devrez fournir un code de vérification lors de la connexion à votre portail.</p><p style="color:#dc2626"><strong>Si vous n'avez pas effectué cette action, contactez immédiatement le support.</strong></p><p><a href="${portalUrl}">Gérer les paramètres de sécurité</a></p>`
+    : `<h3>Portal Two-Factor Authentication Enabled</h3><p>Hello <strong>${patientName}</strong>,</p><p>Two-factor authentication using <strong>${methodLabel}</strong> has been enabled on your Health Watchers patient portal account.</p><p>You will be required to provide a verification code when logging in to your portal.</p><p style="color:#dc2626"><strong>If you did not enable this, please contact support immediately.</strong></p><p><a href="${portalUrl}">Manage Security Settings</a></p>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Portal MFA disabled notification sent to patient */
-export function sendPortalMfaDisabledEmail(to: string, patientName: string): void {
+export function sendPortalMfaDisabledEmail(to: string, patientName: string, language?: string): void {
   const portalUrl = `${APP_BASE_URL()}/portal/settings/security`;
-  const text = `Two-factor authentication has been disabled on your Health Watchers patient portal account.\n\nIf you did not disable this, please contact support immediately.\n\nManage security settings: ${portalUrl}`;
-  const html = `
-    <h3>Portal Two-Factor Authentication Disabled</h3>
-    <p>Hello <strong>${patientName}</strong>,</p>
-    <p>Two-factor authentication has been disabled on your Health Watchers patient portal account.</p>
-    <p style="color:#dc2626"><strong>If you did not disable this, please contact support immediately.</strong></p>
-    <p><a href="${portalUrl}">Manage Security Settings</a></p>
-  `;
-  enqueue(to, 'Portal Two-Factor Authentication Disabled — Health Watchers', text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench
+    ? 'Authentification à deux facteurs désactivée — Health Watchers'
+    : 'Portal Two-Factor Authentication Disabled — Health Watchers';
+  const text = isFrench
+    ? `L'authentification à deux facteurs a été désactivée sur votre compte du portail patient Health Watchers.\n\nSi vous n'avez pas effectué cette action, contactez immédiatement le support.\n\nGérer les paramètres de sécurité : ${portalUrl}`
+    : `Two-factor authentication has been disabled on your Health Watchers patient portal account.\n\nIf you did not disable this, please contact support immediately.\n\nManage security settings: ${portalUrl}`;
+  const html = isFrench
+    ? `<h3>Authentification à deux facteurs du portail désactivée</h3><p>Bonjour <strong>${patientName}</strong>,</p><p>L'authentification à deux facteurs a été désactivée sur votre compte du portail patient Health Watchers.</p><p style="color:#dc2626"><strong>Si vous n'avez pas effectué cette action, contactez immédiatement le support.</strong></p><p><a href="${portalUrl}">Gérer les paramètres de sécurité</a></p>`
+    : `<h3>Portal Two-Factor Authentication Disabled</h3><p>Hello <strong>${patientName}</strong>,</p><p>Two-factor authentication has been disabled on your Health Watchers patient portal account.</p><p style="color:#dc2626"><strong>If you did not disable this, please contact support immediately.</strong></p><p><a href="${portalUrl}">Manage Security Settings</a></p>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Portal MFA backup codes generated notification sent to patient */
-export function sendPortalMfaBackupCodesEmail(to: string, patientName: string, backupCodes: string[]): void {
+export function sendPortalMfaBackupCodesEmail(to: string, patientName: string, backupCodes: string[], language?: string): void {
   const portalUrl = `${APP_BASE_URL()}/portal/settings/security`;
   const codesHtml = backupCodes.map((code) => `<code style="background:#f3f4f6;padding:4px 8px;margin:4px;display:inline-block">${code}</code>`).join('');
-  const text = `Your backup codes for portal two-factor authentication have been generated. Keep these codes in a safe place.\n\nBackup codes:\n${backupCodes.join('\n')}\n\nManage security settings: ${portalUrl}`;
-  const html = `
-    <h3>Portal MFA Backup Codes Generated</h3>
-    <p>Hello <strong>${patientName}</strong>,</p>
-    <p>Your backup codes for portal two-factor authentication have been generated. Keep these codes in a safe place.</p>
-    <p><strong>Backup Codes:</strong></p>
-    <div style="background:#f9fafb;padding:16px;border-radius:6px;margin:16px 0;font-family:monospace">
-      ${codesHtml}
-    </div>
-    <p style="color:#dc2626"><strong>Important:</strong> Each code can only be used once. Store them securely.</p>
-    <p><a href="${portalUrl}">Manage Security Settings</a></p>
-  `;
-  enqueue(to, 'Portal MFA Backup Codes — Health Watchers', text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? 'Codes de secours MFA générés — Health Watchers' : 'Portal MFA Backup Codes — Health Watchers';
+  const text = isFrench
+    ? `Vos codes de secours pour l'authentification à deux facteurs du portail ont été générés. Conservez-les dans un endroit sûr.\n\nCodes de secours :\n${backupCodes.join('\n')}\n\nGérer les paramètres de sécurité : ${portalUrl}`
+    : `Your backup codes for portal two-factor authentication have been generated. Keep these codes in a safe place.\n\nBackup codes:\n${backupCodes.join('\n')}\n\nManage security settings: ${portalUrl}`;
+  const html = isFrench
+    ? `<h3>Codes de secours MFA du portail générés</h3><p>Bonjour <strong>${patientName}</strong>,</p><p>Vos codes de secours pour l'authentification à deux facteurs du portail ont été générés. Conservez-les dans un endroit sûr.</p><p><strong>Codes de secours :</strong></p><div style="background:#f9fafb;padding:16px;border-radius:6px;margin:16px 0;font-family:monospace">${codesHtml}</div><p style="color:#dc2626"><strong>Important :</strong> chaque code ne peut être utilisé qu'une seule fois. Conservez-les en lieu sûr.</p><p><a href="${portalUrl}">Gérer les paramètres de sécurité</a></p>`
+    : `<h3>Portal MFA Backup Codes Generated</h3><p>Hello <strong>${patientName}</strong>,</p><p>Your backup codes for portal two-factor authentication have been generated. Keep these codes in a safe place.</p><p><strong>Backup Codes:</strong></p><div style="background:#f9fafb;padding:16px;border-radius:6px;margin:16px 0;font-family:monospace">${codesHtml}</div><p style="color:#dc2626"><strong>Important:</strong> Each code can only be used once. Store them securely.</p><p><a href="${portalUrl}">Manage Security Settings</a></p>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Referral outcome notification sent to referring doctor */
 export function sendOutcomeNotificationEmail(
   to: string,
   doctorName: string,
-  data: { outcome: string; referralId: string }
+  data: { outcome: string; referralId: string },
+  language?: string
 ): void {
   const referralUrl = `${APP_BASE_URL()}/referrals/${data.referralId}`;
   const outcomeLabel = data.outcome === 'attended' ? 'Patient Attended' : data.outcome.charAt(0).toUpperCase() + data.outcome.slice(1);
-  const text = `A referral outcome has been recorded: ${outcomeLabel}.\n\nReferral ID: ${data.referralId}\nView: ${referralUrl}`;
-  const html = `
-    <h3>Referral Outcome Recorded</h3>
-    <p>Hello <strong>${doctorName}</strong>,</p>
-    <p>A referral outcome has been recorded for one of your referrals.</p>
-    <table style="border-collapse:collapse;width:100%;margin:16px 0">
-      <tr><td style="padding:8px;font-weight:bold">Outcome</td><td style="padding:8px">${outcomeLabel}</td></tr>
-      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Referral ID</td><td style="padding:8px;font-family:monospace;font-size:12px">${data.referralId}</td></tr>
-    </table>
-    <p><a href="${referralUrl}">View Referral Details</a></p>
-  `;
-  enqueue(to, `Referral Outcome Recorded — Health Watchers`, text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const subject = isFrench ? 'Résultat de l’orientation enregistré — Health Watchers' : 'Referral Outcome Recorded — Health Watchers';
+  const text = isFrench
+    ? `Un résultat d'orientation a été enregistré : ${outcomeLabel}.\n\nID de l'orientation : ${data.referralId}\nVoir : ${referralUrl}`
+    : `A referral outcome has been recorded: ${outcomeLabel}.\n\nReferral ID: ${data.referralId}\nView: ${referralUrl}`;
+  const html = isFrench
+    ? `<h3>Résultat de l'orientation enregistré</h3><p>Bonjour <strong>${doctorName}</strong>,</p><p>Un résultat d'orientation a été enregistré pour l'une de vos orientations.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Résultat</td><td style="padding:8px">${outcomeLabel}</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">ID de l'orientation</td><td style="padding:8px;font-family:monospace;font-size:12px">${data.referralId}</td></tr></table><p><a href="${referralUrl}">Voir les détails de l'orientation</a></p>`
+    : `<h3>Referral Outcome Recorded</h3><p>Hello <strong>${doctorName}</strong>,</p><p>A referral outcome has been recorded for one of your referrals.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Outcome</td><td style="padding:8px">${outcomeLabel}</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Referral ID</td><td style="padding:8px;font-family:monospace;font-size:12px">${data.referralId}</td></tr></table><p><a href="${referralUrl}">View Referral Details</a></p>`;
+  enqueue(to, subject, text, html);
 }
 
 /** Claimable balance expiry notification sent to patient */
@@ -348,23 +482,18 @@ export function sendClaimableExpiryEmail(
   to: string,
   patientName: string,
   amount: string,
-  claimableUntil: Date
+  claimableUntil: Date,
+  language?: string
 ): void {
   const portalUrl = `${APP_BASE_URL()}/portal/payments`;
-  const expiryStr = claimableUntil.toLocaleString('en-US', { timeZone: 'UTC', dateStyle: 'medium', timeStyle: 'short' }) + ' UTC';
-  const text = `Your claimable payment of ${amount} XLM is expiring soon (${expiryStr}). Please claim it before it expires or the funds will be returned to the clinic.\n\nClaim now: ${portalUrl}`;
-  const html = `
-    <h3>⏰ Claimable Payment Expiring Soon</h3>
-    <p>Hello <strong>${patientName}</strong>,</p>
-    <p>You have a claimable payment that is expiring within 24 hours. Please claim it before it expires.</p>
-    <table style="border-collapse:collapse;width:100%;margin:16px 0">
-      <tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr>
-      <tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Expires At</td><td style="padding:8px;color:#dc2626">${expiryStr}</td></tr>
-    </table>
-    <p>If you do not claim this payment before the expiry date, the funds will be returned to the clinic.</p>
-    <p><a href="${portalUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Claim Payment Now</a></p>
-    <hr style="margin-top:32px">
-    <small style="color:#6b7280">Health Watchers</small>
-  `;
-  enqueue(to, '⏰ Your Claimable Payment is Expiring Soon — Health Watchers', text, html);
+  const isFrench = resolveLanguage(language) === 'fr';
+  const expiryStr = claimableUntil.toLocaleString(isFrench ? 'fr-FR' : 'en-US', { timeZone: 'UTC', dateStyle: 'medium', timeStyle: 'short' }) + ' UTC';
+  const subject = isFrench ? 'Paiement à réclamer expirant bientôt — Health Watchers' : '⏰ Your Claimable Payment is Expiring Soon — Health Watchers';
+  const text = isFrench
+    ? `Votre paiement réclamable de ${amount} XLM expire bientôt (${expiryStr}). Veuillez le réclamer avant expiration, sinon les fonds seront retournés à la clinique.\n\nRéclamer maintenant : ${portalUrl}`
+    : `Your claimable payment of ${amount} XLM is expiring soon (${expiryStr}). Please claim it before it expires or the funds will be returned to the clinic.\n\nClaim now: ${portalUrl}`;
+  const html = isFrench
+    ? `<h3>⏰ Paiement réclamable expirant bientôt</h3><p>Bonjour <strong>${patientName}</strong>,</p><p>Vous avez un paiement réclamable qui expire dans les 24 heures. Veuillez le réclamer avant son expiration.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Montant</td><td style="padding:8px">${amount} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Expire le</td><td style="padding:8px;color:#dc2626">${expiryStr}</td></tr></table><p>Si vous ne réclamez pas ce paiement avant la date d'expiration, les fonds seront retournés à la clinique.</p><p><a href="${portalUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Réclamer maintenant</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`
+    : `<h3>⏰ Claimable Payment Expiring Soon</h3><p>Hello <strong>${patientName}</strong>,</p><p>You have a claimable payment that is expiring within 24 hours. Please claim it before it expires.</p><table style="border-collapse:collapse;width:100%;margin:16px 0"><tr><td style="padding:8px;font-weight:bold">Amount</td><td style="padding:8px">${amount} XLM</td></tr><tr style="background:#f9fafb"><td style="padding:8px;font-weight:bold">Expires At</td><td style="padding:8px;color:#dc2626">${expiryStr}</td></tr></table><p>If you do not claim this payment before the expiry date, the funds will be returned to the clinic.</p><p><a href="${portalUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Claim Payment Now</a></p><hr style="margin-top:32px"><small style="color:#6b7280">Health Watchers</small>`;
+  enqueue(to, subject, text, html);
 }

--- a/apps/api/src/middlewares/metrics.middleware.ts
+++ b/apps/api/src/middlewares/metrics.middleware.ts
@@ -8,8 +8,17 @@ import {
   httpRequestDurationSeconds,
   httpRequestSizeBytes,
   httpResponseSizeBytes,
+  securityHeaderViolationsTotal,
   normalisePath,
 } from '../services/metrics.service';
+
+const REQUIRED_SECURITY_HEADERS = [
+  'content-security-policy',
+  'strict-transport-security',
+  'x-content-type-options',
+  'x-frame-options',
+  'referrer-policy',
+] as const;
 
 export function metricsMiddleware(req: Request, res: Response, next: NextFunction): void {
   const start = process.hrtime.bigint();
@@ -26,9 +35,18 @@ export function metricsMiddleware(req: Request, res: Response, next: NextFunctio
     const durationNs = process.hrtime.bigint() - start;
     const durationSec = Number(durationNs) / 1e9;
     const status = String(res.statusCode);
+    const pathLabel = path;
 
     httpRequestsTotal.inc({ method, path, status });
     httpRequestDurationSeconds.observe({ method, path }, durationSec);
+
+    if (req.path.startsWith('/api') || req.path.startsWith('/health')) {
+      for (const header of REQUIRED_SECURITY_HEADERS) {
+        if (!res.getHeader(header)) {
+          securityHeaderViolationsTotal.inc({ header, path: pathLabel });
+        }
+      }
+    }
 
     const resSize = parseInt(res.getHeader('content-length') as string ?? '0', 10) || 0;
     if (resSize > 0) {

--- a/apps/api/src/modules/ai/ai.routes.ts
+++ b/apps/api/src/modules/ai/ai.routes.ts
@@ -4,6 +4,7 @@ import {
   generateClinicalSummary,
   generateRawTextSummary,
   generatePatientInsights,
+  generatePatientHealthSummary,
   generateDifferentialDiagnosis,
   isAIServiceAvailable,
   AI_DISCLAIMER,
@@ -15,6 +16,7 @@ import { authenticate, requireRoles } from '../../middlewares/auth.middleware';
 import { validateRequest } from '../../middlewares/validate.middleware';
 import logger from '../../utils/logger';
 import { sendAISummaryNotification } from '@api/lib/email.service';
+import { cache } from '../../services/cache.service';
 import {
   differentialDiagnosisRequestSchema,
   DifferentialDiagnosisRequestDto,
@@ -124,7 +126,7 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
         ]);
         if (doctor?.email && patient) {
           const patientName = `${(patient as any).firstName} ${(patient as any).lastName}`;
-          sendAISummaryNotification(doctor.email, patientName, encounterId);
+          sendAISummaryNotification(doctor.email, patientName, encounterId, doctor?.preferences?.language);
         }
       } catch {
         /* non-critical */
@@ -154,6 +156,139 @@ router.post('/summarize', authenticate, async (req: Request, res: Response) => {
     });
   }
 });
+
+// POST /api/v1/ai/patient-summary/:patientId
+// Returns: { success: boolean, summary: { overview, activeConditions, currentMedications, recentLabResults, upcomingAppointments, riskFactors } }
+router.post(
+  '/patient-summary/:patientId',
+  authenticate,
+  requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN', 'NURSE'),
+  async (req: Request, res: Response) => {
+    const startTime = Date.now();
+    try {
+      if (!isAIServiceAvailable()) {
+        return res.status(503).json({
+          error: 'AIUnavailable',
+          message: 'AI service is not configured. Please contact your administrator.',
+        });
+      }
+
+      const { patientId } = req.params;
+      if (!isValidObjectId(patientId)) {
+        return res.status(400).json({
+          error: 'ValidationError',
+          message: 'Valid patientId is required',
+        });
+      }
+
+      const clinicId = String(req.user!.clinicId);
+      const cacheKey = `ai:patient-summary:${clinicId}:${patientId}`;
+      const cached = await cache.get<{ summary: unknown; generatedAt: string }>(cacheKey);
+      if (cached) {
+        return res.json({ success: true, cached: true, patientId, ...cached });
+      }
+
+      const { EncounterModel } = await import('../encounters/encounter.model');
+      const { LabResultModel } = await import('../lab-results/lab-result.model');
+      const { AppointmentModel } = await import('../appointments/appointment.model');
+      const { MedicalHistoryModel } = await import('../patients/models/medical-history.model');
+      const { PatientModel } = await import('../patients/models/patient.model');
+
+      const [patient, recentEncounters, labResults, appointments, medicalHistory] = await Promise.all([
+        PatientModel.findOne({ _id: patientId, clinicId: req.user!.clinicId, isActive: true }).lean(),
+        EncounterModel.find({ patientId, clinicId: req.user!.clinicId, isActive: true })
+          .sort({ createdAt: -1 })
+          .limit(5)
+          .select('chiefComplaint diagnosis notes createdAt')
+          .lean(),
+        LabResultModel.find({ patientId, clinicId: req.user!.clinicId, status: 'resulted' })
+          .sort({ resultedAt: -1, orderedAt: -1 })
+          .limit(5)
+          .select('testName testCode results orderedAt resultedAt')
+          .lean(),
+        AppointmentModel.find({ patientId, clinicId: req.user!.clinicId })
+          .sort({ scheduledAt: 1 })
+          .limit(5)
+          .select('scheduledAt type status doctorId')
+          .lean(),
+        MedicalHistoryModel.findOne({ patientId, clinicId: req.user!.clinicId }).lean(),
+      ]);
+
+      if (!patient) {
+        return res.status(404).json({ error: 'NotFound', message: 'Patient not found' });
+      }
+
+      const summary = await generatePatientHealthSummary({
+        age: typeof (patient as any).age === 'number' ? (patient as any).age : null,
+        sex: (patient as any).sex ?? null,
+        allergies: (patient as any).allergies?.filter((allergy: any) => allergy.isActive !== false).map((allergy: any) => ({
+          allergen: allergy.allergen,
+          severity: allergy.severity,
+          reaction: allergy.reaction,
+        })) ?? [],
+        currentMedications: medicalHistory?.currentMedications?.map((medication) => ({
+          name: medication.name,
+          dose: medication.dose,
+          frequency: medication.frequency,
+        })) ?? [],
+        recentLabResults: labResults.map((lab) => ({
+          testName: lab.testName,
+          orderedAt: lab.resultedAt ?? lab.orderedAt,
+          results: (lab.results ?? []).map((result) => ({
+            parameter: result.parameter,
+            value: result.value,
+            unit: result.unit,
+            flag: result.flag,
+          })),
+        })),
+        upcomingAppointments: appointments.map((appointment) => ({
+          scheduledAt: appointment.scheduledAt,
+          type: appointment.type,
+          status: appointment.status,
+          clinician: String(appointment.doctorId),
+        })),
+        recentEncounters: recentEncounters.map((encounter) => ({
+          chiefComplaint: encounter.chiefComplaint,
+          diagnosis: encounter.diagnosis,
+          notes: encounter.notes,
+          createdAt: encounter.createdAt,
+        })),
+        riskFactors: Array.from(
+          new Set([
+            ...(patient as any).riskFactors ?? [],
+            ...(patient as any).allergies?.map((allergy: any) => `Allergy: ${allergy.allergen}`) ?? [],
+            medicalHistory?.socialHistory?.smokingStatus ? `Smoking status: ${medicalHistory.socialHistory.smokingStatus}` : null,
+            medicalHistory?.socialHistory?.alcoholUse ? `Alcohol use: ${medicalHistory.socialHistory.alcoholUse}` : null,
+            medicalHistory?.socialHistory?.exerciseFrequency ? `Exercise frequency: ${medicalHistory.socialHistory.exerciseFrequency}` : null,
+          ].filter(Boolean) as string[])
+        ),
+      });
+
+      const generatedAt = new Date().toISOString();
+      const response = { summary, generatedAt };
+      await Promise.all([
+        cache.set(cacheKey, response, 60 * 60),
+        PatientModel.findByIdAndUpdate(patientId, { lastSummaryGeneratedAt: new Date() }),
+      ]);
+
+      logger.info({ patientId, duration: Date.now() - startTime }, 'Patient summary generated');
+      return res.json({ success: true, patientId, ...response });
+    } catch (error: unknown) {
+      const duration = Date.now() - startTime;
+      logger.error({ err: error, duration }, 'AI patient-summary error');
+      if (error instanceof Error && error.message.includes('Failed to generate patient health summary')) {
+        return res.status(503).json({
+          error: 'AIServiceError',
+          message: 'Failed to generate patient summary. Please try again later.',
+        });
+      }
+      return res.status(500).json({
+        error: 'InternalServerError',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred',
+      });
+    }
+  }
+);
 
 // POST /api/v1/ai/insights
 // Request body: { patientId: string }

--- a/apps/api/src/modules/ai/ai.service.ts
+++ b/apps/api/src/modules/ai/ai.service.ts
@@ -121,6 +121,118 @@ export async function generatePatientInsights(encounters: EncounterSummary[]): P
   }
 }
 
+export interface PatientSummaryEncounterInput {
+  chiefComplaint?: string;
+  diagnosis?: unknown;
+  notes?: string;
+  createdAt: Date | string;
+}
+
+export interface PatientHealthSummaryInput {
+  age?: number | null;
+  sex?: string | null;
+  allergies: Array<{ allergen: string; severity: string; reaction?: string }>;
+  currentMedications: Array<{ name: string; dose?: string; frequency?: string }>;
+  recentLabResults: Array<{
+    testName: string;
+    orderedAt: Date | string;
+    results?: Array<{ parameter: string; value: string; unit?: string; flag?: string }>;
+  }>;
+  upcomingAppointments: Array<{
+    scheduledAt: Date | string;
+    type: string;
+    status: string;
+    clinician?: string;
+  }>;
+  recentEncounters: PatientSummaryEncounterInput[];
+  riskFactors: string[];
+}
+
+const patientHealthSummarySchema = z.object({
+  overview: z.string().trim().min(1),
+  activeConditions: z.array(z.string().trim().min(1)),
+  currentMedications: z.array(z.string().trim().min(1)),
+  recentLabResults: z.array(z.string().trim().min(1)),
+  upcomingAppointments: z.array(z.string().trim().min(1)),
+  riskFactors: z.array(z.string().trim().min(1)),
+});
+
+export interface PatientHealthSummary {
+  overview: string;
+  activeConditions: string[];
+  currentMedications: string[];
+  recentLabResults: string[];
+  upcomingAppointments: string[];
+  riskFactors: string[];
+}
+
+export async function generatePatientHealthSummary(input: PatientHealthSummaryInput): Promise<PatientHealthSummary> {
+  const client = getGeminiClient();
+
+  const promptPayload = {
+    demographics: {
+      age: input.age ?? null,
+      sex: input.sex ?? null,
+    },
+    allergies: input.allergies,
+    currentMedications: input.currentMedications,
+    recentLabResults: input.recentLabResults.map((lab) => ({
+      testName: lab.testName,
+      orderedAt: new Date(lab.orderedAt).toISOString(),
+      results: lab.results?.map((result) => ({
+        parameter: result.parameter,
+        value: result.value,
+        unit: result.unit,
+        flag: result.flag,
+      })),
+    })),
+    upcomingAppointments: input.upcomingAppointments.map((appointment) => ({
+      scheduledAt: new Date(appointment.scheduledAt).toISOString(),
+      type: appointment.type,
+      status: appointment.status,
+      clinician: appointment.clinician,
+    })),
+    recentEncounters: input.recentEncounters.map((encounter) => ({
+      createdAt: new Date(encounter.createdAt).toISOString(),
+      chiefComplaint: encounter.chiefComplaint,
+      diagnosis: encounter.diagnosis,
+      notes: encounter.notes,
+    })),
+    riskFactors: input.riskFactors,
+  };
+
+  const safeText = stripPII(JSON.stringify(promptPayload, null, 2));
+
+  const prompt = `You are a medical AI assistant. Generate a one-page clinical patient summary for a clinician using only the de-identified data below.
+
+Return ONLY valid JSON with this exact structure:
+{
+  "overview": "string",
+  "activeConditions": ["string"],
+  "currentMedications": ["string"],
+  "recentLabResults": ["string"],
+  "upcomingAppointments": ["string"],
+  "riskFactors": ["string"]
+}
+
+Sections must be concise and clinically useful. Do not include any direct identifiers or speculate beyond the supplied data.
+
+Patient context:
+${safeText}`;
+
+  try {
+    const model = client.getGenerativeModel({ model: 'gemini-1.5-flash', generationConfig: { responseMimeType: 'application/json' } });
+    const result = await model.generateContent(prompt);
+    const text = result.response.text().trim();
+    const jsonStr = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    const parsed = JSON.parse(jsonStr);
+    return patientHealthSummarySchema.parse(parsed);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Failed to generate patient health summary: ${msg}`);
+  }
+}
+
 // ── Differential Diagnosis ───────────────────────────────────────────────────
 export interface DifferentialDiagnosisInput {
   chiefComplaint: string;

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -120,8 +120,8 @@ router.post(
     const rawToken = crypto.randomBytes(32).toString('hex');
     user.emailVerificationTokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
     await user.save();
-    await sendVerificationEmail(user.email, rawToken);
-    sendWelcomeEmail(user.email, user.fullName);
+    await sendVerificationEmail(user.email, rawToken, user.preferences?.language);
+    sendWelcomeEmail(user.email, user.fullName, user.preferences?.language);
 
     const { password: _pw, emailVerificationTokenHash: _evth, ...sanitized } = user.toObject();
     return res.status(201).json({ status: 'success', data: sanitized });
@@ -594,7 +594,7 @@ router.post(
       user.resetPasswordTokenHash = hashToken(rawToken);
       user.resetPasswordExpiresAt = new Date(Date.now() + RESET_TOKEN_EXPIRY_MS);
       await user.save();
-      await sendPasswordResetEmail(user.email, rawToken);
+      await sendPasswordResetEmail(user.email, rawToken, user.preferences?.language);
     }
     return res.json({
       status: 'success',

--- a/apps/api/src/modules/auth/password-reset.test.ts
+++ b/apps/api/src/modules/auth/password-reset.test.ts
@@ -55,7 +55,7 @@ async function forgotPasswordHandler(body: { email: string }, res: ReturnType<ty
     user.resetPasswordTokenHash = hashToken(rawToken);
     user.resetPasswordExpiresAt = new Date(Date.now() + RESET_TOKEN_EXPIRY_MS);
     await user.save();
-    await sendPasswordResetEmail(user.email, rawToken);
+    await sendPasswordResetEmail(user.email, rawToken, undefined);
   }
   return res.json({
     status: 'success',
@@ -110,7 +110,7 @@ describe('POST /auth/forgot-password', () => {
     expect(saveMock).toHaveBeenCalledTimes(1);
     expect(user.resetPasswordTokenHash).toBeDefined();
     expect(user.resetPasswordExpiresAt).toBeInstanceOf(Date);
-    expect(sendPasswordResetEmail).toHaveBeenCalledWith('doctor@clinic.com', expect.any(String));
+    expect(sendPasswordResetEmail).toHaveBeenCalledWith('doctor@clinic.com', expect.any(String), undefined);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }));
   });
 

--- a/apps/api/src/modules/auth/user-registration.test.ts
+++ b/apps/api/src/modules/auth/user-registration.test.ts
@@ -102,7 +102,7 @@ async function registerHandler(
   const rawToken = crypto.randomBytes(32).toString('hex');
   user.emailVerificationTokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
   await user.save();
-  await sendVerificationEmail(user.email, rawToken);
+  await sendVerificationEmail(user.email, rawToken, undefined);
 
   const { password: _pw, emailVerificationTokenHash: _evth, ...sanitized } = user;
   return res.status(201).json({ status: 'success', data: sanitized });
@@ -149,7 +149,7 @@ describe('POST /auth/register', () => {
     await registerHandler('CLINIC_ADMIN', validBody, res);
 
     expect(res.status).toHaveBeenCalledWith(201);
-    expect(sendVerificationEmail).toHaveBeenCalledWith('alice@clinic.com', expect.any(String));
+    expect(sendVerificationEmail).toHaveBeenCalledWith('alice@clinic.com', expect.any(String), undefined);
     const responseData = (res.json as jest.Mock).mock.calls[0][0].data;
     expect(responseData).not.toHaveProperty('password');
     expect(responseData).not.toHaveProperty('emailVerificationTokenHash');

--- a/apps/api/src/modules/patients/models/patient.model.ts
+++ b/apps/api/src/modules/patients/models/patient.model.ts
@@ -43,6 +43,7 @@ export interface Patient {
   riskLevel?: RiskLevel;
   riskFactors?: string[];
   lastRiskCalculatedAt?: Date;
+  lastSummaryGeneratedAt?: Date;
   nextRiskReviewDate?: Date;
   photoUrl?: string;
   thumbnailUrl?: string;
@@ -100,6 +101,7 @@ const patientSchema = new Schema<Patient>(
     riskLevel: { type: String, enum: ['low', 'medium', 'high', 'critical'] },
     riskFactors: { type: [String], default: undefined },
     lastRiskCalculatedAt: { type: Date },
+    lastSummaryGeneratedAt: { type: Date },
     nextRiskReviewDate: { type: Date },
     photoUrl: { type: String },
     thumbnailUrl: { type: String },

--- a/apps/api/src/services/metrics.service.ts
+++ b/apps/api/src/services/metrics.service.ts
@@ -117,6 +117,13 @@ export const aiRequestsTotal = new client.Counter({
   registers: [register],
 });
 
+export const securityHeaderViolationsTotal = new client.Counter({
+  name: 'security_header_violations_total',
+  help: 'Total number of responses missing required security headers',
+  labelNames: ['header', 'path'] as const,
+  registers: [register],
+});
+
 // ── Payment Expiration Job Metrics ────────────────────────────────────────────
 
 export const paymentExpirationJobErrorsTotal = new client.Counter({

--- a/apps/web/e2e/security-headers.spec.ts
+++ b/apps/web/e2e/security-headers.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('web responses include security headers', async ({ page }) => {
+  const response = await page.goto('/');
+  expect(response).not.toBeNull();
+
+  const headers = response!.headers();
+  expect(headers['x-content-type-options']).toBe('nosniff');
+  expect(headers['x-frame-options']).toBe('DENY');
+  expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  expect(headers['content-security-policy']).toContain("default-src 'self'");
+  expect(headers['content-security-policy']).toContain("frame-ancestors 'none'");
+});


### PR DESCRIPTION
This PR implements three production-focused improvements:

Adds bilingual email templates in English and French, with locale-aware rendering based on user preferences.
Adds a new AI patient summary endpoint that aggregates patient data, strips PII, caches results in Redis, and updates the patient record with the latest summary timestamp.
Adds automated security header verification in the API and frontend E2E suites, plus Prometheus tracking for header violations.
Also updates CI and documentation to cover the new security-header checks.

Closes #652 
closes #651 
closes #650