### PR TITLE
feat: add dark mode support to frontend

### DIFF
--- a/apps/api/src/modules/auth/models/user.model.ts
+++ b/apps/api/src/modules/auth/models/user.model.ts
@@ -14,6 +14,7 @@ const ROLES: AppRole[] = [
 
 export interface UserPreferences {
   language: string;
+  theme: 'light' | 'dark' | 'system';
   emailNotifications: boolean;
   inAppNotifications: boolean;
   notificationTypes: {
@@ -120,6 +121,7 @@ const userSchema = new Schema(
     mustChangePassword: { type: Boolean, default: false },
     preferences: {
       language: { type: String, default: 'en' },
+      theme: { type: String, enum: ['light', 'dark', 'system'], default: 'system' },
       emailNotifications: { type: Boolean, default: true },
       inAppNotifications: { type: Boolean, default: true },
       notificationTypes: {

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -69,6 +69,7 @@ router.get('/me', authenticate, async (req: Request, res: Response) => {
       mfaEnabled: user.mfaEnabled,
       preferences: {
         language: user.preferences?.language ?? 'en',
+        theme: user.preferences?.theme ?? 'system',
         emailNotifications: user.preferences?.emailNotifications ?? true,
         inAppNotifications: user.preferences?.inAppNotifications ?? true,
         notificationTypes: {
@@ -343,6 +344,7 @@ const notificationTypesSchema = z.object({
 
 const updatePreferencesSchema = z.object({
   language: z.enum(['en', 'fr']).optional(),
+  theme: z.enum(['light', 'dark', 'system']).optional(),
   emailNotifications: z.boolean().optional(),
   inAppNotifications: z.boolean().optional(),
   notificationTypes: notificationTypesSchema,
@@ -384,9 +386,10 @@ router.patch(
       return res.status(401).json({ error: 'Unauthorized', message: 'User not found' });
     }
 
-    const { language, emailNotifications, inAppNotifications, notificationTypes } = req.body;
+    const { language, theme, emailNotifications, inAppNotifications, notificationTypes } = req.body;
 
     if (language !== undefined) user.preferences.language = language;
+    if (theme !== undefined) user.preferences.theme = theme;
     if (emailNotifications !== undefined) user.preferences.emailNotifications = emailNotifications;
     if (inAppNotifications !== undefined) user.preferences.inAppNotifications = inAppNotifications;
     if (notificationTypes !== undefined) {
@@ -400,6 +403,7 @@ router.patch(
       data: {
         preferences: {
           language: user.preferences.language,
+          theme: user.preferences.theme,
           emailNotifications: user.preferences.emailNotifications,
           inAppNotifications: user.preferences.inAppNotifications,
           notificationTypes: user.preferences.notificationTypes,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,8 +4,10 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getLocale } from 'next-intl/server';
 import { ThemeProvider } from 'next-themes';
 import { QueryProvider } from '@/lib/QueryProvider';
+import { AuthProvider } from '@/context/AuthContext';
 
 import { Toaster } from '@/components/ui';
+import { ThemeSync } from '@/components/ThemeSync';
 import './globals.css';
 
 const inter = Inter({
@@ -84,11 +86,19 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const messages = await getMessages();
 
   return (
-    <html lang={locale} className={inter.variable}>
-      <body className="min-h-screen bg-neutral-50 font-sans antialiased">
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <Toaster />
-        </NextIntlClientProvider>
+    <html lang={locale} className={inter.variable} suppressHydrationWarning>
+      <body className="min-h-screen bg-neutral-50 font-sans antialiased dark:bg-neutral-900">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <QueryProvider>
+              <AuthProvider>
+                <ThemeSync />
+                {children}
+                <Toaster />
+              </AuthProvider>
+            </QueryProvider>
+          </NextIntlClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/settings/SettingsClient.tsx
+++ b/apps/web/src/app/settings/SettingsClient.tsx
@@ -21,6 +21,7 @@ interface MeResponse {
     mfaEnabled: boolean;
     preferences: {
       language: string;
+      theme: 'light' | 'dark' | 'system';
       emailNotifications: boolean;
       inAppNotifications: boolean;
     };
@@ -61,7 +62,7 @@ export default function SettingsClient() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
-      <h1 className="mb-8 text-2xl font-bold text-neutral-900">Settings</h1>
+      <h1 className="mb-8 text-2xl font-bold text-neutral-900 dark:text-neutral-100">Settings</h1>
       <div className="flex gap-8">
         <aside className="w-48 shrink-0">
           <SubNavigation active={active} onChange={setActive} />

--- a/apps/web/src/components/ThemeSync.tsx
+++ b/apps/web/src/components/ThemeSync.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTheme } from 'next-themes';
+
+/**
+ * Syncs the persisted theme preference from the backend into next-themes on mount.
+ * Renders nothing — purely a side-effect component.
+ */
+export function ThemeSync() {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    fetch('/api/settings/me', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        const theme = data?.data?.preferences?.theme;
+        if (theme === 'light' || theme === 'dark' || theme === 'system') {
+          setTheme(theme);
+        }
+      })
+      .catch(() => {
+        // silently ignore — default theme from next-themes will be used
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -8,12 +8,12 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className="flex h-screen overflow-hidden bg-gray-50">
+    <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-neutral-900">
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <TopBar onMenuClick={() => setSidebarOpen(true)} />
-        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+        <main className="flex-1 overflow-y-auto p-6 dark:bg-neutral-900 dark:text-neutral-100">{children}</main>
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -259,10 +259,10 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
     <nav
       ref={sidebarRef}
       aria-label="Main navigation"
-      className="bg-neutral-0 flex h-full w-60 flex-col border-r border-neutral-200"
+      className="bg-neutral-0 dark:bg-neutral-800 dark:border-neutral-700 flex h-full w-60 flex-col border-r border-neutral-200"
     >
       {/* Logo area */}
-      <div className="flex h-14 shrink-0 items-center gap-2 border-b border-neutral-200 px-5">
+      <div className="flex h-14 shrink-0 items-center gap-2 border-b border-neutral-200 dark:border-neutral-700 px-5">
         <span className="text-primary-500 text-lg font-bold tracking-tight">HealthWatchers</span>
       </div>
 

--- a/apps/web/src/components/layout/TopBar.tsx
+++ b/apps/web/src/components/layout/TopBar.tsx
@@ -12,13 +12,13 @@ export default function TopBar({ onMenuClick }: TopBarProps) {
   const { user, logout } = useAuth();
 
   return (
-    <header className="bg-neutral-0 flex h-14 shrink-0 items-center justify-between border-b border-neutral-200 px-4">
+    <header className="bg-neutral-0 dark:bg-neutral-800 dark:border-neutral-700 flex h-14 shrink-0 items-center justify-between border-b border-neutral-200 px-4">
       {/* Left: hamburger (mobile) */}
       <div className="flex items-center gap-3">
         <button
           type="button"
           onClick={onMenuClick}
-          className="focus:ring-primary-500 rounded-md p-2 text-neutral-500 hover:bg-neutral-100 focus:ring-2 focus:outline-none md:hidden"
+          className="focus:ring-primary-500 rounded-md p-2 text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-700 focus:ring-2 focus:outline-none md:hidden"
           aria-label="Open navigation menu"
         >
           <svg
@@ -42,7 +42,7 @@ export default function TopBar({ onMenuClick }: TopBarProps) {
       </div>
 
       {/* Center: clinic name */}
-      <span className="absolute left-1/2 hidden -translate-x-1/2 text-sm font-semibold text-neutral-700 sm:block">
+      <span className="absolute left-1/2 hidden -translate-x-1/2 text-sm font-semibold text-neutral-700 dark:text-neutral-200 sm:block">
         {user?.clinicName ?? 'Health Watchers'}
       </span>
 
@@ -61,7 +61,7 @@ export default function TopBar({ onMenuClick }: TopBarProps) {
         <button
           type="button"
           onClick={logout}
-          className="text-sm text-neutral-500 hover:text-neutral-800 focus:underline focus:outline-none"
+          className="text-sm text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-100 focus:underline focus:outline-none"
           aria-label="Log out"
         >
           Logout

--- a/apps/web/src/components/settings/PreferencesSection.tsx
+++ b/apps/web/src/components/settings/PreferencesSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTheme } from 'next-themes';
 
 export interface NotificationTypes {
   referral_received: boolean;
@@ -14,6 +15,7 @@ export interface NotificationTypes {
 
 export interface UserPreferences {
   language: string;
+  theme: 'light' | 'dark' | 'system';
   emailNotifications: boolean;
   inAppNotifications: boolean;
   notificationTypes?: NotificationTypes;
@@ -41,7 +43,9 @@ const DEFAULT_TYPES: NotificationTypes = {
   system: true,
 };
 
-async function patchPreferences(patch: Partial<UserPreferences & { notificationTypes: Partial<NotificationTypes> }>): Promise<void> {
+async function patchPreferences(
+  patch: Partial<UserPreferences & { notificationTypes: Partial<NotificationTypes> }>
+): Promise<void> {
   const res = await fetch('/api/settings/preferences', {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
@@ -55,8 +59,12 @@ async function patchPreferences(patch: Partial<UserPreferences & { notificationT
 
 export function PreferencesSection({ preferences }: PreferencesSectionProps) {
   const router = useRouter();
+  const { setTheme } = useTheme();
 
   const [language, setLanguage] = useState(preferences.language);
+  const [theme, setThemeState] = useState<'light' | 'dark' | 'system'>(
+    preferences.theme ?? 'system'
+  );
   const [emailNotifications, setEmailNotifications] = useState(preferences.emailNotifications);
   const [inAppNotifications, setInAppNotifications] = useState(preferences.inAppNotifications);
   const [notifTypes, setNotifTypes] = useState<NotificationTypes>(
@@ -77,6 +85,22 @@ export function PreferencesSection({ preferences }: PreferencesSectionProps) {
     } catch (err) {
       setLanguage(prev);
       setError(err instanceof Error ? err.message : 'Failed to update language');
+    }
+  };
+
+  const handleThemeChange = async (newTheme: 'light' | 'dark' | 'system') => {
+    const prev = theme;
+    setThemeState(newTheme);
+    setTheme(newTheme);
+    setError(null);
+    setSuccessMessage(null);
+    try {
+      await patchPreferences({ theme: newTheme });
+      setSuccessMessage('Preferences saved');
+    } catch (err) {
+      setThemeState(prev);
+      setTheme(prev);
+      setError(err instanceof Error ? err.message : 'Failed to update theme preference');
     }
   };
 
@@ -125,33 +149,64 @@ export function PreferencesSection({ preferences }: PreferencesSectionProps) {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-lg font-semibold text-neutral-900">Preferences</h2>
-        <p className="text-sm text-neutral-500">Manage your language and notification settings.</p>
+        <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">Preferences</h2>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          Manage your language, appearance, and notification settings.
+        </p>
       </div>
 
       <div className="max-w-md space-y-6">
         {/* Language selector */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="language-select" className="text-sm font-medium text-neutral-700">
+          <label htmlFor="language-select" className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
             Language
           </label>
           <select
             id="language-select"
             value={language}
             onChange={(e) => handleLanguageChange(e.target.value)}
-            className="focus-visible:ring-primary-500 rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 focus:outline-none focus-visible:ring-2"
+            className="focus-visible:ring-primary-500 rounded-md border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 px-3 py-2 text-sm text-neutral-800 dark:text-neutral-100 focus:outline-none focus-visible:ring-2"
           >
             <option value="en">English</option>
             <option value="fr">French</option>
           </select>
         </div>
 
+        {/* Appearance / Theme */}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">Appearance</span>
+          <div className="flex gap-2" role="group" aria-label="Theme selection">
+            {(['light', 'dark', 'system'] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => handleThemeChange(option)}
+                aria-pressed={theme === option}
+                className={[
+                  'flex-1 rounded-md border px-3 py-2 text-sm font-medium capitalize transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+                  theme === option
+                    ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                    : 'border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-700',
+                ].join(' ')}
+              >
+                {option === 'light' && '☀️ '}
+                {option === 'dark' && '🌙 '}
+                {option === 'system' && '💻 '}
+                {option.charAt(0).toUpperCase() + option.slice(1)}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">
+            "System" follows your device's dark mode setting.
+          </p>
+        </div>
+
         {/* Global notification toggles */}
         <div className="space-y-4">
-          <h3 className="text-sm font-medium text-neutral-700">Notifications</h3>
+          <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">Notifications</h3>
 
           <div className="flex items-center justify-between">
-            <label htmlFor="email-notifications" className="text-sm text-neutral-700">
+            <label htmlFor="email-notifications" className="text-sm text-neutral-700 dark:text-neutral-300">
               Email Notifications
             </label>
             <input
@@ -166,7 +221,7 @@ export function PreferencesSection({ preferences }: PreferencesSectionProps) {
           </div>
 
           <div className="flex items-center justify-between">
-            <label htmlFor="inapp-notifications" className="text-sm text-neutral-700">
+            <label htmlFor="inapp-notifications" className="text-sm text-neutral-700 dark:text-neutral-300">
               In-App Notifications
             </label>
             <input
@@ -183,12 +238,14 @@ export function PreferencesSection({ preferences }: PreferencesSectionProps) {
 
         {/* Per-type notification preferences */}
         {inAppNotifications && (
-          <div className="space-y-3 border-t border-neutral-200 pt-4">
-            <h3 className="text-sm font-medium text-neutral-700">Notification Types</h3>
-            <p className="text-xs text-neutral-500">Choose which in-app notifications you receive.</p>
+          <div className="space-y-3 border-t border-neutral-200 dark:border-neutral-700 pt-4">
+            <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">Notification Types</h3>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              Choose which in-app notifications you receive.
+            </p>
             {(Object.keys(NOTIFICATION_TYPE_LABELS) as (keyof NotificationTypes)[]).map((type) => (
               <div key={type} className="flex items-center justify-between">
-                <label htmlFor={`notif-type-${type}`} className="text-sm text-neutral-700">
+                <label htmlFor={`notif-type-${type}`} className="text-sm text-neutral-700 dark:text-neutral-300">
                   {NOTIFICATION_TYPE_LABELS[type]}
                 </label>
                 <input
@@ -205,7 +262,7 @@ export function PreferencesSection({ preferences }: PreferencesSectionProps) {
           </div>
         )}
 
-        {successMessage && <p className="text-sm text-green-600">{successMessage}</p>}
+        {successMessage && <p className="text-sm text-green-600 dark:text-green-400">{successMessage}</p>}
         {error && <p className="text-danger-500 text-sm">{error}</p>}
       </div>
     </div>


### PR DESCRIPTION
- Enable ThemeProvider (next-themes) in root layout with system default
- Add suppressHydrationWarning to <html> to prevent hydration mismatch
- Add theme field ('light'|'dark'|'system') to UserPreferences in UserModel
- Expose and accept theme in GET/PATCH /users/me/preferences API
- Add ThemeSync component to apply persisted theme preference on load
- Add dark mode toggle (Light/Dark/System) in PreferencesSection settings
- Add dark: variants to AppLayout, TopBar, Sidebar layout components
- ThemeToggle in TopBar already functional via next-themes
closes #659 