### PR TITLE
feat: implement consent signature feature

### DIFF
--- a/apps/api/src/modules/consent/consent.controller.ts
+++ b/apps/api/src/modules/consent/consent.controller.ts
@@ -4,15 +4,17 @@ import { validateRequest } from '@api/middlewares/validate.middleware';
 import { z } from 'zod';
 import { ConsentModel, CONSENT_TEMPLATES, ConsentType } from './consent.model';
 import { auditLog } from '../audit/audit.service';
+import crypto from 'crypto';
 
 const router = Router();
 router.use(authenticate);
 
-const WRITE_ROLES = requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN', 'NURSE');
+const WRITE_ROLES = requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN', 'NURSE', 'PATIENT');
 
 const grantConsentSchema = z.object({
   type: z.enum(['treatment', 'data_sharing', 'ai_analysis', 'research', 'marketing']),
   expiresAt: z.string().optional(),
+  signatureData: z.string(), // base64 string
 });
 
 // GET /consent/templates
@@ -28,12 +30,18 @@ router.post(
   async (req: Request, res: Response) => {
     const { id: patientId } = req.params;
     const clinicId = req.user!.clinicId;
-    const { type, expiresAt } = req.body as { type: ConsentType; expiresAt?: string };
+    const { type, expiresAt, signatureData } = req.body as { type: ConsentType; expiresAt?: string; signatureData: string };
 
     const template = CONSENT_TEMPLATES[type];
     const ipAddress =
       (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
       req.socket.remoteAddress;
+    const userAgent = req.headers['user-agent'];
+    const signedAt = new Date();
+
+    // Generate SHA-256 hash: content + patientId + timestamp
+    const dataToHash = `${template.text}${patientId}${signedAt.toISOString()}`;
+    const signatureHash = crypto.createHash('sha256').update(dataToHash).digest('hex');
 
     const consent = await ConsentModel.findOneAndUpdate(
       { patientId, clinicId, type },
@@ -44,6 +52,10 @@ router.post(
         expiresAt: expiresAt ? new Date(expiresAt) : undefined,
         version: template.version,
         ipAddress,
+        userAgent,
+        signatureData,
+        signedAt,
+        signatureHash,
         grantedBy: req.user!.userId,
       },
       { upsert: true, new: true }
@@ -56,7 +68,7 @@ router.post(
         resourceId: String(consent._id),
         userId: req.user!.userId,
         clinicId,
-        metadata: { event: 'consent_granted', type, patientId },
+        metadata: { event: 'consent_signed', type, patientId, signatureHash },
       },
       req
     );
@@ -64,6 +76,38 @@ router.post(
     res.status(201).json({ status: 'success', data: consent });
   }
 );
+
+// POST /consent/:id/verify
+router.post('/consent/:id/verify', async (req: Request, res: Response) => {
+  const { id: consentId } = req.params;
+  const clinicId = req.user!.clinicId;
+
+  const consent = await ConsentModel.findById(consentId);
+
+  if (!consent || consent.clinicId.toString() !== clinicId) {
+    return res.status(404).json({ error: 'NotFound', message: 'Consent record not found' });
+  }
+
+  const template = CONSENT_TEMPLATES[consent.type];
+  const dataToHash = `${template.text}${consent.patientId}${consent.signedAt!.toISOString()}`;
+  const computedHash = crypto.createHash('sha256').update(dataToHash).digest('hex');
+
+  const isValid = computedHash === consent.signatureHash;
+
+  await auditLog(
+    {
+      action: 'VIEW',
+      resourceType: 'Consent',
+      resourceId: String(consent._id),
+      userId: req.user!.userId,
+      clinicId,
+      metadata: { event: 'consent_verified', isValid, patientId: consent.patientId },
+    },
+    req
+  );
+
+  res.json({ status: 'success', data: { isValid } });
+});
 
 // GET /patients/:id/consent
 router.get('/patients/:id/consent', async (req: Request, res: Response) => {

--- a/apps/api/src/modules/consent/consent.model.ts
+++ b/apps/api/src/modules/consent/consent.model.ts
@@ -13,6 +13,10 @@ export interface IConsent {
   expiresAt?: Date;
   version: string;
   ipAddress?: string;
+  userAgent?: string;
+  signatureData?: string; // base64 string
+  signedAt?: Date;
+  signatureHash?: string;
   grantedBy?: Types.ObjectId; // userId who recorded the consent
 }
 
@@ -31,6 +35,10 @@ const consentSchema = new Schema<IConsent>(
     expiresAt: { type: Date },
     version: { type: String, required: true, default: '1.0' },
     ipAddress: { type: String },
+    userAgent: { type: String },
+    signatureData: { type: String },
+    signedAt: { type: Date },
+    signatureHash: { type: String },
     grantedBy: { type: Schema.Types.ObjectId, ref: 'User' },
   },
   { timestamps: true, versionKey: false }

--- a/apps/web/src/components/forms/SignaturePad.tsx
+++ b/apps/web/src/components/forms/SignaturePad.tsx
@@ -1,0 +1,88 @@
+import React, { useRef, useState } from 'react';
+import { Button } from '../ui/Button';
+
+interface SignaturePadProps {
+  onSave: (signatureData: string) => void;
+}
+
+export const SignaturePad: React.FC<SignaturePadProps> = ({ onSave }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+
+  const startDrawing = (e: React.MouseEvent | React.TouchEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    setIsDrawing(true);
+    const { offsetX, offsetY } = getCoordinates(e, canvas);
+    ctx.beginPath();
+    ctx.moveTo(offsetX, offsetY);
+  };
+
+  const draw = (e: React.MouseEvent | React.TouchEvent) => {
+    if (!isDrawing) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const { offsetX, offsetY } = getCoordinates(e, canvas);
+    ctx.lineTo(offsetX, offsetY);
+    ctx.stroke();
+  };
+
+  const stopDrawing = () => {
+    setIsDrawing(false);
+  };
+
+  const getCoordinates = (e: React.MouseEvent | React.TouchEvent, canvas: HTMLCanvasElement) => {
+    let clientX, clientY;
+    if ('touches' in e) {
+      clientX = e.touches[0].clientX;
+      clientY = e.touches[0].clientY;
+    } else {
+      clientX = (e as React.MouseEvent).clientX;
+      clientY = (e as React.MouseEvent).clientY;
+    }
+    const rect = canvas.getBoundingClientRect();
+    return { offsetX: clientX - rect.left, offsetY: clientY - rect.top };
+  };
+
+  const clear = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+
+  const save = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    onSave(canvas.toDataURL('image/png'));
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <canvas
+        ref={canvasRef}
+        width={400}
+        height={200}
+        className="border border-gray-300 rounded cursor-crosshair"
+        onMouseDown={startDrawing}
+        onMouseMove={draw}
+        onMouseUp={stopDrawing}
+        onMouseLeave={stopDrawing}
+        onTouchStart={startDrawing}
+        onTouchMove={draw}
+        onTouchEnd={stopDrawing}
+      />
+      <div className="flex gap-2">
+        <Button onClick={clear} variant="outline" size="sm">Clear</Button>
+        <Button onClick={save} size="sm">Accept Signature</Button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
The plan looks good. Proceed with implementation.

Additional constraints:

* Keep the change set minimal and focused on the consent feature only.
* Reuse existing audit logging infrastructure if available; do not create a new logging framework.
* Reuse existing Swagger/OpenAPI patterns already used in the API.
* Prefer built-in Node.js crypto utilities for SHA-256 hashing rather than adding new dependencies.
* Implement the signature pad using existing frontend libraries if already present; otherwise use a lightweight HTML5 canvas approach.
* Do not modify CI workflows, package manager configuration, lint configuration, release tooling, or unrelated modules.
* Do not run tests.
* Do not run dependency upgrades.
* Create a single commit after implementation.

After implementation, provide:

1. Files modified.
2. Summary of changes.
3. Any assumptions made.
4. The commit hash.

closes #663 