### PR TITLE
feat(auth): enforce MFA for DOCTOR and NURSE roles with 7-day grace period

### DIFF
--- a/.changeset/feat-mfa-enforcement-doctor-nurse.md
+++ b/.changeset/feat-mfa-enforcement-doctor-nurse.md
@@ -1,0 +1,12 @@
+---
+"api": minor
+---
+
+feat: enforce MFA for DOCTOR and NURSE roles with 7-day grace period (HIPAA)
+
+- Add DOCTOR and NURSE to MFA_REQUIRED_ROLES (previously only CLINIC_ADMIN and SUPER_ADMIN)
+- First login without MFA assigns a 7-day grace period (mfaGracePeriodEndsAt) and returns tokens with a mfa_required warning
+- After grace period expires, login is blocked (403) until MFA is set up
+- Add mfaGracePeriodEndsAt field to UserModel with DB index
+- Add daily mfa-grace-period-job that sends email reminders 3 days and 1 day before the deadline
+- Add migration 20260624_add_mfa_grace_period for the supporting compound index

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -84,6 +84,10 @@ import {
   stopClaimableExpiryNotificationJob,
 } from './modules/payments/services/claimable-expiry-notification-job';
 import { startXLMRateJob, stopXLMRateJob } from './modules/payments/services/xlm-rate-job';
+import {
+  startMfaGracePeriodJob,
+  stopMfaGracePeriodJob,
+} from './modules/auth/mfa-grace-period-job';
 import { getCacheMetrics } from './services/cache.service';
 import {
   mongodbConnectionPoolSize,
@@ -330,6 +334,7 @@ async function startServer() {
   startAppointmentReminderJob();
   startClaimableExpiryNotificationJob();
   startXLMRateJob();
+  startMfaGracePeriodJob();
 
   // Track MongoDB connection pool metrics for Prometheus
   setInterval(() => {
@@ -358,6 +363,7 @@ async function startServer() {
         stopAppointmentReminderJob();
         stopClaimableExpiryNotificationJob();
         stopXLMRateJob();
+        stopMfaGracePeriodJob();
         logger.info('All background jobs stopped');
 
         // Close database connection

--- a/apps/api/src/lib/email.service.ts
+++ b/apps/api/src/lib/email.service.ts
@@ -517,6 +517,33 @@ export function sendPortalMfaBackupCodesEmail(to: string, patientName: string, b
   enqueue(to, subject, text, html);
 }
 
+/** MFA grace period reminder sent to DOCTOR/NURSE who haven't set up 2FA */
+export function sendMfaGracePeriodReminderEmail(
+  to: string,
+  name: string,
+  daysRemaining: number,
+  gracePeriodEndsAt: Date
+): void {
+  const setupUrl = `${APP_BASE_URL()}/settings/security`;
+  const deadlineStr = gracePeriodEndsAt.toLocaleDateString('en-US', {
+    year: 'numeric', month: 'long', day: 'numeric',
+  });
+  const urgency = daysRemaining === 1 ? '🚨 Last day' : `⚠️ ${daysRemaining} days remaining`;
+  const subject = `${urgency}: Set up Two-Factor Authentication — Health Watchers`;
+  const text = `Hi ${name},\n\nYour account requires two-factor authentication (2FA) to be set up by ${deadlineStr}.\n\nAfter that date, you will not be able to log in until 2FA is enabled.\n\nSet it up now: ${setupUrl}`;
+  const html = `
+    <h3>${urgency}: Two-Factor Authentication Required</h3>
+    <p>Hi <strong>${name}</strong>,</p>
+    <p>Your account requires two-factor authentication (2FA) to protect patient data.</p>
+    <p><strong>Deadline:</strong> ${deadlineStr}</p>
+    <p>After this date, you will <strong>not be able to log in</strong> until 2FA is enabled.</p>
+    <p><a href="${setupUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px">Set Up 2FA Now</a></p>
+    <hr style="margin-top:32px">
+    <small style="color:#6b7280">Health Watchers — HIPAA Compliance</small>
+  `;
+  enqueue(to, subject, text, html);
+}
+
 /** Referral outcome notification sent to referring doctor */
 export function sendOutcomeNotificationEmail(
   to: string,

--- a/apps/api/src/migrations/20260624_add_mfa_grace_period.ts
+++ b/apps/api/src/migrations/20260624_add_mfa_grace_period.ts
@@ -1,0 +1,21 @@
+import { Db } from 'mongodb';
+
+/**
+ * Migration: Add mfaGracePeriodEndsAt to users collection.
+ *
+ * DOCTOR and NURSE users that don't have MFA enabled get a 7-day grace period
+ * before login is blocked. This field tracks when that deadline expires.
+ */
+export async function up(db: Db): Promise<void> {
+  // Add the index so the grace period reminder job query is fast
+  await db.collection('users').createIndex(
+    { role: 1, mfaEnabled: 1, mfaGracePeriodEndsAt: 1 },
+    { background: true, sparse: true, name: 'role_1_mfaEnabled_1_mfaGracePeriodEndsAt_1' }
+  );
+}
+
+export async function down(db: Db): Promise<void> {
+  await db.collection('users')
+    .dropIndex('role_1_mfaEnabled_1_mfaGracePeriodEndsAt_1')
+    .catch(() => {});
+}

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -49,7 +49,8 @@ const MAX_MFA_ATTEMPTS = 5;
 const LOCK_DURATION_MS = 15 * 60 * 1000; // 15 minutes
 
 // Roles that must have 2FA enabled
-const MFA_REQUIRED_ROLES = new Set(['CLINIC_ADMIN', 'SUPER_ADMIN']);
+const MFA_REQUIRED_ROLES = new Set(['CLINIC_ADMIN', 'SUPER_ADMIN', 'DOCTOR', 'NURSE']);
+const MFA_GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /** SHA-256 hash of a token for safe storage */
 function hashToken(token: string): string {
@@ -176,13 +177,44 @@ router.post(
       });
     }
 
-    // Enforce 2FA for admin roles — block login if not set up
+    // Enforce 2FA for required roles — with 7-day grace period for DOCTOR/NURSE
     if (MFA_REQUIRED_ROLES.has(user.role) && !user.mfaEnabled) {
-      return res.status(403).json({
-        error: 'MfaRequired',
-        message: '2FA is mandatory for your role. Please set up 2FA before logging in.',
-        requiresMfaSetup: true,
-        tempToken: signTempToken(user.id),
+      const now = new Date();
+
+      // Assign grace period on first login after becoming required
+      if (!user.mfaGracePeriodEndsAt) {
+        user.mfaGracePeriodEndsAt = new Date(now.getTime() + MFA_GRACE_PERIOD_MS);
+        await user.save();
+      }
+
+      // Grace period expired — block login
+      if (user.mfaGracePeriodEndsAt <= now) {
+        return res.status(403).json({
+          error: 'MfaRequired',
+          message: '2FA is mandatory for your role. Please set up 2FA to log in.',
+          requiresMfaSetup: true,
+          tempToken: signTempToken(user.id),
+        });
+      }
+
+      // Within grace period — allow login with a warning
+      const p = { userId: user.id, role: user.role, clinicId: String(user.clinicId) };
+      const { token: refreshToken, jti, family } = signRefreshToken(p);
+      await RefreshTokenModel.create({
+        jti,
+        userId: user.id,
+        family,
+        consumed: false,
+        expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS),
+      });
+      return res.json({
+        status: 'success',
+        data: {
+          accessToken: signAccessToken(p),
+          refreshToken,
+          warning: 'mfa_required',
+          mfaGracePeriodEndsAt: user.mfaGracePeriodEndsAt,
+        },
       });
     }
 

--- a/apps/api/src/modules/auth/mfa-grace-period-job.ts
+++ b/apps/api/src/modules/auth/mfa-grace-period-job.ts
@@ -1,0 +1,59 @@
+import { UserModel } from './models/user.model';
+import { sendMfaGracePeriodReminderEmail } from '@api/lib/email.service';
+import logger from '@api/utils/logger';
+
+/**
+ * MFA Grace Period Reminder Job
+ *
+ * Runs daily. Sends email reminders to DOCTOR/NURSE users who have not yet
+ * enabled MFA when their grace period is 3 days or 1 day away.
+ */
+
+export const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const REMINDER_DAYS = [3, 1]; // days before deadline to send reminders
+
+let jobInterval: NodeJS.Timeout | null = null;
+
+export async function runMfaGracePeriodReminderTick(): Promise<void> {
+  const now = new Date();
+
+  for (const days of REMINDER_DAYS) {
+    // Window: users whose grace period ends between (now + days*24h - 1h) and (now + days*24h)
+    const windowEnd = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+    const windowStart = new Date(windowEnd.getTime() - 60 * 60 * 1000); // 1-hour window
+
+    const users = await UserModel.find({
+      role: { $in: ['DOCTOR', 'NURSE'] },
+      mfaEnabled: false,
+      mfaGracePeriodEndsAt: { $gte: windowStart, $lt: windowEnd },
+    }).select('email fullName mfaGracePeriodEndsAt');
+
+    for (const user of users) {
+      sendMfaGracePeriodReminderEmail(
+        user.email,
+        user.fullName,
+        days,
+        user.mfaGracePeriodEndsAt!
+      );
+      logger.info({ userId: user.id, days }, '[mfa-grace-period-job] reminder sent');
+    }
+  }
+}
+
+export function startMfaGracePeriodJob(): void {
+  if (jobInterval) {
+    logger.warn('[mfa-grace-period-job] already running');
+    return;
+  }
+  logger.info('[mfa-grace-period-job] starting');
+  runMfaGracePeriodReminderTick();
+  jobInterval = setInterval(() => runMfaGracePeriodReminderTick(), CHECK_INTERVAL_MS);
+}
+
+export function stopMfaGracePeriodJob(): void {
+  if (jobInterval) {
+    clearInterval(jobInterval);
+    jobInterval = null;
+    logger.info('[mfa-grace-period-job] stopped');
+  }
+}

--- a/apps/api/src/modules/auth/mfa-grace-period.test.ts
+++ b/apps/api/src/modules/auth/mfa-grace-period.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for MFA grace period enforcement on DOCTOR and NURSE roles (Issue #701).
+ */
+
+// ── Environment stubs ─────────────────────────────────────────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    apiPort: '3001',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    horizonUrl: '',
+    secretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+  },
+}));
+
+jest.mock('@api/modules/patients/patients.controller', () => ({ patientRoutes: require('express').Router() }));
+jest.mock('@api/modules/encounters/encounters.controller', () => ({ encounterRoutes: require('express').Router() }));
+jest.mock('@api/modules/payments/payments.controller', () => ({ paymentRoutes: require('express').Router() }));
+jest.mock('@api/modules/ai/ai.routes', () => require('express').Router());
+jest.mock('@api/modules/dashboard/dashboard.routes', () => require('express').Router());
+jest.mock('@api/modules/appointments/appointments.controller', () => ({ appointmentRoutes: require('express').Router() }));
+jest.mock('@api/modules/clinics/clinics.controller', () => ({ clinicRoutes: require('express').Router() }));
+jest.mock('@api/modules/users/users.controller', () => ({ userRoutes: require('express').Router() }));
+jest.mock('@api/modules/webhooks/webhooks.controller', () => ({ webhookRoutes: require('express').Router() }));
+jest.mock('@api/modules/audit/audit-logs.controller', () => ({ auditLogRoutes: require('express').Router() }));
+
+jest.mock('@api/config/db', () => ({ connectDB: jest.fn().mockReturnValue(new Promise(() => {})) }));
+jest.mock('@api/docs/swagger', () => ({ setupSwagger: jest.fn() }));
+jest.mock('@api/modules/payments/services/payment-expiration-job', () => ({
+  startPaymentExpirationJob: jest.fn(),
+  stopPaymentExpirationJob: jest.fn(),
+}));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@api/lib/email.service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+  sendMfaGracePeriodReminderEmail: jest.fn(),
+}));
+
+jest.mock('@api/modules/auth/models/user.model', () => ({
+  UserModel: {
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    find: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/auth/models/refresh-token.model', () => ({
+  RefreshTokenModel: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    deleteOne: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/auth/totp.service', () => ({
+  totpService: { setup: jest.fn(), verify: jest.fn() },
+}));
+
+jest.mock('@api/middlewares/rate-limit.middleware', () => {
+  const pass = (_req: unknown, _res: unknown, next: () => void) => next();
+  return {
+    authLimiter: pass,
+    forgotPasswordLimiter: pass,
+    aiLimiter: pass,
+    paymentLimiter: pass,
+    generalLimiter: pass,
+  };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import app from '@api/app';
+import { UserModel } from '@api/modules/auth/models/user.model';
+import { RefreshTokenModel } from '@api/modules/auth/models/refresh-token.model';
+import { sendMfaGracePeriodReminderEmail } from '@api/lib/email.service';
+import { runMfaGracePeriodReminderTick } from './mfa-grace-period-job';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const CLINIC_ID = '507f1f77bcf86cd799439011';
+const USER_ID = '507f1f77bcf86cd799439022';
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: USER_ID,
+    _id: USER_ID,
+    email: 'doctor@clinic.com',
+    fullName: 'Dr. House',
+    password: '$2a$12$hashedpassword',
+    role: 'DOCTOR',
+    clinicId: CLINIC_ID,
+    isActive: true,
+    mfaEnabled: false,
+    failedLoginAttempts: 0,
+    lockedUntil: undefined as Date | undefined,
+    mfaGracePeriodEndsAt: undefined as Date | undefined,
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('MFA grace period enforcement — DOCTOR and NURSE roles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+    (RefreshTokenModel.create as jest.Mock).mockResolvedValue({});
+  });
+
+  // ── DOCTOR and NURSE added to MFA_REQUIRED_ROLES ──────────────────────────
+
+  it('assigns a grace period on first login for DOCTOR without mfaGracePeriodEndsAt', async () => {
+    const user = makeUser({ role: 'DOCTOR' });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'doctor@clinic.com', password: 'ValidPass1!' });
+
+    expect(user.save).toHaveBeenCalled();
+    expect(user.mfaGracePeriodEndsAt).toBeInstanceOf(Date);
+    expect(user.mfaGracePeriodEndsAt!.getTime()).toBeGreaterThan(Date.now());
+    // Login succeeds with a warning
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.warning).toBe('mfa_required');
+    expect(res.body.data).toHaveProperty('mfaGracePeriodEndsAt');
+  });
+
+  it('assigns a grace period on first login for NURSE without mfaGracePeriodEndsAt', async () => {
+    const user = makeUser({ role: 'NURSE', email: 'nurse@clinic.com' });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'nurse@clinic.com', password: 'ValidPass1!' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.warning).toBe('mfa_required');
+    expect(user.mfaGracePeriodEndsAt).toBeInstanceOf(Date);
+  });
+
+  it('allows login during active grace period and returns tokens + warning', async () => {
+    const gracePeriodEndsAt = new Date(Date.now() + 4 * 24 * 60 * 60 * 1000); // 4 days away
+    const user = makeUser({ mfaGracePeriodEndsAt: gracePeriodEndsAt });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'doctor@clinic.com', password: 'ValidPass1!' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data).toHaveProperty('accessToken');
+    expect(res.body.data).toHaveProperty('refreshToken');
+    expect(res.body.data.warning).toBe('mfa_required');
+    expect(res.body.data).toHaveProperty('mfaGracePeriodEndsAt');
+  });
+
+  it('blocks login after grace period expires and returns 403 with tempToken', async () => {
+    const gracePeriodEndsAt = new Date(Date.now() - 60 * 1000); // 1 minute ago
+    const user = makeUser({ mfaGracePeriodEndsAt: gracePeriodEndsAt });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'doctor@clinic.com', password: 'ValidPass1!' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('MfaRequired');
+    expect(res.body.requiresMfaSetup).toBe(true);
+    expect(res.body).toHaveProperty('tempToken');
+    expect(typeof res.body.tempToken).toBe('string');
+  });
+
+  it('blocks NURSE login after grace period expires', async () => {
+    const gracePeriodEndsAt = new Date(Date.now() - 1000);
+    const user = makeUser({ role: 'NURSE', email: 'nurse@clinic.com', mfaGracePeriodEndsAt: gracePeriodEndsAt });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'nurse@clinic.com', password: 'ValidPass1!' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('MfaRequired');
+  });
+
+  it('does not block DOCTOR login once MFA is enabled (proceeds to mfa_required challenge)', async () => {
+    const user = makeUser({ mfaEnabled: true });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'doctor@clinic.com', password: 'ValidPass1!' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('mfa_required');
+    expect(res.body.data.mfaRequired).toBe(true);
+  });
+
+  it('does not apply grace period logic to ASSISTANT role', async () => {
+    const user = makeUser({ role: 'ASSISTANT' });
+    (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+    const res = await request(app)
+      .post('/api/v1/auth/login')
+      .send({ email: 'doctor@clinic.com', password: 'ValidPass1!' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.warning).toBeUndefined();
+  });
+});
+
+// ── MFA grace period reminder job ─────────────────────────────────────────────
+describe('runMfaGracePeriodReminderTick', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('sends a 3-day reminder to users whose grace period ends in ~3 days', async () => {
+    const threeDays = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000 - 30 * 60 * 1000); // 30min inside window
+    const user = { id: USER_ID, email: 'doctor@clinic.com', fullName: 'Dr. House', mfaGracePeriodEndsAt: threeDays };
+
+    (UserModel.find as jest.Mock)
+      .mockResolvedValueOnce([user]) // 3-day window
+      .mockResolvedValueOnce([]);    // 1-day window
+
+    await runMfaGracePeriodReminderTick();
+
+    expect(sendMfaGracePeriodReminderEmail).toHaveBeenCalledWith(
+      user.email,
+      user.fullName,
+      3,
+      threeDays
+    );
+  });
+
+  it('sends a 1-day reminder to users whose grace period ends in ~1 day', async () => {
+    const oneDay = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000 - 30 * 60 * 1000);
+    const user = { id: USER_ID, email: 'nurse@clinic.com', fullName: 'Nurse Joy', mfaGracePeriodEndsAt: oneDay };
+
+    (UserModel.find as jest.Mock)
+      .mockResolvedValueOnce([])      // 3-day window
+      .mockResolvedValueOnce([user]); // 1-day window
+
+    await runMfaGracePeriodReminderTick();
+
+    expect(sendMfaGracePeriodReminderEmail).toHaveBeenCalledWith(
+      user.email,
+      user.fullName,
+      1,
+      oneDay
+    );
+  });
+
+  it('sends no emails when no users are in a reminder window', async () => {
+    (UserModel.find as jest.Mock).mockResolvedValue([]);
+
+    await runMfaGracePeriodReminderTick();
+
+    expect(sendMfaGracePeriodReminderEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/auth/models/user.model.ts
+++ b/apps/api/src/modules/auth/models/user.model.ts
@@ -51,6 +51,7 @@ export interface User {
   failedMfaAttempts: number;
   lockedUntil?: Date; // brute-force protection
   mustChangePassword?: boolean; // Force password change on next login
+  mfaGracePeriodEndsAt?: Date; // DOCTOR/NURSE: deadline to enable MFA before login is blocked
   preferences: UserPreferences;
   stellarPublicKey?: string; // Doctor's personal Stellar wallet for payment splits
   // Portal MFA fields (for PATIENT role)
@@ -119,6 +120,12 @@ const userSchema = new Schema(
       index: true,
     },
     mustChangePassword: { type: Boolean, default: false },
+    mfaGracePeriodEndsAt: {
+      type: Date,
+      required: false,
+      default: undefined,
+      index: true,
+    },
     preferences: {
       language: { type: String, default: 'en' },
       theme: { type: String, enum: ['light', 'dark', 'system'], default: 'system' },


### PR DESCRIPTION
## Summary

Implements HIPAA-recommended MFA enforcement for `DOCTOR` and `NURSE` roles, which have full read/write access to patient PHI.

## Changes

### Core enforcement (`auth.controller.ts`)
- Add `DOCTOR` and `NURSE` to `MFA_REQUIRED_ROLES`
- On first login without MFA: assign `mfaGracePeriodEndsAt` (+7 days) and return tokens with `warning: 'mfa_required'` in the response
- During the grace period: login succeeds with the warning
- After the grace period: login blocked with `403 MfaRequired` + `tempToken` for MFA setup redirect

### UserModel (`user.model.ts`)
- Add `mfaGracePeriodEndsAt?: Date` field with a DB index

### Email reminders (`email.service.ts`)
- Add `sendMfaGracePeriodReminderEmail` function

### Background job (`mfa-grace-period-job.ts`)
- Runs daily; sends email reminders 3 days and 1 day before the grace period ends
- Wired into `app.ts` startup and graceful shutdown

### Migration (`20260624_add_mfa_grace_period.ts`)
- Adds a compound index on `{role, mfaEnabled, mfaGracePeriodEndsAt}` for efficient job queries

### Tests (`mfa-grace-period.test.ts`)
- Grace period assigned on first login for DOCTOR and NURSE
- Login allowed with warning during active grace period
- Login blocked after grace period expires
- Unaffected roles (ASSISTANT) bypass grace period logic
- Reminder job sends 3-day and 1-day emails in the correct time windows

## Acceptance Criteria

- [x] DOCTOR and NURSE roles are required to enable MFA
- [x] Existing users get a 7-day grace period before enforcement
- [x] Login returns a warning with `mfaGracePeriodEndsAt` during the grace period
- [x] After the grace period, login is blocked until MFA is set up
- [x] Email reminders are sent 3 days and 1 day before the grace period ends

Closes #701