### PR TITLE
feat(stellar): comprehensive structured logging for blockchain operations (closes #711)

### DIFF
--- a/apps/api/src/modules/payments/services/stellar-client.ts
+++ b/apps/api/src/modules/payments/services/stellar-client.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { config } from '@health-watchers/config';
+import { getRequestId } from '@api/utils/request-id';
+import logger from '@api/utils/logger';
 
 /**
  * Stellar Service Client
@@ -39,6 +41,57 @@ class StellarClient {
         'Content-Type': 'application/json',
       },
     });
+
+    // Propagate the API request ID so stellar-service logs can be correlated
+    // with the originating API request, and log every Horizon-service call.
+    this.client.interceptors.request.use((req) => {
+      const requestId = getRequestId();
+      if (requestId) {
+        req.headers = req.headers ?? {};
+        req.headers['x-request-id'] = requestId;
+      }
+      (req as { metadata?: { start: number } }).metadata = { start: Date.now() };
+      logger.debug(
+        { requestId, method: req.method, url: req.url, service: 'stellar-service' },
+        'stellar-service request'
+      );
+      return req;
+    });
+
+    this.client.interceptors.response.use(
+      (res) => {
+        const start = (res.config as { metadata?: { start: number } }).metadata?.start;
+        logger.debug(
+          {
+            requestId: getRequestId(),
+            method: res.config.method,
+            url: res.config.url,
+            status: res.status,
+            durationMs: start ? Date.now() - start : undefined,
+            service: 'stellar-service',
+          },
+          'stellar-service response'
+        );
+        return res;
+      },
+      (error) => {
+        const cfg = (error.config ?? {}) as { metadata?: { start: number }; method?: string; url?: string };
+        const start = cfg.metadata?.start;
+        logger.error(
+          {
+            requestId: getRequestId(),
+            method: cfg.method,
+            url: cfg.url,
+            status: error.response?.status,
+            durationMs: start ? Date.now() - start : undefined,
+            error: { message: error.message, data: error.response?.data },
+            service: 'stellar-service',
+          },
+          'stellar-service request failed'
+        );
+        return Promise.reject(error);
+      }
+    );
   }
 
   /**

--- a/apps/stellar-service/src/__tests__/logging-context.test.ts
+++ b/apps/stellar-service/src/__tests__/logging-context.test.ts
@@ -1,0 +1,90 @@
+import { jest } from '@jest/globals';
+import logger from '../logger';
+
+// Mock Horizon server so no real network calls are made.
+const mockFeeStats = jest.fn<any>();
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk') as any;
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: jest.fn().mockImplementation(() => ({
+        feeStats: mockFeeStats,
+      })),
+    },
+  };
+});
+
+import * as stellar from '../stellar';
+
+type Call = [Record<string, any>, string?];
+
+describe('Stellar logging context', () => {
+  let infoSpy: any;
+  let errorSpy: any;
+  let debugSpy: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    infoSpy = jest.spyOn(logger as any, 'info');
+    errorSpy = jest.spyOn(logger as any, 'error');
+    debugSpy = jest.spyOn(logger as any, 'debug');
+  });
+
+  it('logs the operation outcome and Horizon request/response for a successful call', async () => {
+    mockFeeStats.mockResolvedValueOnce({
+      fee_charged: {
+        min: '100',
+        mode: '100',
+        max: '10000',
+        p10: '100',
+        p50: '200',
+        p90: '500',
+        p99: '1000',
+      },
+    });
+
+    await stellar.getFeeStats();
+
+    // Operation-level structured log with explicit outcome + timing.
+    const opLog = (infoSpy.mock.calls as Call[]).find(
+      (c) => c[0]?.operation === 'getFeeStats' && c[0]?.outcome === 'success'
+    );
+    expect(opLog).toBeTruthy();
+    expect(typeof opLog![0].durationMs).toBe('number');
+
+    // Horizon request + response are both logged with timing.
+    const reqLog = (debugSpy.mock.calls as Call[]).find(
+      (c) => c[0]?.horizonOp === 'feeStats' && c[0]?.phase === 'request'
+    );
+    const resLog = (debugSpy.mock.calls as Call[]).find(
+      (c) => c[0]?.horizonOp === 'feeStats' && c[0]?.phase === 'response' && c[0]?.outcome === 'success'
+    );
+    expect(reqLog).toBeTruthy();
+    expect(resLog).toBeTruthy();
+    expect(typeof resLog![0].durationMs).toBe('number');
+  });
+
+  it('logs full error context (status, Horizon result codes) with outcome=failure', async () => {
+    mockFeeStats.mockRejectedValueOnce({
+      message: 'Service unavailable',
+      response: {
+        status: 503,
+        data: { extras: { result_codes: { transaction: 'tx_insufficient_fee' } }, detail: 'boom' },
+      },
+    });
+
+    await expect(stellar.getFeeStats()).rejects.toBeTruthy();
+
+    const failLog = (errorSpy.mock.calls as Call[]).find(
+      (c) => c[0]?.horizonOp === 'feeStats' && c[0]?.outcome === 'failure'
+    );
+    expect(failLog).toBeTruthy();
+    expect(failLog![0].error.message).toBe('Service unavailable');
+    expect(failLog![0].error.status).toBe(503);
+    expect(failLog![0].error.horizonResultCodes).toEqual({ transaction: 'tx_insufficient_fee' });
+    expect(typeof failLog![0].durationMs).toBe('number');
+  });
+});

--- a/apps/stellar-service/src/__tests__/stellar.test.ts
+++ b/apps/stellar-service/src/__tests__/stellar.test.ts
@@ -48,7 +48,7 @@ describe('Stellar Service Tests', () => {
 
       const result = await stellar.fundAccount('GTEST123');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         funded: true,
         hash: 'test-hash-123',
         ledger: 12345,
@@ -164,7 +164,7 @@ describe('Stellar Service Tests', () => {
 
       const result = await stellar.verifyIntent('valid-hash-789');
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         found: true,
         hash: 'valid-hash-789',
         successful: true,

--- a/apps/stellar-service/src/stellar.ts
+++ b/apps/stellar-service/src/stellar.ts
@@ -17,6 +17,58 @@ const horizonClient = new ResilientHorizonClient(stellarConfig.horizonUrls);
 horizonClient.startHealthChecks();
 
 /**
+ * Normalise a thrown value into a fully-detailed error context for logging.
+ * Captures the message, stack, name, and any Horizon-specific result codes —
+ * which are essential for debugging failed (and irreversible) transactions.
+ */
+export function toErrorContext(error: unknown): Record<string, unknown> {
+  const err = error as any;
+  return {
+    message: err?.message ?? String(error),
+    name: err?.name,
+    stack: err?.stack,
+    status: err?.response?.status,
+    horizonResultCodes: err?.response?.data?.extras?.result_codes,
+    horizonDetail: err?.response?.data?.detail ?? err?.response?.data?.title,
+  };
+}
+
+/**
+ * Instrument a single Horizon API call: logs the request and the response
+ * (with timing + outcome) at debug level, and any failure with full context.
+ * Returns the wrapped call's result so callers keep their existing behaviour.
+ */
+export async function withHorizonCall<T>(
+  horizonOp: string,
+  meta: Record<string, unknown>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const start = Date.now();
+  logger.debug({ horizonOp, ...meta, phase: 'request' }, `Horizon request: ${horizonOp}`);
+  try {
+    const result = await fn();
+    logger.debug(
+      { horizonOp, ...meta, phase: 'response', outcome: 'success', durationMs: Date.now() - start },
+      `Horizon response: ${horizonOp}`
+    );
+    return result;
+  } catch (error) {
+    logger.error(
+      {
+        horizonOp,
+        ...meta,
+        phase: 'response',
+        outcome: 'failure',
+        durationMs: Date.now() - start,
+        error: toErrorContext(error),
+      },
+      `Horizon call failed: ${horizonOp}`
+    );
+    throw error;
+  }
+}
+
+/**
  * Get the appropriate network passphrase using SDK constants
  */
 export function getNetworkPassphrase(): string {
@@ -62,8 +114,8 @@ export async function fundAccount(publicKey: string, amount?: number) {
 
     const json = await response.json() as { hash: string; ledger: number };
     const durationMs = Date.now() - start;
-    logger.info({ operation: 'fundAccount', publicKey, hash: json.hash, ledger: json.ledger, durationMs }, 'Account funded successfully');
-    
+    logger.info({ operation: 'fundAccount', publicKey, asset: 'XLM', hash: json.hash, ledger: json.ledger, outcome: 'success', durationMs }, 'Account funded successfully');
+
     return {
       funded: true,
       hash: json.hash,
@@ -71,7 +123,7 @@ export async function fundAccount(publicKey: string, amount?: number) {
       durationMs,
     };
   } catch (error) {
-    logger.error({ operation: 'fundAccount', error: { message: (error as Error).message, stack: (error as any).stack }, publicKey }, 'Failed to fund account');
+    logger.error({ operation: 'fundAccount', publicKey, asset: 'XLM', outcome: 'failure', durationMs: Date.now() - start, error: toErrorContext(error) }, 'Failed to fund account');
     throw error;
   }
 }
@@ -84,13 +136,17 @@ export async function getAccountBalance(publicKey: string) {
   try {
     const start = Date.now();
     logger.info({ operation: 'getAccountBalance', publicKey }, 'Loading account from Horizon');
-    const account = await server.loadAccount(publicKey);
+    const account = await withHorizonCall('loadAccount', { publicKey }, () =>
+      server.loadAccount(publicKey)
+    );
     const xlmBalance = account.balances.find((b: any) => b.asset_type === 'native');
     const usdcBalance = account.balances.find(
       (b: any) => b.asset_code === 'USDC' && b.asset_type !== 'native'
     );
 
-    const payments = await server.payments().forAccount(publicKey).limit(10).order('desc').call();
+    const payments = await withHorizonCall('payments', { publicKey }, () =>
+      server.payments().forAccount(publicKey).limit(10).order('desc').call()
+    );
     const transactions = payments.records
       .filter((r: any) => r.type === 'payment' || r.type === 'create_account')
       .map((r: any) => ({
@@ -105,7 +161,7 @@ export async function getAccountBalance(publicKey: string) {
       }));
 
     const durationMs = Date.now() - start;
-    logger.info({ operation: 'getAccountBalance', publicKey, durationMs }, 'Fetched account balance and recent transactions');
+    logger.info({ operation: 'getAccountBalance', publicKey, outcome: 'success', durationMs }, 'Fetched account balance and recent transactions');
     return {
       balance: xlmBalance ? xlmBalance.balance : '0',
       usdcBalance: usdcBalance ? usdcBalance.balance : null,
@@ -113,7 +169,7 @@ export async function getAccountBalance(publicKey: string) {
       durationMs,
     };
   } catch (error: any) {
-    logger.error({ operation: 'getAccountBalance', error: { message: error.message, stack: error.stack }, publicKey }, 'Failed to get account balance');
+    logger.error({ operation: 'getAccountBalance', publicKey, outcome: 'failure', error: toErrorContext(error) }, 'Failed to get account balance');
     throw error;
   }
 }
@@ -122,43 +178,71 @@ export async function getAccountBalance(publicKey: string) {
  * Create a USDC trustline for an account
  */
 export async function createUsdcTrustline(publicKey: string, usdcIssuer: string) {
-  const server = getHorizonServer();
-  const sourceAccount = await server.loadAccount(publicKey);
-
-  // Check if trustline already exists
-  const existing = sourceAccount.balances.find(
-    (b: any) => b.asset_code === 'USDC' && b.asset_issuer === usdcIssuer
-  );
-  if (existing) {
-    return { alreadyExists: true, trustline: 'USDC' };
-  }
-
   const start = Date.now();
-  const fee = await server.fetchBaseFee();
-  const transaction = new TransactionBuilder(sourceAccount, {
-    fee: String(fee),
-    networkPassphrase: getNetworkPassphrase(),
-  })
-    .addOperation(
-      Operation.changeTrust({
-        asset: new Asset('USDC', usdcIssuer),
-      })
-    )
-    .setTimeout(30)
-    .build();
+  logger.info(
+    { operation: 'createUsdcTrustline', publicKey, asset: 'USDC', usdcIssuer },
+    'Creating USDC trustline'
+  );
+
+  try {
+    const server = getHorizonServer();
+    const sourceAccount = await withHorizonCall('loadAccount', { publicKey }, () =>
+      server.loadAccount(publicKey)
+    );
+
+    // Check if trustline already exists
+    const existing = sourceAccount.balances.find(
+      (b: any) => b.asset_code === 'USDC' && b.asset_issuer === usdcIssuer
+    );
+    if (existing) {
+      logger.info(
+        { operation: 'createUsdcTrustline', publicKey, asset: 'USDC', outcome: 'success', alreadyExists: true },
+        'USDC trustline already exists'
+      );
+      return { alreadyExists: true, trustline: 'USDC' };
+    }
+
+    const fee = await withHorizonCall('fetchBaseFee', { publicKey }, () => server.fetchBaseFee());
+    const transaction = new TransactionBuilder(sourceAccount, {
+      fee: String(fee),
+      networkPassphrase: getNetworkPassphrase(),
+    })
+      .addOperation(
+        Operation.changeTrust({
+          asset: new Asset('USDC', usdcIssuer),
+        })
+      )
+      .setTimeout(30)
+      .build();
 
     if (stellarConfig.stellarSecretKey) {
-    const keypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
-    transaction.sign(keypair);
+      const keypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
+      transaction.sign(keypair);
       if (!stellarConfig.dryRun) {
-        const result = await server.submitTransaction(transaction);
+        const result = await withHorizonCall('submitTransaction', { publicKey, asset: 'USDC' }, () =>
+          server.submitTransaction(transaction)
+        );
         const durationMs = Date.now() - start;
-        logger.info({ operation: 'createUsdcTrustline', publicKey, usdcIssuer, hash: result.hash, durationMs }, 'USDC trustline created');
+        logger.info(
+          { operation: 'createUsdcTrustline', publicKey, asset: 'USDC', usdcIssuer, hash: result.hash, outcome: 'success', durationMs },
+          'USDC trustline created'
+        );
         return { created: true, hash: result.hash, durationMs };
       }
-  }
+    }
 
-  return { envelope: transaction.toEnvelope().toXDR('base64'), dryRun: true };
+    logger.info(
+      { operation: 'createUsdcTrustline', publicKey, asset: 'USDC', outcome: 'success', dryRun: true, durationMs: Date.now() - start },
+      'USDC trustline transaction built (dry run)'
+    );
+    return { envelope: transaction.toEnvelope().toXDR('base64'), dryRun: true };
+  } catch (error) {
+    logger.error(
+      { operation: 'createUsdcTrustline', publicKey, asset: 'USDC', usdcIssuer, outcome: 'failure', durationMs: Date.now() - start, error: toErrorContext(error) },
+      'Failed to create USDC trustline'
+    );
+    throw error;
+  }
 }
 
 /**
@@ -178,8 +262,10 @@ export async function createIntent(
   const sourceKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
 
   try {
-    const account = await server.loadAccount(fromPublicKey);
-    
+    const account = await withHorizonCall('loadAccount', { publicKey: fromPublicKey }, () =>
+      server.loadAccount(fromPublicKey)
+    );
+
     const transaction = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: getNetworkPassphrase(),
@@ -200,7 +286,7 @@ export async function createIntent(
     const hash = transaction.hash().toString('hex');
     const durationMs = Date.now() - start;
 
-    logger.info({ operation: 'createIntent', hash, durationMs }, 'Payment intent created');
+    logger.info({ operation: 'createIntent', from: fromPublicKey, to: toPublicKey, amount, asset: 'XLM', hash, outcome: 'success', durationMs }, 'Payment intent created');
 
     return {
       xdr,
@@ -210,7 +296,7 @@ export async function createIntent(
       durationMs,
     };
   } catch (error) {
-    logger.error({ operation: 'createIntent', error: { message: (error as Error).message, stack: (error as any).stack }, from: fromPublicKey, to: toPublicKey }, 'Failed to create intent');
+    logger.error({ operation: 'createIntent', from: fromPublicKey, to: toPublicKey, amount, asset: 'XLM', outcome: 'failure', durationMs: Date.now() - start, error: toErrorContext(error) }, 'Failed to create intent');
     throw error;
   }
 }
@@ -225,9 +311,11 @@ export async function verifyIntent(hash: string) {
   const server = getHorizonServer();
 
   try {
-    const transaction = await server.transactions().transaction(hash).call();
+    const transaction = await withHorizonCall('transactions', { hash }, () =>
+      server.transactions().transaction(hash).call()
+    );
     const durationMs = Date.now() - start;
-    logger.info({ operation: 'verifyIntent', hash, successful: transaction.successful, durationMs }, 'Transaction verified');
+    logger.info({ operation: 'verifyIntent', hash, successful: transaction.successful, outcome: 'success', durationMs }, 'Transaction verified');
 
     return {
       found: true,
@@ -238,10 +326,11 @@ export async function verifyIntent(hash: string) {
       durationMs,
     };
   } catch (error: any) {
-    logger.error({ operation: 'verifyIntent', error: { message: error.message, stack: error.stack }, hash }, 'Failed to verify transaction');
     if (error.response?.status === 404) {
+      logger.info({ operation: 'verifyIntent', hash, outcome: 'not_found' }, 'Transaction not found on Horizon');
       return { found: false, error: 'Transaction not found' };
     }
+    logger.error({ operation: 'verifyIntent', hash, outcome: 'failure', error: toErrorContext(error) }, 'Failed to verify transaction');
     throw error;
   }
 }
@@ -268,12 +357,14 @@ export async function findPaths(
 
   try {
     const start = Date.now();
-    const paths = await server
-      .strictReceivePaths(sourceAssets, destAsset, destinationAmount)
-      .call();
+    const paths = await withHorizonCall(
+      'strictReceivePaths',
+      { sourceAssetCode, destinationAssetCode, destinationAmount },
+      () => server.strictReceivePaths(sourceAssets, destAsset, destinationAmount).call()
+    );
 
     const durationMs = Date.now() - start;
-    logger.info({ operation: 'findPaths', sourceAssetCode, destinationAssetCode, destinationAmount, durationMs, count: paths.records.length }, 'Found payment paths');
+    logger.info({ operation: 'findPaths', sourceAssetCode, destinationAssetCode, destinationAmount, outcome: 'success', durationMs, count: paths.records.length }, 'Found payment paths');
 
     return paths.records.map((p: Horizon.ServerApi.PaymentPathRecord) => ({
       sourceAssetCode: p.source_asset_type === 'native' ? 'XLM' : p.source_asset_code,
@@ -285,7 +376,7 @@ export async function findPaths(
       path: p.path.map((a: any) => a.asset_type === 'native' ? 'XLM' : a.asset_code),
     }));
   } catch (error: any) {
-    logger.error({ operation: 'findPaths', error: { message: error.message, stack: error.stack }, sourceAssetCode, destinationAssetCode }, 'Failed to find paths');
+    logger.error({ operation: 'findPaths', sourceAssetCode, destinationAssetCode, outcome: 'failure', error: toErrorContext(error) }, 'Failed to find paths');
     throw error;
   }
 }
@@ -306,9 +397,13 @@ export async function getOrderbook(
 
   try {
     const start = Date.now();
-    const orderbook = await server.orderbook(base, counter).call();
+    const orderbook = await withHorizonCall(
+      'orderbook',
+      { baseAssetCode, counterAssetCode },
+      () => server.orderbook(base, counter).call()
+    );
     const durationMs = Date.now() - start;
-    logger.info({ operation: 'getOrderbook', baseAssetCode, counterAssetCode, durationMs }, 'Fetched orderbook');
+    logger.info({ operation: 'getOrderbook', baseAssetCode, counterAssetCode, outcome: 'success', durationMs }, 'Fetched orderbook');
     return {
       base: baseAssetCode,
       counter: counterAssetCode,
@@ -317,7 +412,7 @@ export async function getOrderbook(
       durationMs,
     };
   } catch (error: any) {
-    logger.error({ operation: 'getOrderbook', error: { message: error.message, stack: error.stack }, baseAssetCode, counterAssetCode }, 'Failed to get orderbook');
+    logger.error({ operation: 'getOrderbook', baseAssetCode, counterAssetCode, outcome: 'failure', error: toErrorContext(error) }, 'Failed to get orderbook');
     throw error;
   }
 }
@@ -330,37 +425,62 @@ const STROOPS_PER_XLM = 10_000_000;
 export async function issueRefund(toPublicKey: string, amount: string, memo: string) {
   assertTransactionLimit(parseFloat(amount));
 
-  const server = getHorizonServer();
-  const sourceKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
-  const account = await server.loadAccount(sourceKeypair.publicKey());
-  const fee = await server.fetchBaseFee();
-
-  const transaction = new TransactionBuilder(account, {
-    fee: String(fee),
-    networkPassphrase: getNetworkPassphrase(),
-  })
-    .addOperation(
-      Operation.payment({
-        destination: toPublicKey,
-        asset: Asset.native(),
-        amount,
-      })
-    )
-    .addMemo({ type: 'text', value: memo.slice(0, 28) } as any)
-    .setTimeout(300)
-    .build();
-
-  transaction.sign(sourceKeypair);
-
-  if (stellarConfig.dryRun) {
-    return { transactionHash: 'dry-run-' + transaction.hash().toString('hex'), dryRun: true };
-  }
-
   const start = Date.now();
-  const result = await server.submitTransaction(transaction);
-  const durationMs = Date.now() - start;
-  logger.info({ operation: 'issueRefund', hash: result.hash, to: toPublicKey, amount, durationMs }, 'Refund issued');
-  return { transactionHash: result.hash, durationMs };
+  logger.info(
+    { operation: 'issueRefund', to: toPublicKey, amount, asset: 'XLM' },
+    'Issuing refund'
+  );
+
+  try {
+    const server = getHorizonServer();
+    const sourceKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
+    const account = await withHorizonCall('loadAccount', { publicKey: sourceKeypair.publicKey() }, () =>
+      server.loadAccount(sourceKeypair.publicKey())
+    );
+    const fee = await withHorizonCall('fetchBaseFee', {}, () => server.fetchBaseFee());
+
+    const transaction = new TransactionBuilder(account, {
+      fee: String(fee),
+      networkPassphrase: getNetworkPassphrase(),
+    })
+      .addOperation(
+        Operation.payment({
+          destination: toPublicKey,
+          asset: Asset.native(),
+          amount,
+        })
+      )
+      .addMemo({ type: 'text', value: memo.slice(0, 28) } as any)
+      .setTimeout(300)
+      .build();
+
+    transaction.sign(sourceKeypair);
+
+    if (stellarConfig.dryRun) {
+      const hash = 'dry-run-' + transaction.hash().toString('hex');
+      logger.info(
+        { operation: 'issueRefund', to: toPublicKey, amount, asset: 'XLM', hash, outcome: 'success', dryRun: true, durationMs: Date.now() - start },
+        'Refund transaction built (dry run)'
+      );
+      return { transactionHash: hash, dryRun: true };
+    }
+
+    const result = await withHorizonCall('submitTransaction', { to: toPublicKey, amount, asset: 'XLM' }, () =>
+      server.submitTransaction(transaction)
+    );
+    const durationMs = Date.now() - start;
+    logger.info(
+      { operation: 'issueRefund', hash: result.hash, to: toPublicKey, amount, asset: 'XLM', outcome: 'success', durationMs },
+      'Refund issued'
+    );
+    return { transactionHash: result.hash, durationMs };
+  } catch (error) {
+    logger.error(
+      { operation: 'issueRefund', to: toPublicKey, amount, asset: 'XLM', outcome: 'failure', durationMs: Date.now() - start, error: toErrorContext(error) },
+      'Failed to issue refund'
+    );
+    throw error;
+  }
 }
 
 function stroopsToXlm(stroops: string): string {
@@ -369,9 +489,16 @@ function stroopsToXlm(stroops: string): string {
 
 /** Fetch fee statistics from Horizon */
 export async function getFeeStats() {
+  const start = Date.now();
   const server = getHorizonServer();
-  const stats = await server.feeStats();
+  const stats = await withHorizonCall('feeStats', { operation: 'getFeeStats' }, () =>
+    server.feeStats()
+  );
   const { fee_charged } = stats;
+  logger.info(
+    { operation: 'getFeeStats', outcome: 'success', durationMs: Date.now() - start },
+    'Fetched fee statistics'
+  );
   return {
     slow:     { stroops: fee_charged.p10,  xlm: stroopsToXlm(fee_charged.p10),  confirmationTime: '~60s' },
     standard: { stroops: fee_charged.p50,  xlm: stroopsToXlm(fee_charged.p50),  confirmationTime: '~30s' },
@@ -401,34 +528,50 @@ export async function buildFeeBumpTransaction(innerXdr: string): Promise<{
     throw new Error('Platform secret key not configured for fee sponsorship');
   }
 
-  const platformKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
-  const { Transaction } = await import('@stellar/stellar-sdk');
+  const start = Date.now();
+  logger.info({ operation: 'buildFeeBumpTransaction' }, 'Building fee bump transaction');
 
-  // Deserialise the inner transaction
-  const innerTx = new Transaction(innerXdr, getNetworkPassphrase());
+  try {
+    const platformKeypair = Keypair.fromSecret(stellarConfig.stellarSecretKey);
+    const { Transaction } = await import('@stellar/stellar-sdk');
 
-  const feeStroops = parseInt(BASE_FEE, 10) * 10; // 10× base fee for priority
+    // Deserialise the inner transaction
+    const innerTx = new Transaction(innerXdr, getNetworkPassphrase());
 
-  const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
-    platformKeypair,
-    String(feeStroops),
-    innerTx,
-    getNetworkPassphrase(),
-  );
+    const feeStroops = parseInt(BASE_FEE, 10) * 10; // 10× base fee for priority
 
-  feeBumpTx.sign(platformKeypair);
+    const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+      platformKeypair,
+      String(feeStroops),
+      innerTx,
+      getNetworkPassphrase(),
+    );
 
-  const xdr = feeBumpTx.toXDR();
-  const hash = feeBumpTx.hash().toString('hex');
+    feeBumpTx.sign(platformKeypair);
 
-  logger.info({ hash, feeStroops }, 'Fee bump transaction built');
+    const xdr = feeBumpTx.toXDR();
+    const hash = feeBumpTx.hash().toString('hex');
 
-  if (!stellarConfig.dryRun) {
-    const server = getHorizonServer();
-    await server.submitTransaction(feeBumpTx);
+    if (!stellarConfig.dryRun) {
+      const server = getHorizonServer();
+      await withHorizonCall('submitTransaction', { operation: 'buildFeeBumpTransaction', hash, feeStroops }, () =>
+        server.submitTransaction(feeBumpTx)
+      );
+    }
+
+    logger.info(
+      { operation: 'buildFeeBumpTransaction', hash, feeStroops, outcome: 'success', durationMs: Date.now() - start },
+      'Fee bump transaction built'
+    );
+
+    return { xdr, hash, feeStroops };
+  } catch (error) {
+    logger.error(
+      { operation: 'buildFeeBumpTransaction', outcome: 'failure', durationMs: Date.now() - start, error: toErrorContext(error) },
+      'Failed to build fee bump transaction'
+    );
+    throw error;
   }
-
-  return { xdr, hash, feeStroops };
 }
 
 /** Check Horizon connectivity and latency */
@@ -437,9 +580,13 @@ export async function checkHorizon(): Promise<{ status: 'healthy' | 'unhealthy';
   const start = Date.now();
   try {
     await server.feeStats();
-    return { status: 'healthy', latency: Date.now() - start };
-  } catch {
-    return { status: 'unhealthy', latency: Date.now() - start };
+    const latency = Date.now() - start;
+    logger.debug({ operation: 'checkHorizon', outcome: 'success', latency }, 'Horizon healthy');
+    return { status: 'healthy', latency };
+  } catch (error) {
+    const latency = Date.now() - start;
+    logger.warn({ operation: 'checkHorizon', outcome: 'failure', latency, error: toErrorContext(error) }, 'Horizon health check failed');
+    return { status: 'unhealthy', latency };
   }
 }
 
@@ -465,7 +612,7 @@ export function streamAccountTransactions(
 ): () => void {
   const server = getHorizonServer();
 
-  logger.info({ publicKey }, 'Starting account transaction stream');
+  logger.info({ operation: 'streamAccountTransactions', publicKey }, 'Starting account transaction stream');
 
   const close = server
     .payments()
@@ -485,7 +632,7 @@ export function streamAccountTransactions(
         });
       },
       onerror: (err: unknown) => {
-        logger.error({ err, publicKey }, 'Account transaction stream error');
+        logger.error({ operation: 'streamAccountTransactions', publicKey, outcome: 'failure', error: toErrorContext(err) }, 'Account transaction stream error');
         onError?.(err);
       },
     });


### PR DESCRIPTION
## Summary

Makes all `stellar-service` blockchain operations fully auditable and debuggable. Because Stellar operations are irreversible, comprehensive structured logging is essential for debugging failed transactions and demonstrating compliance.

## Changes

**`stellar-service/src/stellar.ts`**
- `withHorizonCall(op, meta, fn)` — wraps every Horizon API call and logs it as a **request/response pair** with `durationMs` (timing) and `outcome`, surfacing failures with full context.
- `toErrorContext(error)` — captures `message`, `name`, `stack`, HTTP `status`, **Horizon `result_codes`** and `detail` — not just the error message.
- Every operation now logs **operation type, public key, amount, asset, tx hash, outcome and timing**: `fundAccount`, `getAccountBalance`, `createIntent`, `verifyIntent`, `createUsdcTrustline`, `issueRefund`, `getFeeStats`, `buildFeeBumpTransaction`, `findPaths`, `getOrderbook`, `checkHorizon`, `streamAccountTransactions`. Previously `createUsdcTrustline`, `issueRefund`, `getFeeStats` and `buildFeeBumpTransaction` had little/no logging and errors were logged as bare messages.

**`api/.../services/stellar-client.ts`** — completes request-id **correlation**: an axios interceptor forwards `x-request-id` (from the API's `getRequestId()`) to stellar-service and logs each service call's request/response/error with timing. The service already binds `x-request-id` into `AsyncLocalStorage`, so every service log line carries `requestId` — giving end-to-end correlation from API request → service log.

**Tests** — `logging-context.test.ts` verifies request/response logs, `outcome`, timing, and full error context (status + Horizon result codes) for a key operation. Also fixed two pre-existing `toEqual` assertions in `stellar.test.ts` that predated the `durationMs` return field (switched to `toMatchObject`).

## Acceptance criteria

- [x] All stellar-service operations logged with full context (operation, key, amount, asset, hash, outcome, timing)
- [x] Horizon API calls logged with request/response details
- [x] Errors include full context (status, Horizon result codes, stack)
- [x] Log correlation with API request ID works (API forwards `x-request-id`; service binds it via AsyncLocalStorage)
- [x] Tests verify log output for key operations

## Notes

- `tsc --noEmit` is clean for all changed files. The only type errors in the service tree are in the pre-existing, unrelated `payment-stream.ts`.
- The repo's jest runner currently fails to start across all suites due to a pre-existing `jest` / `jest-runtime` version skew (30.x vs hoisted 29.x), unrelated to this change — so the added test is verified by construction, not execution.

closes #711
