### PR TITLE
feat(patients): risk score explanation with factor breakdown and trends (closes #712)

### DIFF
--- a/apps/api/src/modules/ai/risk-calculator.test.ts
+++ b/apps/api/src/modules/ai/risk-calculator.test.ts
@@ -1,4 +1,9 @@
-import { calculateRiskScore, scoreToLevel } from './risk-calculator';
+import {
+  calculateRiskScore,
+  scoreToLevel,
+  buildFactorBreakdown,
+  getImprovedFactors,
+} from './risk-calculator';
 
 describe('scoreToLevel', () => {
   it('returns low for score < 20', () => expect(scoreToLevel(0)).toBe('low'));
@@ -358,5 +363,62 @@ describe('calculateRiskScore', () => {
     expect(factors).toContain('Diabetes');
     expect(factors).toContain('Recent hospitalization');
     expect(factors).toContain('Smoking history');
+  });
+});
+
+describe('buildFactorBreakdown (risk explanation generation)', () => {
+  const weights = {
+    'Recent hospitalization': 20,
+    Diabetes: 15,
+    'Age > 65': 10,
+  };
+  const factors = ['Recent hospitalization', 'Diabetes', 'Age > 65'];
+
+  it('computes each factor percentage of the total weight', () => {
+    const breakdown = buildFactorBreakdown(factors, weights, [], false);
+    const byFactor = Object.fromEntries(breakdown.map((b) => [b.factor, b]));
+    // total = 45 → 20/45=44%, 15/45=33%, 10/45=22%
+    expect(byFactor['Recent hospitalization'].percentage).toBe(44);
+    expect(byFactor['Diabetes'].percentage).toBe(33);
+    expect(byFactor['Age > 65'].percentage).toBe(22);
+  });
+
+  it('carries through the point weight for each factor', () => {
+    const breakdown = buildFactorBreakdown(factors, weights, [], false);
+    expect(breakdown.find((b) => b.factor === 'Diabetes')!.weight).toBe(15);
+  });
+
+  it('marks all factors stable when there is no prior assessment', () => {
+    const breakdown = buildFactorBreakdown(factors, weights, [], false);
+    expect(breakdown.every((b) => b.trend === 'stable')).toBe(true);
+  });
+
+  it('marks a newly-appeared factor as worsening and an unchanged one as stable', () => {
+    const previous = ['Diabetes', 'Age > 65']; // hospitalization is new
+    const breakdown = buildFactorBreakdown(factors, weights, previous, true);
+    const byFactor = Object.fromEntries(breakdown.map((b) => [b.factor, b]));
+    expect(byFactor['Recent hospitalization'].trend).toBe('worsening');
+    expect(byFactor['Diabetes'].trend).toBe('stable');
+    expect(byFactor['Age > 65'].trend).toBe('stable');
+  });
+
+  it('does not divide by zero when all weights are zero', () => {
+    const breakdown = buildFactorBreakdown(['X'], { X: 0 }, [], false);
+    expect(breakdown[0].percentage).toBe(0);
+  });
+});
+
+describe('getImprovedFactors (risk explanation generation)', () => {
+  it('returns factors present before but resolved now', () => {
+    const improved = getImprovedFactors(['Diabetes'], ['Diabetes', 'Smoking history']);
+    expect(improved).toEqual(['Smoking history']);
+  });
+
+  it('returns empty when nothing resolved', () => {
+    expect(getImprovedFactors(['Diabetes'], ['Diabetes'])).toEqual([]);
+  });
+
+  it('returns empty when there is no prior assessment', () => {
+    expect(getImprovedFactors(['Diabetes'], [])).toEqual([]);
   });
 });

--- a/apps/api/src/modules/ai/risk-calculator.ts
+++ b/apps/api/src/modules/ai/risk-calculator.ts
@@ -98,4 +98,52 @@ export function scoreToLevel(score: number): RiskLevel {
   return 'low';
 }
 
+export type FactorTrend = 'improving' | 'stable' | 'worsening';
+
+export interface FactorBreakdown {
+  factor: string;
+  weight: number;
+  /** Share of the total weight this factor represents (0–100, rounded). */
+  percentage: number;
+  trend: FactorTrend;
+}
+
+/**
+ * Build the per-factor breakdown shown in the risk explanation: each current
+ * factor with its point weight, its percentage of the total, and a trend
+ * relative to the previous assessment.
+ *
+ * Trend rules (a factor only appears here if it's currently present):
+ *  - no prior assessment            → 'stable'
+ *  - present in the prior assessment too → 'stable'
+ *  - newly appeared since last time  → 'worsening'
+ */
+export function buildFactorBreakdown(
+  currentFactors: string[],
+  weights: Record<string, number>,
+  previousFactors: string[],
+  hasHistory: boolean
+): FactorBreakdown[] {
+  const totalWeight = Object.values(weights).reduce((s, v) => s + v, 0) || 1;
+  return currentFactors.map((factor) => {
+    const weight = weights[factor] ?? 0;
+    const wasPresent = previousFactors.includes(factor);
+    const trend: FactorTrend = !hasHistory ? 'stable' : wasPresent ? 'stable' : 'worsening';
+    return {
+      factor,
+      weight,
+      percentage: Math.round((weight / totalWeight) * 100),
+      trend,
+    };
+  });
+}
+
+/**
+ * Factors that were present in the previous assessment but are no longer
+ * present — i.e. risk factors the patient has resolved/improved on.
+ */
+export function getImprovedFactors(currentFactors: string[], previousFactors: string[]): string[] {
+  return previousFactors.filter((f) => !currentFactors.includes(f));
+}
+
 export { CHRONIC_KEYWORDS };

--- a/apps/api/src/modules/patients/patients.controller.ts
+++ b/apps/api/src/modules/patients/patients.controller.ts
@@ -1539,26 +1539,16 @@ router.get(
         ? Object.fromEntries((patient as any).riskFactorWeights)
         : ((patient as any).riskFactorWeights ?? {});
 
-    const totalWeight = Object.values(rawWeights).reduce((s, v) => s + v, 0) || 1;
-
-    const factorWeights = patient.riskFactors.map((factor) => {
-      const weight = rawWeights[factor] ?? 0;
-      const wasPresent = previousFactors.includes(factor);
-      // A factor that is new is "worsening"; one that disappeared would not appear here
-      const trend: 'improving' | 'stable' | 'worsening' =
-        history.length < 2 ? 'stable' : wasPresent ? 'stable' : 'worsening';
-      return {
-        factor,
-        weight,
-        percentage: Math.round((weight / totalWeight) * 100),
-        trend,
-      };
-    });
+    const { buildFactorBreakdown, getImprovedFactors } = await import('../ai/risk-calculator');
+    const factorWeights = buildFactorBreakdown(
+      patient.riskFactors,
+      rawWeights,
+      previousFactors,
+      history.length >= 2
+    );
 
     // Factors that were present before but are gone now = improving
-    const improvedFactors = previousFactors.filter(
-      (f) => !patient.riskFactors!.includes(f)
-    );
+    const improvedFactors = getImprovedFactors(patient.riskFactors, previousFactors);
 
     // Generate AI explanation + recommendations
     const { isAIServiceAvailable, AI_DISCLAIMER } = await import('../ai/ai.service');

--- a/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
+++ b/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
@@ -710,6 +710,7 @@ export default function PatientDetailClient({
         {/* Consent tab */}
         <TabsContent value="consent">
           <ConsentTab patientId={patientId} canEdit={!!canEdit} />
+        </TabsContent>
         {/* Risk tab */}
         <TabsContent value="risk">
           <RiskTab patient={patient} patientId={patientId} apiV1={API_V1} />


### PR DESCRIPTION
## Summary

Makes the patient risk score **actionable** by explaining which factors drive it, how much each contributes, whether they're improving or worsening, and what to do about them — instead of presenting a black-box number.

Much of the backend already existed on `main` (the `riskFactorWeights` model field, the calculator emitting per-factor weights, persistence in the recalculation job, and the `GET /patients/:id/risk-explanation` endpoint with a Gemini-generated explanation + recommendations). This PR completes the feature and fixes what was broken.

## Changes

- **Fix `PatientDetailClient.tsx`** — the Consent tab's `<TabsContent>` was missing its closing tag, a compile error (`TabsContent has no corresponding closing tag`) that also hid the new **Risk** tab. The Risk tab now renders `RiskTab` → `RiskExplanationPanel`:
  - Per-factor **breakdown bars** with point weight and percentage of total
  - **Trend indicators** (↑ worsening / → stable / ↓ improving) per factor
  - "Factors resolved since last assessment" section
  - AI natural-language explanation, numbered recommendations, and disclaimer
  - All components are already dark-mode aware
- **Extract explanation logic into testable helpers** — moved the inline factor-breakdown/trend computation out of the controller into pure functions `buildFactorBreakdown()` and `getImprovedFactors()` in `risk-calculator.ts`, and wired the endpoint to use them.
- **Tests** — cover factor percentages, point weights, trend classification (no-history → stable, newly-appeared → worsening, unchanged → stable), the divide-by-zero guard, and improved-factor detection.

## Acceptance criteria

- [x] Risk explanation endpoint returns factor weights and natural-language explanation (Gemini, with deterministic fallback)
- [x] Frontend shows a risk factor breakdown visualization
- [x] Trend indicators show factor changes over time
- [x] Recommendations are provided for high-risk factors
- [x] Tests cover explanation generation

## Notes

- `tsc --noEmit` is clean for every changed file (`PatientDetailClient.tsx` no longer errors). Other unrelated pre-existing type errors remain in the tree.
- The repo's jest runner currently can't start due to a pre-existing `jest`/`jest-runtime` version skew, unrelated to this change — the added tests are verified by construction.

closes #712
