### PR TITLE
feat(payments): add Stellar claimable balance expiration notifications

### DIFF
--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -1876,7 +1876,13 @@ router.get(
  * @swagger
  * /payments/expiring-claimable:
  *   get:
- *     summary: List claimable balances expiring within 24 hours
+ *     summary: List claimable balances expiring within 24 hours (CLINIC_ADMIN)
+ *     description: >
+ *       Returns all unclaimed claimable-balance payment records whose `claimableUntil`
+ *       falls within the next 24 hours. Useful for clinic admins to monitor patients
+ *       who have not yet claimed their payment before the window closes.
+ *       The hourly expiry-notification job also uses this window to send proactive
+ *       email, in-app, and Socket.IO notifications to patients (issue #714).
  *     tags: [Payments]
  *     security:
  *       - bearerAuth: []
@@ -1901,7 +1907,7 @@ router.get(
  *                       claimableUntil: { type: string, format: date-time }
  *                       claimableExpiryNotificationSent: { type: boolean }
  *       403:
- *         description: Forbidden — CLINIC_ADMIN only
+ *         description: Forbidden — CLINIC_ADMIN or SUPER_ADMIN only
  */
 // GET /payments/expiring-claimable — list claimable balances expiring within 24h (CLINIC_ADMIN)
 router.get(


### PR DESCRIPTION
## Summary

Closes #714

Implements expiration notifications for Stellar claimable balances so patients are alerted before the claiming window closes.

## Changes

### Scheduled Job
- `apps/api/src/modules/payments/services/claimable-expiry-notification-job.ts`
  - `sendClaimableExpiryNotifications()` — queries `PaymentRecord` for balances expiring within 24 hours with `claimableExpiryNotificationSent != true`, notifies the patient, and marks the flag
  - Runs every hour; wired into `app.ts` startup/shutdown

### Notifications
- **In-app**: creates a `claimable_expiring` notification via `notification.service.ts`
- **Email**: HTML email via `sendClaimableExpiryEmail()` in `email.service.ts`
- **Socket.IO**: emits `payment:claimable_expiring` event via `emitToUser()`

### Model
- `PaymentRecordModel` — `claimableExpiryNotificationSent: Boolean` field (indexed) ensures one-time notification per balance

### API Endpoint
- `GET /api/v1/payments/expiring-claimable` — CLINIC_ADMIN / SUPER_ADMIN only

### Migration
- `apps/api/src/migrations/20260528_add_claimable_expiry_notification.ts` — compound index + backfill; reversible with `down()`

### Tests
- `apps/api/src/modules/payments/__tests__/claimable-expiry-notification-job.test.ts` — covers no-records, happy path, multiple records, skips, error resilience, socket failures, fallback name

## Acceptance Criteria

- [x] Patients receive notifications 24 hours before claimable balance expiry
- [x] Notifications sent via email and in-app
- [x] Socket.IO event `payment:claimable_expiring` emitted
- [x] Notification only sent once per balance
- [x] Tests cover the expiration notification job