### PR TITLE
feat: Immunization Tracker, Referral Management, Settings API Keys, and CDS Display

### DIFF
--- a/apps/web/src/app/cds/CDSRecommendationsClient.tsx
+++ b/apps/web/src/app/cds/CDSRecommendationsClient.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  EmptyState,
+  ErrorMessage,
+  PageWrapper,
+  Toast,
+} from '@/components/ui';
+import { API_V1 } from '@/lib/api';
+import type { AlertSeverity, AlertAction, RuleCategory } from '@/types/cds';
+
+interface EvidenceReference {
+  title: string;
+  source: string;
+  url?: string;
+  year?: number;
+}
+
+interface CDSRecommendation {
+  _id: string;
+  ruleId: string;
+  ruleName: string;
+  category: RuleCategory;
+  severity: AlertSeverity;
+  action: AlertAction;
+  message: string;
+  confidenceScore: number;
+  rationale?: string;
+  evidenceReferences?: EvidenceReference[];
+  patientId?: { firstName: string; lastName: string; systemId: string };
+  encounterId?: string;
+  acknowledged: boolean;
+  acknowledgedAt?: string;
+  acknowledgedBy?: string;
+  createdAt: string;
+}
+
+interface RecommendationsResponse {
+  status: string;
+  data: CDSRecommendation[];
+}
+
+const SEVERITY_STYLES: Record<AlertSeverity, { border: string; bg: string; badge: 'danger' | 'warning' | 'default' }> = {
+  critical: { border: 'border-danger-300', bg: 'bg-danger-50', badge: 'danger' },
+  warning: { border: 'border-warning-300', bg: 'bg-warning-50', badge: 'warning' },
+  info: { border: 'border-primary-200', bg: 'bg-primary-50', badge: 'default' },
+};
+
+const CATEGORY_LABEL: Record<RuleCategory, string> = {
+  drug_interaction: 'Drug Interaction',
+  screening: 'Screening',
+  vital_sign: 'Vital Sign',
+  care_gap: 'Care Gap',
+  allergy: 'Allergy',
+};
+
+const ACTION_LABEL: Record<AlertAction, string> = {
+  alert: 'Alert',
+  recommendation: 'Recommendation',
+  block: 'Block',
+};
+
+function ConfidenceBar({ score }: { score: number }) {
+  const pct = Math.round(score * 100);
+  const color =
+    pct >= 80 ? 'bg-success-500' : pct >= 50 ? 'bg-warning-500' : 'bg-danger-400';
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2 w-24 overflow-hidden rounded-full bg-neutral-200">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-xs font-medium text-neutral-600">{pct}%</span>
+    </div>
+  );
+}
+
+function RecommendationCard({
+  rec,
+  onAcknowledge,
+}: {
+  rec: CDSRecommendation;
+  onAcknowledge: (id: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const style = SEVERITY_STYLES[rec.severity];
+
+  return (
+    <Card
+      padding="none"
+      className={`border ${style.border} ${style.bg} transition-shadow hover:shadow-md`}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-4 px-5 pt-5">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={style.badge}>{rec.severity}</Badge>
+          <span className="rounded-sm bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">
+            {CATEGORY_LABEL[rec.category]}
+          </span>
+          <span className="rounded-sm bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600">
+            {ACTION_LABEL[rec.action]}
+          </span>
+          {rec.acknowledged && (
+            <span className="rounded-sm bg-success-50 px-2 py-0.5 text-xs text-success-700">
+              Acknowledged
+            </span>
+          )}
+        </div>
+        <span className="shrink-0 text-xs text-neutral-400">
+          {new Date(rec.createdAt).toLocaleDateString()}
+        </span>
+      </div>
+
+      {/* Rule name + message */}
+      <div className="px-5 pt-3">
+        <p className="text-sm font-semibold text-neutral-800">{rec.ruleName}</p>
+        <p className="mt-1 text-sm text-neutral-700">{rec.message}</p>
+      </div>
+
+      {/* Confidence score */}
+      <div className="flex items-center gap-3 px-5 pt-3">
+        <span className="text-xs text-neutral-500">Confidence:</span>
+        <ConfidenceBar score={rec.confidenceScore} />
+      </div>
+
+      {/* Patient link if present */}
+      {rec.patientId && (
+        <div className="px-5 pt-2">
+          <span className="text-xs text-neutral-500">
+            Patient: {rec.patientId.firstName} {rec.patientId.lastName}
+            <span className="ml-1 font-mono text-neutral-400">({rec.patientId.systemId})</span>
+          </span>
+        </div>
+      )}
+
+      {/* Collapsible details toggle */}
+      <div className="px-5 pt-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex items-center gap-1 text-xs font-medium text-primary-600 hover:text-primary-700"
+          aria-expanded={expanded}
+        >
+          <svg
+            className={`h-3 w-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+
+      {/* Collapsible section */}
+      {expanded && (
+        <div className="space-y-4 px-5 py-4">
+          {rec.rationale && (
+            <div>
+              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                Clinical Rationale
+              </h4>
+              <p className="text-sm text-neutral-700">{rec.rationale}</p>
+            </div>
+          )}
+
+          {rec.evidenceReferences && rec.evidenceReferences.length > 0 && (
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                Evidence References
+              </h4>
+              <ul className="space-y-2">
+                {rec.evidenceReferences.map((ref, idx) => (
+                  <li key={idx} className="rounded-md border border-neutral-200 bg-white p-3">
+                    <p className="text-sm font-medium text-neutral-800">{ref.title}</p>
+                    <p className="text-xs text-neutral-500">
+                      {ref.source}
+                      {ref.year ? `, ${ref.year}` : ''}
+                    </p>
+                    {ref.url && (
+                      <a
+                        href={ref.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-0.5 inline-block text-xs text-primary-600 hover:underline"
+                      >
+                        View source
+                      </a>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {rec.acknowledged && rec.acknowledgedAt && (
+            <p className="text-xs text-neutral-400">
+              Acknowledged {new Date(rec.acknowledgedAt).toLocaleString()}
+              {rec.acknowledgedBy ? ` by ${rec.acknowledgedBy}` : ''}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Actions */}
+      {!rec.acknowledged && (
+        <div className="border-t border-neutral-200 px-5 py-3">
+          <Button size="sm" variant="secondary" onClick={() => onAcknowledge(rec._id)}>
+            Acknowledge
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+async function fetchRecommendations(): Promise<CDSRecommendation[]> {
+  const res = await fetch(`${API_V1}/cds/recommendations`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Failed to load CDS recommendations');
+  const body: RecommendationsResponse = await res.json();
+  return body.data ?? [];
+}
+
+const SEVERITY_ORDER: AlertSeverity[] = ['critical', 'warning', 'info'];
+
+export default function CDSRecommendationsClient() {
+  const queryClient = useQueryClient();
+  const [filter, setFilter] = useState<'all' | 'unacknowledged'>('unacknowledged');
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  const { data: recommendations = [], isLoading, error } = useQuery<CDSRecommendation[]>({
+    queryKey: ['cds', 'recommendations'],
+    queryFn: fetchRecommendations,
+  });
+
+  const handleAcknowledge = async (id: string) => {
+    try {
+      const res = await fetch(`${API_V1}/cds/recommendations/${id}/acknowledge`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error();
+      setToast({ message: 'Recommendation acknowledged', type: 'success' });
+      queryClient.invalidateQueries({ queryKey: ['cds', 'recommendations'] });
+    } catch {
+      setToast({ message: 'Failed to acknowledge recommendation', type: 'error' });
+    }
+  };
+
+  const filtered = recommendations
+    .filter((r) => (filter === 'unacknowledged' ? !r.acknowledged : true))
+    .sort((a, b) => SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity));
+
+  const unacknowledgedCount = recommendations.filter((r) => !r.acknowledged).length;
+
+  return (
+    <PageWrapper className="py-8">
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900">Clinical Decision Support</h1>
+          <p className="mt-1 text-sm text-neutral-500">AI-generated recommendations and alerts</p>
+        </div>
+        {unacknowledgedCount > 0 && (
+          <Badge variant="danger">{unacknowledgedCount} unacknowledged</Badge>
+        )}
+      </div>
+
+      {/* Filter bar */}
+      <Card padding="none" className="mb-6">
+        <CardContent className="flex gap-2 p-3">
+          {(['unacknowledged', 'all'] as const).map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setFilter(f)}
+              className={[
+                'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                filter === f
+                  ? 'bg-primary-500 text-white'
+                  : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200',
+              ].join(' ')}
+            >
+              {f === 'all' ? 'All' : 'Unacknowledged'}
+            </button>
+          ))}
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-32 animate-pulse rounded-lg bg-neutral-100" />
+          ))}
+        </div>
+      ) : error ? (
+        <ErrorMessage
+          message="Failed to load CDS recommendations"
+          onRetry={() => queryClient.invalidateQueries({ queryKey: ['cds', 'recommendations'] })}
+        />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          title={filter === 'unacknowledged' ? 'No unacknowledged recommendations' : 'No recommendations'}
+          icon="✅"
+        />
+      ) : (
+        <div className="space-y-4">
+          {filtered.map((rec) => (
+            <RecommendationCard key={rec._id} rec={rec} onAcknowledge={handleAcknowledge} />
+          ))}
+        </div>
+      )}
+    </PageWrapper>
+  );
+}

--- a/apps/web/src/app/cds/page.tsx
+++ b/apps/web/src/app/cds/page.tsx
@@ -1,0 +1,7 @@
+import CDSRecommendationsClient from './CDSRecommendationsClient';
+
+export const metadata = { title: 'Clinical Decision Support' };
+
+export default function CDSPage() {
+  return <CDSRecommendationsClient />;
+}

--- a/apps/web/src/app/immunizations/ImmunizationsClient.tsx
+++ b/apps/web/src/app/immunizations/ImmunizationsClient.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  EmptyState,
+  ErrorMessage,
+  Input,
+  Modal,
+  PageWrapper,
+  Textarea,
+  Toast,
+} from '@/components/ui';
+import { API_V1 } from '@/lib/api';
+
+type ImmunizationStatus = 'administered' | 'scheduled' | 'overdue' | 'upcoming';
+
+interface ImmunizationRecord {
+  _id: string;
+  vaccine: string;
+  dateAdministered: string;
+  administrator?: string;
+  lotNumber?: string;
+  site?: string;
+  notes?: string;
+  nextDoseDate?: string;
+  patientId?: string;
+}
+
+interface UpcomingVaccine {
+  _id: string;
+  vaccine: string;
+  dueDate: string;
+  status: ImmunizationStatus;
+  description?: string;
+}
+
+interface ImmunizationFormData {
+  vaccine: string;
+  dateAdministered: string;
+  administrator: string;
+  lotNumber: string;
+  site: string;
+  notes: string;
+  nextDoseDate: string;
+}
+
+const INITIAL_FORM: ImmunizationFormData = {
+  vaccine: '',
+  dateAdministered: '',
+  administrator: '',
+  lotNumber: '',
+  site: '',
+  notes: '',
+  nextDoseDate: '',
+};
+
+const STATUS_VARIANT: Record<ImmunizationStatus, 'danger' | 'warning' | 'success' | 'default'> = {
+  overdue: 'danger',
+  upcoming: 'warning',
+  scheduled: 'primary' as 'default',
+  administered: 'success',
+};
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function getUpcomingStatus(dueDate: string): ImmunizationStatus {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+  const diffDays = Math.ceil((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays < 0) return 'overdue';
+  if (diffDays <= 30) return 'upcoming';
+  return 'scheduled';
+}
+
+async function fetchRecords(): Promise<ImmunizationRecord[]> {
+  const res = await fetch(`${API_V1}/immunizations`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Failed to load immunization records');
+  const data = await res.json();
+  return data.data ?? [];
+}
+
+async function fetchUpcoming(): Promise<UpcomingVaccine[]> {
+  const res = await fetch(`${API_V1}/immunizations/upcoming`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Failed to load upcoming vaccines');
+  const data = await res.json();
+  return data.data ?? [];
+}
+
+function AlertBanner({ overdue }: { overdue: UpcomingVaccine[] }) {
+  if (overdue.length === 0) return null;
+  return (
+    <div className="rounded-lg border border-danger-200 bg-danger-50 p-4">
+      <div className="flex items-start gap-3">
+        <svg className="mt-0.5 h-5 w-5 shrink-0 text-danger-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <div>
+          <p className="text-sm font-semibold text-danger-700">
+            {overdue.length} overdue vaccine{overdue.length > 1 ? 's' : ''}
+          </p>
+          <ul className="mt-1 space-y-0.5">
+            {overdue.map((v) => (
+              <li key={v._id} className="text-sm text-danger-600">
+                {v.vaccine} — due {formatDate(v.dueDate)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UpcomingCard({ vaccine }: { vaccine: UpcomingVaccine }) {
+  const status = vaccine.status ?? getUpcomingStatus(vaccine.dueDate);
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-3">
+      <div>
+        <p className="text-sm font-medium text-neutral-900">{vaccine.vaccine}</p>
+        {vaccine.description && (
+          <p className="text-xs text-neutral-500">{vaccine.description}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-neutral-500">{formatDate(vaccine.dueDate)}</span>
+        <Badge variant={STATUS_VARIANT[status]}>{status}</Badge>
+      </div>
+    </div>
+  );
+}
+
+function RecordRow({ record }: { record: ImmunizationRecord }) {
+  return (
+    <tr className="border-b border-neutral-100 last:border-0">
+      <td className="py-3 pr-4 text-sm font-medium text-neutral-900">{record.vaccine}</td>
+      <td className="py-3 pr-4 text-sm text-neutral-600">{formatDate(record.dateAdministered)}</td>
+      <td className="py-3 pr-4 text-sm text-neutral-600">{record.administrator ?? '—'}</td>
+      <td className="py-3 pr-4 font-mono text-xs text-neutral-500">{record.lotNumber ?? '—'}</td>
+      <td className="py-3 pr-4 text-sm text-neutral-600">{record.site ?? '—'}</td>
+      <td className="py-3 text-sm text-neutral-500">
+        {record.nextDoseDate ? formatDate(record.nextDoseDate) : '—'}
+      </td>
+    </tr>
+  );
+}
+
+export default function ImmunizationsClient() {
+  const queryClient = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<ImmunizationFormData>(INITIAL_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  const {
+    data: records = [],
+    isLoading: recordsLoading,
+    error: recordsError,
+  } = useQuery<ImmunizationRecord[]>({
+    queryKey: ['immunizations', 'records'],
+    queryFn: fetchRecords,
+  });
+
+  const {
+    data: upcoming = [],
+    isLoading: upcomingLoading,
+    error: upcomingError,
+  } = useQuery<UpcomingVaccine[]>({
+    queryKey: ['immunizations', 'upcoming'],
+    queryFn: fetchUpcoming,
+  });
+
+  const overdue = upcoming.filter(
+    (v) => (v.status ?? getUpcomingStatus(v.dueDate)) === 'overdue',
+  );
+
+  const handleChange = (field: keyof ImmunizationFormData, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.vaccine || !form.dateAdministered) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${API_V1}/immunizations`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          vaccine: form.vaccine,
+          dateAdministered: form.dateAdministered,
+          administrator: form.administrator || undefined,
+          lotNumber: form.lotNumber || undefined,
+          site: form.site || undefined,
+          notes: form.notes || undefined,
+          nextDoseDate: form.nextDoseDate || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to save immunization record');
+      setToast({ message: 'Immunization record saved', type: 'success' });
+      setForm(INITIAL_FORM);
+      setShowForm(false);
+      queryClient.invalidateQueries({ queryKey: ['immunizations'] });
+    } catch {
+      setToast({ message: 'Failed to save immunization record', type: 'error' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PageWrapper className="py-8">
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-neutral-900">Immunization Schedule</h1>
+        <Button onClick={() => setShowForm(true)}>+ Log Vaccination</Button>
+      </div>
+
+      {/* Overdue alerts */}
+      {!upcomingLoading && <AlertBanner overdue={overdue} />}
+
+      <div className="mt-6 space-y-6">
+        {/* Upcoming vaccines */}
+        <Card padding="none">
+          <CardHeader className="px-5 pt-5">
+            <CardTitle>Upcoming Vaccines</CardTitle>
+          </CardHeader>
+          <CardContent className="px-5 pb-5">
+            {upcomingLoading ? (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-12 animate-pulse rounded-lg bg-neutral-100" />
+                ))}
+              </div>
+            ) : upcomingError ? (
+              <ErrorMessage
+                message="Failed to load upcoming vaccines"
+                onRetry={() => queryClient.invalidateQueries({ queryKey: ['immunizations', 'upcoming'] })}
+              />
+            ) : upcoming.length === 0 ? (
+              <EmptyState title="No upcoming vaccines" icon="💉" />
+            ) : (
+              <div className="space-y-2">
+                {upcoming.map((v) => (
+                  <UpcomingCard key={v._id} vaccine={v} />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Immunization records */}
+        <Card padding="none">
+          <CardHeader className="px-5 pt-5">
+            <CardTitle>Immunization Records</CardTitle>
+          </CardHeader>
+          <CardContent className="px-5 pb-5">
+            {recordsLoading ? (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-10 animate-pulse rounded bg-neutral-100" />
+                ))}
+              </div>
+            ) : recordsError ? (
+              <ErrorMessage
+                message="Failed to load immunization records"
+                onRetry={() => queryClient.invalidateQueries({ queryKey: ['immunizations', 'records'] })}
+              />
+            ) : records.length === 0 ? (
+              <EmptyState title="No immunization records" icon="📋" />
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-neutral-200 text-left text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                      <th className="pb-2 pr-4">Vaccine</th>
+                      <th className="pb-2 pr-4">Date Administered</th>
+                      <th className="pb-2 pr-4">Administrator</th>
+                      <th className="pb-2 pr-4">Lot #</th>
+                      <th className="pb-2 pr-4">Site</th>
+                      <th className="pb-2">Next Dose</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {records.map((r) => (
+                      <RecordRow key={r._id} record={r} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Add entry modal */}
+      <Modal
+        open={showForm}
+        onClose={() => { setShowForm(false); setForm(INITIAL_FORM); }}
+        title="Log Vaccination"
+        size="lg"
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Input
+              label="Vaccine *"
+              placeholder="e.g. Influenza, COVID-19"
+              value={form.vaccine}
+              onChange={(e) => handleChange('vaccine', e.target.value)}
+              required
+            />
+            <Input
+              label="Date Administered *"
+              type="date"
+              value={form.dateAdministered}
+              onChange={(e) => handleChange('dateAdministered', e.target.value)}
+              required
+            />
+            <Input
+              label="Administrator"
+              placeholder="Clinician name"
+              value={form.administrator}
+              onChange={(e) => handleChange('administrator', e.target.value)}
+            />
+            <Input
+              label="Lot Number"
+              placeholder="Vaccine lot number"
+              value={form.lotNumber}
+              onChange={(e) => handleChange('lotNumber', e.target.value)}
+            />
+            <Input
+              label="Injection Site"
+              placeholder="e.g. Left deltoid"
+              value={form.site}
+              onChange={(e) => handleChange('site', e.target.value)}
+            />
+            <Input
+              label="Next Dose Date"
+              type="date"
+              value={form.nextDoseDate}
+              onChange={(e) => handleChange('nextDoseDate', e.target.value)}
+            />
+          </div>
+          <Textarea
+            label="Notes"
+            placeholder="Any additional notes"
+            value={form.notes}
+            onChange={(e) => handleChange('notes', e.target.value)}
+            rows={3}
+          />
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => { setShowForm(false); setForm(INITIAL_FORM); }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" loading={submitting}>
+              Save Record
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </PageWrapper>
+  );
+}

--- a/apps/web/src/app/immunizations/page.tsx
+++ b/apps/web/src/app/immunizations/page.tsx
@@ -1,0 +1,7 @@
+import ImmunizationsClient from './ImmunizationsClient';
+
+export const metadata = { title: 'Immunization Schedule' };
+
+export default function ImmunizationsPage() {
+  return <ImmunizationsClient />;
+}

--- a/apps/web/src/app/referrals/ReferralsClient.tsx
+++ b/apps/web/src/app/referrals/ReferralsClient.tsx
@@ -7,11 +7,15 @@ import {
   Button,
   EmptyState,
   ErrorMessage,
+  Input,
+  Modal,
   PageWrapper,
+  Select,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Textarea,
   Toast,
 } from '@/components/ui';
 import { API_V1 } from '@/lib/api';
@@ -28,7 +32,23 @@ interface Referral {
   urgency: Urgency;
   status: ReferralStatus;
   notes?: string;
+  declinedReason?: string;
   createdAt: string;
+  updatedAt?: string;
+}
+
+interface StatusEvent {
+  status: ReferralStatus;
+  label: string;
+  date?: string;
+}
+
+interface ReferralFormData {
+  patientId: string;
+  toClinicId: string;
+  reason: string;
+  urgency: Urgency;
+  notes: string;
 }
 
 const URGENCY_VARIANT: Record<Urgency, 'danger' | 'warning' | 'default'> = {
@@ -44,11 +64,82 @@ const STATUS_VARIANT: Record<ReferralStatus, 'warning' | 'success' | 'danger' | 
   completed: 'default',
 };
 
+const STATUS_ORDER: ReferralStatus[] = ['pending', 'accepted', 'completed'];
+
+const URGENCY_OPTIONS = [
+  { value: 'routine', label: 'Routine' },
+  { value: 'urgent', label: 'Urgent' },
+  { value: 'emergency', label: 'Emergency' },
+];
+
+const INITIAL_FORM: ReferralFormData = {
+  patientId: '',
+  toClinicId: '',
+  reason: '',
+  urgency: 'routine',
+  notes: '',
+};
+
 async function fetchReferrals(direction: 'incoming' | 'outgoing'): Promise<Referral[]> {
   const res = await fetch(`${API_V1}/referrals/${direction}`, { credentials: 'include' });
   if (!res.ok) throw new Error('Failed to load referrals');
   const data = await res.json();
   return data.data ?? [];
+}
+
+function buildTimeline(referral: Referral): StatusEvent[] {
+  const isDeclined = referral.status === 'declined';
+
+  if (isDeclined) {
+    return [
+      { status: 'pending', label: 'Referral Created', date: referral.createdAt },
+      { status: 'declined', label: 'Declined', date: referral.updatedAt },
+    ];
+  }
+
+  const completedStatuses: ReferralStatus[] = STATUS_ORDER.filter((s) => {
+    const idx = STATUS_ORDER.indexOf(s);
+    const currentIdx = STATUS_ORDER.indexOf(referral.status);
+    return idx <= currentIdx;
+  });
+
+  return completedStatuses.map((s, i) => ({
+    status: s,
+    label: s === 'pending' ? 'Referral Created' : s.charAt(0).toUpperCase() + s.slice(1),
+    date: i === 0 ? referral.createdAt : i === completedStatuses.length - 1 ? referral.updatedAt : undefined,
+  }));
+}
+
+function StatusTimeline({ referral }: { referral: Referral }) {
+  const events = buildTimeline(referral);
+  return (
+    <div className="mt-3 flex items-center gap-0">
+      {events.map((event, idx) => (
+        <div key={event.status} className="flex items-center">
+          <div className="flex flex-col items-center">
+            <div
+              className={[
+                'flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-bold',
+                event.status === 'declined'
+                  ? 'bg-danger-100 text-danger-600'
+                  : STATUS_VARIANT[event.status] === 'success'
+                    ? 'bg-success-50 text-success-700'
+                    : STATUS_VARIANT[event.status] === 'warning'
+                      ? 'bg-warning-50 text-warning-700'
+                      : 'bg-neutral-200 text-neutral-500',
+              ].join(' ')}
+            >
+              {idx + 1}
+            </div>
+            <span className="mt-0.5 text-[10px] text-neutral-500 whitespace-nowrap">{event.label}</span>
+          </div>
+          {idx < events.length - 1 && (
+            <div className="mb-3 h-px w-8 bg-neutral-200" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 function ReferralCard({
@@ -68,25 +159,35 @@ function ReferralCard({
   return (
     <li className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-2">
-        <div>
+        <div className="min-w-0 flex-1">
           <p className="font-medium text-neutral-900">
             {patient ? `${patient.firstName} ${patient.lastName}` : 'Unknown patient'}
             {patient?.systemId && (
               <span className="ml-2 font-mono text-xs text-neutral-400">{patient.systemId}</span>
             )}
           </p>
-          <p className="text-xs text-neutral-500 mt-0.5">
+          <p className="mt-0.5 text-xs text-neutral-500">
             {direction === 'incoming' ? 'From' : 'To'}: {clinic?.name ?? '—'}
           </p>
-          <p className="text-sm text-neutral-700 mt-1">{referral.reason}</p>
-          {referral.notes && <p className="text-xs text-neutral-400 mt-0.5 italic">{referral.notes}</p>}
-          <p className="text-xs text-neutral-400 mt-1">{new Date(referral.createdAt).toLocaleDateString()}</p>
+          <p className="mt-1 text-sm text-neutral-700">{referral.reason}</p>
+          {referral.notes && (
+            <p className="mt-0.5 text-xs italic text-neutral-400">{referral.notes}</p>
+          )}
+          {referral.declinedReason && (
+            <p className="mt-0.5 text-xs text-danger-500">Declined: {referral.declinedReason}</p>
+          )}
+          <p className="mt-1 text-xs text-neutral-400">
+            {new Date(referral.createdAt).toLocaleDateString()}
+          </p>
         </div>
         <div className="flex flex-col items-end gap-2">
           <Badge variant={URGENCY_VARIANT[referral.urgency]}>{referral.urgency}</Badge>
           <Badge variant={STATUS_VARIANT[referral.status]}>{referral.status}</Badge>
         </div>
       </div>
+
+      <StatusTimeline referral={referral} />
+
       {direction === 'incoming' && referral.status === 'pending' && (
         <div className="mt-3 flex gap-2">
           <Button size="sm" variant="primary" onClick={() => onAccept?.(referral._id)}>
@@ -101,9 +202,108 @@ function ReferralCard({
   );
 }
 
+function NewReferralModal({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [form, setForm] = useState<ReferralFormData>(INITIAL_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleChange = (field: keyof ReferralFormData, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.patientId || !form.toClinicId || !form.reason) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await fetch(`${API_V1}/referrals`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          patientId: form.patientId,
+          toClinicId: form.toClinicId,
+          reason: form.reason,
+          urgency: form.urgency,
+          notes: form.notes || undefined,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to create referral');
+      setForm(INITIAL_FORM);
+      onCreated();
+    } catch {
+      setError('Failed to create referral. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="New Referral" size="lg">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Input
+            label="Patient ID *"
+            placeholder="Patient system ID"
+            value={form.patientId}
+            onChange={(e) => handleChange('patientId', e.target.value)}
+            required
+          />
+          <Input
+            label="Referring To (Clinic ID) *"
+            placeholder="Destination clinic ID"
+            value={form.toClinicId}
+            onChange={(e) => handleChange('toClinicId', e.target.value)}
+            required
+          />
+        </div>
+        <Input
+          label="Reason *"
+          placeholder="Reason for referral"
+          value={form.reason}
+          onChange={(e) => handleChange('reason', e.target.value)}
+          required
+        />
+        <Select
+          label="Urgency"
+          options={URGENCY_OPTIONS}
+          value={form.urgency}
+          onChange={(e) => handleChange('urgency', e.target.value as Urgency)}
+        />
+        <Textarea
+          label="Notes"
+          placeholder="Additional clinical notes"
+          value={form.notes}
+          onChange={(e) => handleChange('notes', e.target.value)}
+          rows={3}
+        />
+        {error && <p className="text-sm text-danger-500">{error}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={submitting}>
+            Send Referral
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
 export default function ReferralsClient() {
   const queryClient = useQueryClient();
-  const [tab, setTab] = useState<'incoming' | 'outgoing'>('incoming');
+  const [tab, setTab] = useState<'incoming' | 'outgoing' | 'history'>('incoming');
+  const [showNewReferral, setShowNewReferral] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
   const { data: incoming = [], isLoading: incomingLoading, error: incomingError } = useQuery<Referral[]>({
@@ -119,7 +319,7 @@ export default function ReferralsClient() {
   const handleAccept = async (id: string) => {
     try {
       const res = await fetch(`${API_V1}/referrals/${id}/accept`, { method: 'PUT', credentials: 'include' });
-      if (!res.ok) throw new Error('Failed to accept referral');
+      if (!res.ok) throw new Error();
       setToast({ message: 'Referral accepted', type: 'success' });
       queryClient.invalidateQueries({ queryKey: ['referrals', 'incoming'] });
     } catch {
@@ -136,7 +336,7 @@ export default function ReferralsClient() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ declinedReason: reason }),
       });
-      if (!res.ok) throw new Error('Failed to decline referral');
+      if (!res.ok) throw new Error();
       setToast({ message: 'Referral declined', type: 'success' });
       queryClient.invalidateQueries({ queryKey: ['referrals', 'incoming'] });
     } catch {
@@ -144,41 +344,71 @@ export default function ReferralsClient() {
     }
   };
 
+  const handleReferralCreated = () => {
+    setShowNewReferral(false);
+    setToast({ message: 'Referral sent successfully', type: 'success' });
+    queryClient.invalidateQueries({ queryKey: ['referrals', 'outgoing'] });
+  };
+
+  // History = completed + declined from both directions
+  const allReferrals = [...incoming, ...outgoing];
+  const seen = new Set<string>();
+  const history = allReferrals.filter((r) => {
+    if (seen.has(r._id)) return false;
+    seen.add(r._id);
+    return r.status === 'completed' || r.status === 'declined';
+  });
+
+  const activePendingCount = incoming.filter((r) => r.status === 'pending').length;
+
   return (
     <PageWrapper className="py-8">
       {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
 
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-neutral-900">Referrals</h1>
+        <Button onClick={() => setShowNewReferral(true)}>+ New Referral</Button>
       </div>
 
-      <Tabs value={tab} onValueChange={(v) => setTab(v as 'incoming' | 'outgoing')}>
+      <Tabs value={tab} onValueChange={(v) => setTab(v as typeof tab)}>
         <TabsList>
           <TabsTrigger value="incoming">
             Incoming
-            {incoming.filter((r) => r.status === 'pending').length > 0 && (
+            {activePendingCount > 0 && (
               <span className="ml-2 rounded-full bg-warning-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
-                {incoming.filter((r) => r.status === 'pending').length}
+                {activePendingCount}
               </span>
             )}
           </TabsTrigger>
           <TabsTrigger value="outgoing">Outgoing</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
         </TabsList>
 
         <TabsContent value="incoming">
           {incomingLoading ? (
             <div className="space-y-3">
-              {[1, 2, 3].map((i) => <div key={i} className="h-24 animate-pulse rounded-lg bg-neutral-100" />)}
+              {[1, 2, 3].map((i) => <div key={i} className="h-28 animate-pulse rounded-lg bg-neutral-100" />)}
             </div>
           ) : incomingError ? (
-            <ErrorMessage message="Failed to load incoming referrals" onRetry={() => queryClient.invalidateQueries({ queryKey: ['referrals', 'incoming'] })} />
-          ) : incoming.length === 0 ? (
-            <EmptyState title="No incoming referrals" icon="📥" />
+            <ErrorMessage
+              message="Failed to load incoming referrals"
+              onRetry={() => queryClient.invalidateQueries({ queryKey: ['referrals', 'incoming'] })}
+            />
+          ) : incoming.filter((r) => r.status !== 'completed' && r.status !== 'declined').length === 0 ? (
+            <EmptyState title="No active incoming referrals" icon="📥" />
           ) : (
             <ol className="space-y-3">
-              {incoming.map((r) => (
-                <ReferralCard key={r._id} referral={r} direction="incoming" onAccept={handleAccept} onDecline={handleDecline} />
-              ))}
+              {incoming
+                .filter((r) => r.status !== 'completed' && r.status !== 'declined')
+                .map((r) => (
+                  <ReferralCard
+                    key={r._id}
+                    referral={r}
+                    direction="incoming"
+                    onAccept={handleAccept}
+                    onDecline={handleDecline}
+                  />
+                ))}
             </ol>
           )}
         </TabsContent>
@@ -186,21 +416,52 @@ export default function ReferralsClient() {
         <TabsContent value="outgoing">
           {outgoingLoading ? (
             <div className="space-y-3">
-              {[1, 2, 3].map((i) => <div key={i} className="h-24 animate-pulse rounded-lg bg-neutral-100" />)}
+              {[1, 2, 3].map((i) => <div key={i} className="h-28 animate-pulse rounded-lg bg-neutral-100" />)}
             </div>
           ) : outgoingError ? (
-            <ErrorMessage message="Failed to load outgoing referrals" onRetry={() => queryClient.invalidateQueries({ queryKey: ['referrals', 'outgoing'] })} />
-          ) : outgoing.length === 0 ? (
-            <EmptyState title="No outgoing referrals" icon="📤" />
+            <ErrorMessage
+              message="Failed to load outgoing referrals"
+              onRetry={() => queryClient.invalidateQueries({ queryKey: ['referrals', 'outgoing'] })}
+            />
+          ) : outgoing.filter((r) => r.status !== 'completed' && r.status !== 'declined').length === 0 ? (
+            <EmptyState title="No active outgoing referrals" icon="📤" />
           ) : (
             <ol className="space-y-3">
-              {outgoing.map((r) => (
-                <ReferralCard key={r._id} referral={r} direction="outgoing" />
+              {outgoing
+                .filter((r) => r.status !== 'completed' && r.status !== 'declined')
+                .map((r) => (
+                  <ReferralCard key={r._id} referral={r} direction="outgoing" />
+                ))}
+            </ol>
+          )}
+        </TabsContent>
+
+        <TabsContent value="history">
+          {incomingLoading || outgoingLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => <div key={i} className="h-28 animate-pulse rounded-lg bg-neutral-100" />)}
+            </div>
+          ) : history.length === 0 ? (
+            <EmptyState title="No referral history" icon="📋" />
+          ) : (
+            <ol className="space-y-3">
+              {history.map((r) => (
+                <ReferralCard
+                  key={r._id}
+                  referral={r}
+                  direction={r.toClinicId ? 'outgoing' : 'incoming'}
+                />
               ))}
             </ol>
           )}
         </TabsContent>
       </Tabs>
+
+      <NewReferralModal
+        open={showNewReferral}
+        onClose={() => setShowNewReferral(false)}
+        onCreated={handleReferralCreated}
+      />
     </PageWrapper>
   );
 }

--- a/apps/web/src/app/settings/SettingsClient.tsx
+++ b/apps/web/src/app/settings/SettingsClient.tsx
@@ -8,8 +8,9 @@ import { SecuritySection } from '@/components/settings/SecuritySection';
 import { PreferencesSection } from '@/components/settings/PreferencesSection';
 import { SubscriptionSection } from '@/components/settings/SubscriptionSection';
 import { SessionManagement } from '@/components/settings/SessionManagement';
+import ApiKeyManager from '@/components/settings/ApiKeyManager';
 
-type Section = 'profile' | 'security' | 'preferences' | 'subscription' | 'sessions';
+type Section = 'profile' | 'security' | 'preferences' | 'subscription' | 'sessions' | 'api-keys';
 
 interface MeResponse {
   status: 'success';
@@ -87,6 +88,7 @@ export default function SettingsClient() {
           {active === 'preferences' && <PreferencesSection preferences={data.preferences} />}
           {active === 'subscription' && <SubscriptionSection />}
           {active === 'sessions' && <SessionManagement />}
+          {active === 'api-keys' && <ApiKeyManager />}
         </main>
       </div>
     </div>

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -116,6 +116,26 @@ const navItems: NavItem[] = [
     ),
   },
   {
+    label: 'CDS',
+    href: '/cds',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+        />
+      </svg>
+    ),
+  },
+  {
     label: 'Immunizations',
     href: '/immunizations',
     icon: (

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -116,6 +116,26 @@ const navItems: NavItem[] = [
     ),
   },
   {
+    label: 'Immunizations',
+    href: '/immunizations',
+    icon: (
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
+        />
+      </svg>
+    ),
+  },
+  {
     label: 'Documents',
     href: '/documents',
     icon: (

--- a/apps/web/src/components/settings/SubNavigation.tsx
+++ b/apps/web/src/components/settings/SubNavigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-type Section = 'profile' | 'security' | 'preferences' | 'subscription' | 'sessions';
+type Section = 'profile' | 'security' | 'preferences' | 'subscription' | 'sessions' | 'api-keys';
 
 interface SubNavigationProps {
   active: Section;
@@ -13,6 +13,7 @@ const items: { id: Section; label: string }[] = [
   { id: 'preferences', label: 'Preferences' },
   { id: 'sessions', label: 'Sessions' },
   { id: 'subscription', label: 'Subscription' },
+  { id: 'api-keys', label: 'API Keys' },
 ];
 
 export function SubNavigation({ active, onChange }: SubNavigationProps) {


### PR DESCRIPTION
## Summary

This PR delivers four frontend features across the health_watchers web application:

---

### #845 — Immunization Schedule Tracker

- Added `/immunizations` page (`ImmunizationsClient.tsx`) as a new route in the app
- **Immunization Records table**: displays vaccine name, date administered, administrator, lot number, injection site, and next dose date
- **Upcoming Vaccines list**: shows each scheduled vaccine with its due date and a computed status badge (`overdue` / `upcoming` / `scheduled`) calculated against today's date
- **Overdue alert banner**: prominently warns when one or more vaccines are past their due date, listing each by name and date
- **Log Vaccination modal form**: fields for vaccine, date administered, administrator, lot number, injection site, next dose date, and notes — POSTs to `POST /api/v1/immunizations`
- Added **Immunizations** entry to the sidebar navigation

---

### #843 — Referral Management Interface

- Rewrote `ReferralsClient.tsx` with the following additions:
- **New Referral creation form** (modal): patient ID, destination clinic ID, reason, urgency selector (routine / urgent / emergency), and clinical notes — POSTs to `POST /api/v1/referrals`
- **Status timeline**: each referral card now renders a step-by-step visual timeline showing progression through `pending → accepted → completed` (or `pending → declined`) with numbered nodes
- **History tab**: third tab alongside Incoming and Outgoing that aggregates completed and declined referrals from both directions (deduped by `_id`)
- **Toast notifications** for referral created, accepted, and declined actions; decline reason is captured via a prompt before calling `PUT /api/v1/referrals/:id/decline`

---

### #842 — Settings and Preferences Page

- Extended `SubNavigation` to include an **API Keys** section (new `'api-keys'` value in the `Section` union)
- Wired `ApiKeyManager` into `SettingsClient` so it renders when the API Keys nav item is active
- The existing settings sections remain intact:
  - **Profile**: editable full name, read-only email / role / clinic
  - **Security**: change password form + 2FA (MFA) toggle
  - **Preferences**: language selector, light/dark/system theme picker, email and in-app notification toggles with per-type granularity
  - **Sessions**: active session management
  - **Subscription**: subscription details

---

### #844 — Clinical Decision Support Display

- Added `/cds` page (`CDSRecommendationsClient.tsx`) for displaying AI-generated clinical recommendations
- **Recommendation cards**: bordered and colour-coded by severity (`critical` → red, `warning` → amber, `info` → blue), showing rule name, message, category badge, action type, and date
- **Confidence score bar**: labelled percentage progress bar per recommendation, colour-coded green ≥ 80%, amber ≥ 50%, red below
- **Evidence references panel** (collapsible): lists each reference with title, source, year, and an optional external link
- **Collapsible details**: a chevron toggle expands clinical rationale and evidence; collapsed by default to keep the list scannable
- **Acknowledge action**: marks a recommendation as acknowledged via `POST /api/v1/cds/recommendations/:id/acknowledge`; acknowledged items are labelled and excluded from the default `Unacknowledged` filter view
- **Filter bar**: toggle between *Unacknowledged* (default) and *All*; unacknowledged count badge shown in the page header
- Added **CDS** entry to the sidebar navigation

---

## Files Changed

| File | Change |
|------|--------|
| `apps/web/src/app/immunizations/page.tsx` | New |
| `apps/web/src/app/immunizations/ImmunizationsClient.tsx` | New |
| `apps/web/src/app/cds/page.tsx` | New |
| `apps/web/src/app/cds/CDSRecommendationsClient.tsx` | New |
| `apps/web/src/app/referrals/ReferralsClient.tsx` | Enhanced |
| `apps/web/src/app/settings/SettingsClient.tsx` | API Keys section wired |
| `apps/web/src/components/settings/SubNavigation.tsx` | API Keys nav item added |
| `apps/web/src/components/layout/Sidebar.tsx` | CDS + Immunizations nav entries added |

---

Closes #845
Closes #843
Closes #842
Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)