### PR TITLE
feat(k8s): add Kubernetes network policies for service isolation

### DIFF
--- a/helm/health-watchers/templates/network-policies.yaml
+++ b/helm/health-watchers/templates/network-policies.yaml
@@ -1,0 +1,159 @@
+{{- if .Values.networkPolicies.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "health-watchers.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "health-watchers.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: web-network-policy
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "health-watchers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: web
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - port: {{ .Values.api.service.port }}
+          protocol: TCP
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-network-policy
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "health-watchers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: api
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: web
+      ports:
+        - port: {{ .Values.api.service.port }}
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - port: {{ .Values.api.service.port }}
+          protocol: TCP
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: stellar-service
+      ports:
+        - port: {{ .Values.stellarService.service.port }}
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: mongodb
+      ports:
+        - port: 27017
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    - ports:
+        - port: 587
+          protocol: TCP
+        - port: 2525
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stellar-service-network-policy
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "health-watchers.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: stellar-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - port: {{ .Values.stellarService.service.port }}
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+{{- end }}

--- a/helm/health-watchers/values.yaml
+++ b/helm/health-watchers/values.yaml
@@ -190,3 +190,9 @@ redis:
       cpu: "100m"
   service:
     port: 6379
+
+# ── Network Policies ──────────────────────────────────────────────────────────
+# Set enabled: false in single-node dev clusters where the CNI does not
+# enforce NetworkPolicy (e.g. basic kubeadm without Calico/Cilium).
+networkPolicies:
+  enabled: true

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -11,6 +11,7 @@ k8s/
 ├── secrets.yaml                # Kubernetes Secrets (placeholder values)
 ├── external-secrets.yaml       # External Secrets Operator integration
 ├── ingress.yaml                # Ingress with TLS (cert-manager)
+├── network-policies.yaml       # NetworkPolicy resources (default-deny + per-service rules)
 ├── api/
 │   ├── deployment.yaml         # API Deployment (2 replicas)
 │   ├── service.yaml            # API ClusterIP Service
@@ -217,6 +218,52 @@ helm install external-secrets external-secrets/external-secrets -n external-secr
 # Configure your SecretStore (AWS, Vault, GCP, etc.)
 # Then apply the ExternalSecret manifest
 kubectl apply -f k8s/external-secrets.yaml
+```
+
+## Network Topology and Policies
+
+`k8s/network-policies.yaml` enforces a least-privilege network model for the `health-watchers` namespace.
+
+### Allowed traffic
+
+```
+Ingress controller ──► web (3000)
+Ingress controller ──► api  (3001)
+web                ──► api  (3001)
+api                ──► stellar-service (3002)
+api                ──► mongodb         (27017)
+api                ──► redis           (6379)
+api                ──► external HTTPS  (443)  — Stellar Horizon, Gemini AI, etc.
+api                ──► external SMTP   (587 / 2525)
+stellar-service    ──► external HTTPS  (443)  — Stellar Horizon / Friendbot
+all pods           ──► kube-dns        (53 UDP/TCP)
+```
+
+### Denied traffic (blocked by default-deny-all)
+
+| Source          | Destination      | Reason                                      |
+|-----------------|------------------|---------------------------------------------|
+| web             | stellar-service  | Must go through API auth layer              |
+| web             | mongodb          | Direct DB access not permitted              |
+| web             | redis            | Direct cache access not permitted           |
+| stellar-service | mongodb          | No DB access needed                         |
+| stellar-service | redis            | No cache access needed                      |
+
+### Applying network policies
+
+```bash
+kubectl apply -f k8s/network-policies.yaml
+# Verify
+kubectl get networkpolicies -n health-watchers
+```
+
+### Helm chart
+
+Network policies are controlled in `values.yaml` (see `helm/health-watchers/templates/network-policies.yaml`). To disable (e.g. in a local dev cluster without a CNI that enforces NetworkPolicy):
+
+```yaml
+networkPolicies:
+  enabled: false
 ```
 
 ## Helm Chart

--- a/k8s/network-policies.yaml
+++ b/k8s/network-policies.yaml
@@ -1,0 +1,165 @@
+---
+# Default deny-all ingress and egress for the namespace.
+# All traffic must be explicitly permitted by the policies below.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: health-watchers
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+
+---
+# Allow DNS egress for all pods (required for service discovery).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: health-watchers
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+---
+# Web frontend: allow ingress from the Ingress controller and egress only to API.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: web-network-policy
+  namespace: health-watchers
+spec:
+  podSelector:
+    matchLabels:
+      app: web
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept traffic from the nginx ingress controller pods
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+  egress:
+    # Web → API only (port 3001)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - port: 3001
+          protocol: TCP
+
+---
+# API: ingress from web and ingress controller; egress to stellar-service, MongoDB, and Redis.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-network-policy
+  namespace: health-watchers
+spec:
+  podSelector:
+    matchLabels:
+      app: api
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept from web pods
+    - from:
+        - podSelector:
+            matchLabels:
+              app: web
+      ports:
+        - port: 3001
+          protocol: TCP
+    # Accept from ingress controller (health probes, direct API access)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - port: 3001
+          protocol: TCP
+  egress:
+    # API → stellar-service (port 3002)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: stellar-service
+      ports:
+        - port: 3002
+          protocol: TCP
+    # API → MongoDB (port 27017)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: mongodb
+      ports:
+        - port: 27017
+          protocol: TCP
+    # API → Redis (port 6379)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # API → external SMTP / email services (port 587 / 2525)
+    - ports:
+        - port: 587
+          protocol: TCP
+        - port: 2525
+          protocol: TCP
+    # API → external HTTPS (Stellar Horizon, Gemini, etc.)
+    - ports:
+        - port: 443
+          protocol: TCP
+
+---
+# Stellar service: ingress from API only; egress to external Stellar network.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stellar-service-network-policy
+  namespace: health-watchers
+spec:
+  podSelector:
+    matchLabels:
+      app: stellar-service
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept from API pods only (web is explicitly NOT listed here)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - port: 3002
+          protocol: TCP
+  egress:
+    # stellar-service → external Stellar Horizon / Friendbot APIs
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP


### PR DESCRIPTION
## Summary

Implements [#716] — adds `NetworkPolicy` resources to enforce least-privilege pod-to-pod communication in the `health-watchers` namespace.

## Changes

- **`k8s/network-policies.yaml`** — five policies:
  - `default-deny-all` — blocks all ingress/egress by default
  - `allow-dns-egress` — permits DNS (UDP/TCP 53) for all pods
  - `web-network-policy` — web can only reach the API (port 3001)
  - `api-network-policy` — API can reach stellar-service (3002), MongoDB (27017), Redis (6379), and external HTTPS/SMTP
  - `stellar-service-network-policy` — stellar-service only accepts traffic from the API; web is explicitly excluded
- **`helm/health-watchers/templates/network-policies.yaml`** — Helm-templated equivalent, gated by `networkPolicies.enabled` (default: `true`)
- **`helm/health-watchers/values.yaml`** — added `networkPolicies.enabled: true`
- **`k8s/README.md`** — documented network topology, allowed/denied traffic table, and apply instructions

## Security impact

| Source | Destination | Before | After |
|---|---|---|---|
| web | stellar-service | ✅ allowed | ❌ denied |
| web | MongoDB | ✅ allowed | ❌ denied |
| web | Redis | ✅ allowed | ❌ denied |
| api | stellar-service | ✅ allowed | ✅ allowed |
| api | MongoDB | ✅ allowed | ✅ allowed |

## Testing

Apply to a cluster with a NetworkPolicy-capable CNI (Calico, Cilium, etc.):
```bash
kubectl apply -f k8s/network-policies.yaml
kubectl get networkpolicies -n health-watchers
```

Closes #716