### PR TITLE
ci: add PR title linting against conventional commits

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,31 @@
+name: Lint PR Title
+
+# The existing "Lint Commit Messages" workflow validates the individual commits
+# in a PR. This workflow additionally validates the PR *title*, because squash
+# merges use the PR title as the resulting commit subject on `main` — so the
+# title must also follow Conventional Commits for the changelog/release tooling
+# to classify it correctly.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install commitlint
+        run: npm install @commitlint/cli @commitlint/config-conventional
+      - name: Validate PR title against Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -497,6 +497,12 @@ We follow the [Conventional Commits](https://www.conventionalcommits.org/) speci
 
 See [Conventional Commits](https://www.conventionalcommits.org/) for details on valid types and structure.
 
+### Pull Request Titles
+
+Because pull requests are squash-merged, **the PR title becomes the commit subject on `main`** and feeds the automated changelog/release tooling. PR titles must therefore also follow the Conventional Commits format (e.g. `feat(patients): add insurance tab`).
+
+This is enforced in CI by the **Lint PR Title** workflow, which runs `commitlint` against the PR title whenever it is opened or edited. A non-conforming title will fail the check until it is corrected.
+
 ## Release Process
 
 We use [Changesets](https://github.com/changesets/changesets) for automated versioning and release management. For details, see [docs/RELEASE.md](docs/RELEASE.md).


### PR DESCRIPTION
## Summary

Adds the one missing piece of automated changelog/release tooling from the issue: **PR title linting**.

The repo already enforces Conventional Commits on individual commits (`.commitlintrc.json`, `.husky/commit-msg`, and the `Lint Commit Messages` workflow) and ships automated versioning + `CHANGELOG.md` generation via Changesets (`release.yml`). The acceptance criterion *"PR titles are validated against conventional commit format"* was not yet covered.

## Changes
- New `.github/workflows/pr-title-lint.yml` — runs `commitlint` against the PR title on `opened`/`edited`/`reopened`/`synchronize`, reusing the existing `@commitlint/config-conventional` config. This matters because squash merges turn the PR title into the commit subject on `main`.
- `CONTRIBUTING.md` — documents the PR-title requirement under Commit Messages.

## Notes
- The remaining tasks in the issue (commitlint config, husky commit-msg, automated release workflow, version bumping, CHANGELOG generation, CONTRIBUTING commit guidelines) are already implemented on `main`; this PR completes the PR-title-linting gap.

Closes #718