### PR TITLE
test(anonymize): comprehensive unit tests for anonymization package

### DIFF
--- a/packages/anonymize/jest.config.js
+++ b/packages/anonymize/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/src/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js'],
+};

--- a/packages/anonymize/package.json
+++ b/packages/anonymize/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "test": "jest dist",
+    "test": "jest --config jest.config.js",
     "build": "tsc"
   },
   "dependencies": {

--- a/packages/anonymize/src/index.ts
+++ b/packages/anonymize/src/index.ts
@@ -35,7 +35,7 @@ export interface AnonymizedPatientData {
 // PII regex patterns for clinical notes
 const PII_PATTERNS: [RegExp, string][] = [
   [/\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/g, '[PHONE]'],
-  [/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[EMAIL]'],
+  [/[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[EMAIL]'],
   [/\b\d{3}-\d{2}-\d{4}\b/g, '[SSN]'],
   [/\b\d{1,5}\s+\w+\s+(street|st|avenue|ave|road|rd|drive|dr|lane|ln|boulevard|blvd)\b/gi, '[ADDRESS]'],
   [/\b(0[1-9]|1[0-2])[\/\-](0[1-9]|[12]\d|3[01])[\/\-]\d{2,4}\b/g, '[DATE]'],


### PR DESCRIPTION
## Summary

Closes #715

Completes the test suite for the `@health-watchers/anonymize` package to achieve 100% passing coverage with all 86 tests green.

### Changes

- **Fix email PII regex** — extended `PII_PATTERNS` email pattern to cover all RFC 5321 local-part characters (`!`, `#`, `$`, `%`, `&`, `'`, `+`, etc.) so the property-based test with `fc.emailAddress()` passes for all generated inputs (counterexample was `!@a.aa`)
- **Add `jest.config.js`** — ts-jest preset config so tests run directly against TypeScript source without a pre-build step
- **Fix test script** — updated from `jest dist` (required compiled output) to `jest --config jest.config.js` so `npm test` works out of the box

### Test coverage

| Suite | Tests |
|---|---|
| HIPAA Safe Harbor — all 18 identifiers | 18 |
| Level: de-identification | 6 |
| Level: pseudonymization | 9 |
| Level: aggregation (anonymizeBatch) | 11 |
| Clinical notes — PII stripping | 14 |
| Edge cases — names and identifiers | 8 |
| Purpose parameter | 5 |
| createAuditLog | 3 |
| Property-based tests (fast-check) | 8 |
| Performance — large clinical notes | 3 |
| **Total** | **86 ✅** |

### What was tested

- Verified with `npm test` — all 86 tests pass (0 failures)
- Email property test now passes for all `fc.emailAddress()` generated values