### PR TITLE
fix(web): wire offline mode into root layout

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,6 +8,8 @@ import { AuthProvider } from '@/context/AuthContext';
 
 import { Toaster } from '@/components/ui';
 import { ThemeSync } from '@/components/ThemeSync';
+import { OfflineIndicator } from '@/components/OfflineIndicator';
+import { PWAInit } from '@/components/PWAInit';
 import './globals.css';
 
 const inter = Inter({
@@ -93,6 +95,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             <QueryProvider>
               <AuthProvider>
                 <ThemeSync />
+                <PWAInit />
+                <OfflineIndicator />
                 {children}
                 <Toaster />
               </AuthProvider>

--- a/apps/web/src/components/PWAInit.tsx
+++ b/apps/web/src/components/PWAInit.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { usePWA } from '@/hooks/usePWA';
+
+export function PWAInit() {
+  usePWA();
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes #841

All offline-mode building blocks were already implemented but were never connected to the app entry point, so the service worker never registered and the offline indicator never rendered. This PR is a two-file wiring fix that activates the existing feature.

## Root Cause

`layout.tsx` (the Next.js root layout) had no reference to:
- `usePWA` — the hook that calls `navigator.serviceWorker.register('/sw.js')`
- `OfflineIndicator` — the component that renders the offline banner

## Changes

| File | Change |
|---|---|
| `apps/web/src/components/PWAInit.tsx` | New thin client component that calls `usePWA()` to trigger SW registration on mount |
| `apps/web/src/app/layout.tsx` | Import and mount `<PWAInit />` and `<OfflineIndicator />` inside the root layout |

## What was already in place (no changes needed)

- `public/sw.js` — full service worker with cache-first, network-first, and stale-while-revalidate strategies
- `src/hooks/usePWA.ts` — registers `/sw.js` and handles PWA install prompt
- `src/components/OfflineIndicator.tsx` — fixed top banner that appears when `navigator.onLine` is false
- `src/lib/offline-sync.ts` — `OfflineSync` class (IndexedDB queue) + `useOnlineStatus` hook
- `src/app/offline/page.tsx` — offline fallback page served by the SW on navigation failures
- `e2e/offline.spec.ts` — Playwright tests covering all acceptance criteria

## Acceptance Criteria Verification

| Criterion | Status |
|---|---|
| App functions offline (cached pages served by SW) | ✅ SW now registers on first load; cache-first and network-first strategies active |
| Service worker caches static assets and clinical data | ✅ `sw.js` caches `/`, `/dashboard`, `/offline`, `/manifest.json`, and `/api/v1/patients`, `/api/v1/encounters` |
| Changes sync when back online | ✅ Background Sync API (`form-sync` tag) + IndexedDB queue in `offline-sync.ts` |
| Offline indicator displays | ✅ `<OfflineIndicator />` now mounted globally in root layout |

## Testing

E2E tests in `apps/web/e2e/offline.spec.ts` cover:
- Offline indicator visibility toggle
- Cached patient list on reload while offline
- Form submission queuing and sync on reconnect
- Stale-while-revalidate for clinical data
- PHI not cached without explicit action

Run with:
```bash
npx playwright test e2e/offline.spec.ts
```