### PR TITLE
feat(web): apply SectionErrorBoundary to patient detail tabs

### DIFF
--- a/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
+++ b/apps/web/src/app/patients/[id]/PatientDetailClient.tsx
@@ -20,6 +20,7 @@ import {
   TabsTrigger,
   Toast,
 } from '@/components/ui';
+import { SectionErrorBoundary } from '@/components/ui/SectionErrorBoundary';
 import { StellarAddressDisplay } from '@/components/ui/StellarAddressDisplay';
 import {
   CreatePaymentIntentForm,
@@ -561,20 +562,24 @@ export default function PatientDetailClient({
 
         {/* Lab Results tab */}
         <TabsContent value="lab-results">
-          <LabResultsTab patientId={patientId} />
+          <SectionErrorBoundary name="Lab Results">
+            <LabResultsTab patientId={patientId} />
+          </SectionErrorBoundary>
         </TabsContent>
 
         {/* Vitals & Analytics tab */}
         <TabsContent value="vitals">
-          {vitalsLoading || analyticsLoading ? (
-            <div className="space-y-3" aria-busy="true">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-20 animate-pulse rounded-lg bg-neutral-100" />
-              ))}
-            </div>
-          ) : (
-            <VitalSignsCharts vitals={vitals} analytics={analytics} />
-          )}
+          <SectionErrorBoundary name="Vitals & Analytics">
+            {vitalsLoading || analyticsLoading ? (
+              <div className="space-y-3" aria-busy="true">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-20 animate-pulse rounded-lg bg-neutral-100" />
+                ))}
+              </div>
+            ) : (
+              <VitalSignsCharts vitals={vitals} analytics={analytics} />
+            )}
+          </SectionErrorBoundary>
         </TabsContent>
 
         {/* Allergies tab */}
@@ -712,11 +717,15 @@ export default function PatientDetailClient({
           <ConsentTab patientId={patientId} canEdit={!!canEdit} />
         {/* Risk tab */}
         <TabsContent value="risk">
-          <RiskTab patient={patient} patientId={patientId} apiV1={API_V1} />
+          <SectionErrorBoundary name="Risk Assessment">
+            <RiskTab patient={patient} patientId={patientId} apiV1={API_V1} />
+          </SectionErrorBoundary>
         </TabsContent>
         {/* Referrals tab */}
         <TabsContent value="referrals">
-          <PatientReferralsTab patientId={patientId} />
+          <SectionErrorBoundary name="Referrals">
+            <PatientReferralsTab patientId={patientId} />
+          </SectionErrorBoundary>
         </TabsContent>
       </Tabs>
 


### PR DESCRIPTION
## Summary

Closes #840

Applies `SectionErrorBoundary` to the dynamic tab sections in `PatientDetailClient` so a render crash in one tab (Lab Results, Vitals, Risk, Referrals) is isolated — the rest of the page stays alive and the user gets a retryable inline error card. Errors are reported to Sentry via the underlying `ErrorBoundary`.

## Change

**`apps/web/src/app/patients/[id]/PatientDetailClient.tsx`**
- Import `SectionErrorBoundary`
- Wrap `<LabResultsTab>`, `<VitalSignsCharts>`, `<RiskTab>`, `<PatientReferralsTab>` each in `<SectionErrorBoundary name="...">`

## What was already in place

- `error-boundary.tsx` — `ErrorBoundary` class with Sentry reporting, error ID, retry
- `SectionErrorBoundary.tsx` — compact inline error card wrapping `ErrorBoundary`
- `(dashboard)/layout.tsx` — top-level `<ErrorBoundary>` covering all authenticated pages
- `__tests__/error-boundary.test.tsx` — full Jest suite

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Errors caught and displayed | ✅ SectionErrorBoundary renders inline alert with error message |
| Details logged to Sentry | ✅ ErrorBoundary calls Sentry.withScope with errorId tag + component stack |
| Users can retry | ✅ Retry button resets boundary state and re-renders the section |
| App doesn't crash | ✅ Error in one tab is isolated; rest of patient detail page stays interactive |