### PR TITLE
Feat/stellar key rotation

### DIFF
--- a/apps/api/src/modules/audit/audit.model.ts
+++ b/apps/api/src/modules/audit/audit.model.ts
@@ -93,6 +93,8 @@ const auditLogSchema = new Schema<AuditLog>(
         'CLINIC_SWITCH',
         'DATA_EXPORT_REQUEST',
         'DATA_EXPORT_FULFILLED',
+        'KEYPAIR_ROTATE',
+        'CONSENT_VERSION_ACCEPTED',
       ],
       index: true,
     },

--- a/apps/api/src/modules/audit/audit.model.ts
+++ b/apps/api/src/modules/audit/audit.model.ts
@@ -93,7 +93,6 @@ const auditLogSchema = new Schema<AuditLog>(
         'CLINIC_SWITCH',
         'DATA_EXPORT_REQUEST',
         'DATA_EXPORT_FULFILLED',
-        'KEYPAIR_ROTATE',
         'CONSENT_VERSION_ACCEPTED',
       ],
       index: true,

--- a/apps/api/src/modules/clinics/clinics.controller.test.ts
+++ b/apps/api/src/modules/clinics/clinics.controller.test.ts
@@ -62,13 +62,62 @@ jest.mock('@api/modules/clinics/clinic.model', () => ({
   ClinicModel: {
     create: jest.fn(),
     findById: jest.fn(),
+    findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+    exists: jest.fn().mockResolvedValue(false),
   },
+}));
+
+jest.mock('@api/modules/clinics/clinic-keypair.model', () => ({
+  ClinicKeypairModel: {
+    findOne: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ keyVersion: 1 }) }),
+    }),
+    create: jest.fn().mockResolvedValue({ _id: 'kp-id' }),
+    findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+    findByIdAndDelete: jest.fn().mockResolvedValue({}),
+    updateMany: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+jest.mock('@api/modules/clinics/keypair.service', () => ({
+  generateClinicKeypair: jest.fn().mockReturnValue({
+    publicKey: 'GNEWPUBLICKEY',
+    encryptedSecretKey: 'enc',
+    iv: 'iv',
+  }),
+  rotateClinicKeypair: jest.fn(),
+}));
+
+jest.mock('@api/modules/audit/audit.service', () => ({
+  auditLog: jest.fn(),
+}));
+
+jest.mock('@api/lib/email.service', () => ({
+  sendKeypairRotationEmail: jest.fn(),
+}));
+
+jest.mock('@api/modules/auth/models/user.model', () => ({
+  UserModel: {
+    updateMany: jest.fn().mockResolvedValue({}),
+    findOne: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue({ email: 'admin@test.com' }) }),
+  },
+}));
+
+jest.mock('@api/modules/clinics/clinic-settings.model', () => ({
+  ClinicSettingsModel: { create: jest.fn().mockResolvedValue({}) },
+}));
+
+jest.mock('@api/modules/payments/services/stellar-client', () => ({
+  stellarClient: { fundAccount: jest.fn().mockResolvedValue({}), transferBalance: jest.fn() },
 }));
 
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import app from '@api/app';
 import { ClinicModel } from './clinic.model';
+import { rotateClinicKeypair } from './keypair.service';
+import { auditLog } from '@api/modules/audit/audit.service';
+import { sendKeypairRotationEmail } from '@api/lib/email.service';
 
 function makeToken(role: string, clinicId: string) {
   return jwt.sign(
@@ -139,5 +188,105 @@ describe('Clinics API', () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('Forbidden');
+  });
+});
+
+describe('POST /api/v1/clinics/:id/keypair/rotate', () => {
+  const CLINIC_ID = '507f1f77bcf86cd799439011';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ClinicModel.findById as jest.Mock).mockResolvedValue({
+      _id: CLINIC_ID,
+      name: 'Test Clinic',
+      stellarPublicKey: 'GOLDKEY',
+    });
+    (rotateClinicKeypair as jest.Mock).mockResolvedValue({
+      publicKey: 'GNEWKEY',
+      keyVersion: 2,
+      transferResult: { transferred: true, amount: '10', hash: 'txhash' },
+    });
+  });
+
+  it('returns 200 with new publicKey and keyVersion on success', async () => {
+    const res = await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('SUPER_ADMIN', CLINIC_ID)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.publicKey).toBe('GNEWKEY');
+    expect(res.body.data.keyVersion).toBe(2);
+  });
+
+  it('calls rotateClinicKeypair with correct clinicId', async () => {
+    await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('SUPER_ADMIN', CLINIC_ID)}`);
+
+    expect(rotateClinicKeypair).toHaveBeenCalledWith(
+      CLINIC_ID,
+      expect.objectContaining({ stellarNetwork: 'testnet' }),
+    );
+  });
+
+  it('records KEYPAIR_ROTATE audit log after successful rotation', async () => {
+    await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('SUPER_ADMIN', CLINIC_ID)}`);
+
+    expect(auditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'KEYPAIR_ROTATE',
+        resourceType: 'Clinic',
+        resourceId: CLINIC_ID,
+        metadata: expect.objectContaining({ newPublicKey: 'GNEWKEY', keyVersion: 2 }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('sends email notification to clinic admin after successful rotation', async () => {
+    await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('SUPER_ADMIN', CLINIC_ID)}`);
+
+    expect(sendKeypairRotationEmail).toHaveBeenCalledWith(
+      'admin@test.com',
+      'Test Clinic',
+      'GNEWKEY',
+      2,
+    );
+  });
+
+  it('returns 404 when clinic is not found', async () => {
+    (ClinicModel.findById as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('SUPER_ADMIN', CLINIC_ID)}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('NotFound');
+  });
+
+  it('returns 500 and does NOT send email when rotation fails', async () => {
+    (rotateClinicKeypair as jest.Mock).mockRejectedValue(new Error('Transfer failed'));
+
+    const res = await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('SUPER_ADMIN', CLINIC_ID)}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('RotationFailed');
+    expect(sendKeypairRotationEmail).not.toHaveBeenCalled();
+  });
+
+  it('denies non-SUPER_ADMIN access', async () => {
+    const res = await request(app)
+      .post(`/api/v1/clinics/${CLINIC_ID}/keypair/rotate`)
+      .set('Authorization', `Bearer ${makeToken('CLINIC_ADMIN', CLINIC_ID)}`);
+
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/api/src/modules/clinics/keypair.service.test.ts
+++ b/apps/api/src/modules/clinics/keypair.service.test.ts
@@ -121,3 +121,150 @@ describe('keypair.service', () => {
     });
   });
 });
+
+/**
+ * rotateClinicKeypair — Issue #707
+ *
+ * Covers:
+ *  - Successful rotation: new keypair created, balance transferred, clinic updated, old keypair deactivated
+ *  - Failed balance transfer triggers rollback (new keypair document deleted)
+ *  - Clinic not found throws
+ *  - No existing stellarPublicKey: skips transfer, still rotates
+ *  - Key version increments correctly (starts at 1 when no prior keypair, increments otherwise)
+ *  - Testnet funding attempted before balance transfer
+ */
+describe('rotateClinicKeypair', () => {
+  const CLINIC_ID = '507f1f77bcf86cd799439011';
+  const OLD_PUBLIC_KEY = 'GOLDPUBLICKEY1111111111111111111111111111111111111111111111';
+  const NEW_PUBLIC_KEY = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZQE3NMQKK6UUUHKKOAIB';
+
+  let mockFindById: jest.Mock;
+  let mockClinicUpdate: jest.Mock;
+  let mockKeypairFindOne: jest.Mock;
+  let mockKeypairCreate: jest.Mock;
+  let mockKeypairFindByIdAndUpdate: jest.Mock;
+  let mockKeypairFindByIdAndDelete: jest.Mock;
+  let mockKeypairUpdateMany: jest.Mock;
+  let mockTransferBalance: jest.Mock;
+  let mockFundAccount: jest.Mock;
+  let deps: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('@stellar/stellar-sdk', () => ({
+      Keypair: {
+        random: () => ({
+          publicKey: () => NEW_PUBLIC_KEY,
+          secret: () => 'SCZANGBA5RLKJZ65NOVCKVS2VIOWV2MRDBBR7BVNKPKGZBJKHOSXWC3',
+        }),
+      },
+    }));
+
+    mockFindById = jest.fn().mockResolvedValue({
+      _id: CLINIC_ID,
+      stellarPublicKey: OLD_PUBLIC_KEY,
+    });
+    mockClinicUpdate = jest.fn().mockResolvedValue({});
+    mockKeypairFindOne = jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ keyVersion: 1 }),
+      }),
+    });
+    mockKeypairCreate = jest.fn().mockResolvedValue({ _id: 'new-kp-id' });
+    mockKeypairFindByIdAndUpdate = jest.fn().mockResolvedValue({});
+    mockKeypairFindByIdAndDelete = jest.fn().mockResolvedValue({});
+    mockKeypairUpdateMany = jest.fn().mockResolvedValue({});
+    mockTransferBalance = jest.fn().mockResolvedValue({ transferred: true, amount: '10', hash: 'txhash' });
+    mockFundAccount = jest.fn().mockResolvedValue({ funded: true });
+
+    deps = {
+      ClinicModel: { findById: mockFindById, findByIdAndUpdate: mockClinicUpdate },
+      ClinicKeypairModel: {
+        findOne: mockKeypairFindOne,
+        create: mockKeypairCreate,
+        findByIdAndUpdate: mockKeypairFindByIdAndUpdate,
+        findByIdAndDelete: mockKeypairFindByIdAndDelete,
+        updateMany: mockKeypairUpdateMany,
+      },
+      stellarClient: { transferBalance: mockTransferBalance, fundAccount: mockFundAccount },
+      stellarNetwork: 'testnet',
+      logger: { warn: jest.fn(), error: jest.fn() },
+    };
+  });
+
+  it('returns new publicKey and incremented keyVersion on success', async () => {
+    const { rotateClinicKeypair } = require('./keypair.service');
+    const result = await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(result.publicKey).toBe(NEW_PUBLIC_KEY);
+    expect(result.keyVersion).toBe(2);
+    expect(result.transferResult).toEqual({ transferred: true, amount: '10', hash: 'txhash' });
+  });
+
+  it('creates new keypair as inactive, then activates after successful transfer', async () => {
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(mockKeypairCreate).toHaveBeenCalledWith(expect.objectContaining({ isActive: false }));
+    expect(mockKeypairFindByIdAndUpdate).toHaveBeenCalledWith('new-kp-id', { isActive: true });
+  });
+
+  it('updates clinic stellarPublicKey to new key', async () => {
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(mockClinicUpdate).toHaveBeenCalledWith(CLINIC_ID, { stellarPublicKey: NEW_PUBLIC_KEY });
+  });
+
+  it('deactivates old keypairs after successful rotation', async () => {
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(mockKeypairUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ clinicId: CLINIC_ID, isActive: true }),
+      { isActive: false },
+    );
+  });
+
+  it('calls transferBalance with old and new public keys', async () => {
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(mockTransferBalance).toHaveBeenCalledWith(OLD_PUBLIC_KEY, NEW_PUBLIC_KEY);
+  });
+
+  it('rolls back (deletes new keypair) when balance transfer fails', async () => {
+    mockTransferBalance.mockRejectedValue(new Error('Transfer failed'));
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await expect(rotateClinicKeypair(CLINIC_ID, deps)).rejects.toThrow('Transfer failed');
+    expect(mockKeypairFindByIdAndDelete).toHaveBeenCalledWith('new-kp-id');
+    expect(mockClinicUpdate).not.toHaveBeenCalled();
+    expect(mockKeypairUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('throws when clinic is not found', async () => {
+    mockFindById.mockResolvedValue(null);
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await expect(rotateClinicKeypair(CLINIC_ID, deps)).rejects.toThrow('Clinic not found');
+  });
+
+  it('skips transferBalance when clinic has no existing stellarPublicKey', async () => {
+    mockFindById.mockResolvedValue({ _id: CLINIC_ID, stellarPublicKey: undefined });
+    const { rotateClinicKeypair } = require('./keypair.service');
+    const result = await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(mockTransferBalance).not.toHaveBeenCalled();
+    expect(result.publicKey).toBe(NEW_PUBLIC_KEY);
+  });
+
+  it('starts keyVersion at 1 when no prior keypair exists', async () => {
+    mockKeypairFindOne.mockReturnValue({
+      sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }),
+    });
+    const { rotateClinicKeypair } = require('./keypair.service');
+    const result = await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(result.keyVersion).toBe(1);
+    expect(mockKeypairCreate).toHaveBeenCalledWith(expect.objectContaining({ keyVersion: 1 }));
+  });
+
+  it('funds new account on testnet before balance transfer', async () => {
+    const { rotateClinicKeypair } = require('./keypair.service');
+    await rotateClinicKeypair(CLINIC_ID, deps);
+    expect(mockFundAccount).toHaveBeenCalledWith(NEW_PUBLIC_KEY);
+    expect(mockTransferBalance).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION

  feat(clinics): implement atomic Stellar keypair rotation

  Summary

  Implements zero-downtime Stellar keypair rotation for clinic accounts. A new keypair is only activated after the XLM balance has been successfully transferred from the old account —
  ensuring no funds are lost and no partial state is ever persisted

  Why

  Clinics need to rotate their Stellar signing keys periodically for security compliance. A naive swap (deactivate old → create new) risks losing funds or leaving the system in a broken
  state if anything fails mid-rotation.

  What was implemented

  keypair.service.ts — rotateClinicKeypair()

  - New keypair is persisted as isActive: false first
  - Testnet Friendbot funding attempted (best-effort, non-blocking)
  - XLM balance transferred from old → new account (blocking — must succeed)
  - New keypair activated and clinic stellarPublicKey updated only after successful transfer
  - Old keypairs deactivated last
  - On any failure: new keypair document is deleted and clinic record is left unchanged (full rollback)

  clinics.controller.ts — POST /api/v1/clinics/:id/keypair/rotate

  - SUPER_ADMIN only
  - Delegates to rotateClinicKeypair() with dependency injection
  - Records KEYPAIR_ROTATE audit log on success
  - Sends email notification to clinic admin on success (best-effort)
  - Returns 500 RotationFailed with rollback applied on error

  audit.model.ts

  - Removed duplicate KEYPAIR_ROTATE entry from Mongoose schema enum array



  Tests

  │ File                             │ Coverage                                                                                                                                           │
  
  │ keypair.service.test.ts          │ Successful rotation, new key inactive then activated, transfer called with correct keys, rollback on transfer failure, clinic not found, skips     │
  │                                  │ transfer when no old key, key version increments, testnet funding before transfer                                                                  │
    │ keypair-rotation.service.test.ts │ Same rotation scenarios via direct import                                                                                                          │
  
  │ clinics.controller.test.ts       │ 200 on success, audit log recorded, email sent, 404 when clinic not found, 500 + no email on failure, 403 for non-SUPER_ADMIN                      │
  
  Rotation flow

  1. Generate new keypair → persist as inactive
  2. Fund new account via Friendbot (testnet only, best-effort)
  3. Transfer XLM balance old → new  ← must succeed
  4. Activate new keypair + update clinic.stellarPublicKey
  5. Deactivate all old keypairs
  ↳ On failure at step 3+: delete new keypair doc, clinic unchanged


  Closes #707