### PR TITLE
feat: distributed tracing status, request correlation, API versioning upgrade path, and health check completeness

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -54,6 +54,7 @@ import {
   apiVersionHeader,
   v1DeprecationWarning,
   getSupportedVersions,
+  acceptVersionMiddleware,
 } from './middlewares/api-versioning.middleware';
 import { traceIdHeader } from './middlewares/trace-id.middleware';
 import { clinicSettingsRoutes } from './modules/clinics/clinic-settings.controller';
@@ -121,7 +122,9 @@ import federationRouter from './modules/federation/federation.router';
 import exportRouter from './modules/export/export.routes';
 import { complianceRoutes } from './modules/compliance/compliance.controller';
 import { requestIdPropagationMiddleware } from './middlewares/request-id-propagation.middleware';
+import { correlationMiddleware } from './middlewares/correlation.middleware';
 import { breachIncidentRoutes } from './modules/breach-incidents/breach-incidents.controller';
+import { backupHealthRoutes } from './modules/health/backup-health.controller';
 
 const app = express();
 const server = createServer(app);
@@ -204,7 +207,10 @@ app.use(
   })
 );
 
-// ── Request ID propagation ────────────────────────────────────────────────────
+// ── Request ID correlation & propagation ──────────────────────────────────────
+// correlationMiddleware: stamps req.requestId and echoes X-Request-ID header
+app.use(correlationMiddleware);
+// requestIdPropagationMiddleware: stores the ID in AsyncLocalStorage for downstream services
 app.use(requestIdPropagationMiddleware);
 
 // ── Body parsing & sanitization ───────────────────────────────────────────────
@@ -231,6 +237,7 @@ app.use((req, res, next) => {
 
 // ── Health check ──────────────────────────────────────────────────────────────
 app.use('/health', healthRoutes);
+app.use('/health', backupHealthRoutes);
 
 // ── Prometheus metrics ────────────────────────────────────────────────────────
 // Must be registered before API routes so all requests are measured
@@ -242,6 +249,9 @@ app.get('/api/versions', (_req, res) => {
   const versions = getSupportedVersions();
   res.json(versions);
 });
+
+// ── Accept-Version header negotiation ─────────────────────────────────────────
+app.use('/api', acceptVersionMiddleware);
 
 // ── V1 API Routes (with deprecation warnings) ────────────────────────────────
 app.use('/api/v1', v1DeprecationWarning);

--- a/apps/api/src/middlewares/api-versioning.middleware.ts
+++ b/apps/api/src/middlewares/api-versioning.middleware.ts
@@ -71,7 +71,7 @@ export const v1DeprecationWarning: RequestHandler = (_req, res, next) => {
 };
 
 /**
- * Get all supported API versions with their status
+ * Get all supported API versions with their status and upgrade path.
  */
 export function getSupportedVersions() {
   return {
@@ -79,5 +79,43 @@ export function getSupportedVersions() {
     current: 'v2',
     deprecated: API_VERSIONS.filter((v) => v.status === 'deprecated'),
     sunset: API_VERSIONS.filter((v) => v.status === 'sunset'),
+    upgradePath: {
+      from: 'v1',
+      to: 'v2',
+      deprecatedAt: '2025-12-01',
+      sunsetAt: '2026-12-01',
+      breakingChanges: [
+        'Appointment response shape updated — date fields are now ISO-8601 strings',
+        'Pagination envelope moved from data[] to items[] with a meta object',
+      ],
+      migrationGuide: 'https://docs.health-watchers.io/api/migration-v1-v2',
+    },
   };
 }
+
+/**
+ * Middleware that validates the Accept-Version request header.
+ * Rejects unknown versions (406) and sunset versions (410).
+ * When a valid version is specified it overwrites the API-Version response header.
+ */
+export const acceptVersionMiddleware: RequestHandler = (req, res, next) => {
+  const requested = req.headers['accept-version'] as string | undefined;
+  if (!requested) return next();
+
+  const matched = API_VERSIONS.find((v) => v.version === requested);
+  if (!matched) {
+    return res.status(406).json({
+      error: 'NotAcceptable',
+      message: `API version '${requested}' is not supported. See /api/versions for available versions.`,
+    });
+  }
+  if (matched.status === 'sunset') {
+    return res.status(410).json({
+      error: 'Gone',
+      message: `API version '${requested}' has been sunset. Please migrate to v2. See /api/versions for upgrade path.`,
+    });
+  }
+
+  res.set('API-Version', matched.version);
+  next();
+};

--- a/apps/api/src/modules/health/health.controller.ts
+++ b/apps/api/src/modules/health/health.controller.ts
@@ -6,6 +6,8 @@ import { isAIServiceAvailable } from '../ai/ai.service';
 import { config } from '@health-watchers/config';
 import { getDbStatus, getPoolMetrics } from '../../config/db';
 import { getJobStatus, CHECK_INTERVAL_MS } from '../payments/services/payment-expiration-job';
+import { currentTraceId } from '../../utils/tracer';
+import { getRequestId } from '../../utils/request-id';
 
 const router = Router();
 
@@ -152,6 +154,64 @@ router.get('/jobs', (_req: Request, res: Response) => {
         neverRan,
       },
     },
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/**
+ * GET /health - Quick summary of all health sub-systems
+ */
+router.get('/', (_req: Request, res: Response) => {
+  res.status(200).json({
+    status: 'ok',
+    service: 'health-watchers-api',
+    version: process.env.npm_package_version || '1.0.0',
+    uptime: Math.floor(process.uptime()),
+    endpoints: [
+      '/health/live',
+      '/health/ready',
+      '/health/startup',
+      '/health/jobs',
+      '/health/backup',
+      '/health/tracing',
+      '/health/trace-context',
+    ],
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/**
+ * GET /health/tracing - OpenTelemetry configuration status
+ */
+router.get('/tracing', (_req: Request, res: Response) => {
+  const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? null;
+  const samplingRate = parseFloat(
+    process.env.OTEL_SAMPLING_RATE ?? (process.env.NODE_ENV !== 'production' ? '1.0' : '0.1')
+  );
+
+  res.status(200).json({
+    status: 'active',
+    serviceName: 'health-watchers-api',
+    exporter: otlpEndpoint ? 'otlp' : process.env.NODE_ENV !== 'production' ? 'console' : 'none',
+    otlpEndpoint,
+    samplingRate,
+    autoInstrumentation: ['express', 'mongodb', 'http'],
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/**
+ * GET /health/trace-context - Current request correlation (request ID ↔ trace ID)
+ */
+router.get('/trace-context', (req: Request, res: Response) => {
+  const requestId =
+    getRequestId() ?? ((req as any).id as string | undefined) ?? (req.headers['x-request-id'] as string) ?? null;
+  const traceId = currentTraceId() ?? null;
+
+  res.status(200).json({
+    requestId,
+    traceId,
+    correlated: requestId !== null && traceId !== null,
     timestamp: new Date().toISOString(),
   });
 });


### PR DESCRIPTION
## Summary


This PR completes four observability and reliability features that were partially scaffolded but missing their final wiring and endpoints.

---

### #862 — Distributed Tracing Setup

The OpenTelemetry SDK, `withSpan` utility, and `X-Trace-Id` response header were already configured. What was missing was a way to inspect the tracing configuration at runtime.

**Added:** `GET /health/tracing` — returns the active OTel exporter type (`otlp` / `console` / `none`), OTLP endpoint, sampling rate, and the list of auto-instrumented libraries. This serves as the operational trace dashboard entry point and makes trace configuration observable without needing to inspect env vars.

---

### #863 — Request ID Correlation

Request ID generation and AsyncLocalStorage propagation were in place, but `correlationMiddleware` (which stamps `req.requestId` on the Express request object and echoes `X-Request-ID` in the response) was never mounted in `app.ts`.

**Added:**
- `correlationMiddleware` mounted after `pinoHttp` so `req.requestId` is populated for all downstream handlers.
- `GET /health/trace-context` — returns the current request's `requestId` alongside the active OTel `traceId` and a boolean `correlated` flag, providing a concrete viewer for the request ID ↔ trace ID linkage.

---

### #864 — API Versioning Strategy

Version routing, deprecation headers (RFC 8594 `Deprecation` / `Sunset` / `Link`), and the `/api/versions` discovery endpoint were all present. Missing was a documented upgrade path and support for client-driven version negotiation via the `Accept-Version` header.

**Added:**
- `upgradePath` object in `getSupportedVersions()` — includes breaking changes between v1 and v2, deprecation/sunset dates, and a link to the migration guide.
- `acceptVersionMiddleware` — validates the `Accept-Version` request header; responds `406 Not Acceptable` for unknown versions and `410 Gone` for sunset ones. Mounted on `/api` globally.

---

### #865 — Health Check Endpoint

The `/health/live`, `/health/ready`, `/health/startup`, and `/health/jobs` routes were complete. `backup-health.controller.ts` (which provides `/health/backup` and `/health/backup/detailed`) existed but was not imported or mounted in `app.ts`, leaving backup health entirely unreachable.

**Added:**
- `backupHealthRoutes` mounted at `/health` — exposes `/health/backup` (quick check) and `/health/backup/detailed` (with recommendations).
- `GET /health` (root) — lightweight summary endpoint listing all available health sub-routes with service name, version, and uptime. Useful for monitoring dashboards and k8s startup scripts that need a single entry point.

---
Closes #862 
closes #863 
closes #864 
closes #865 

## Files changed

| File | Change |
|------|--------|
| `apps/api/src/app.ts` | Mount `correlationMiddleware`, `backupHealthRoutes`, `acceptVersionMiddleware` |
| `apps/api/src/middlewares/api-versioning.middleware.ts` | Add `upgradePath` to `getSupportedVersions()`; add `acceptVersionMiddleware` |
| `apps/api/src/modules/health/health.controller.ts` | Add `GET /`, `GET /tracing`, `GET /trace-context` endpoints |

## Test plan

- [ ] `GET /health` returns `200` with service name, uptime, and endpoint list
- [ ] `GET /health/tracing` returns exporter and sampling rate
- [ ] `GET /health/trace-context` returns `requestId` on every request; `traceId` populated when OTel is active
- [ ] `GET /health/backup` returns `200` or `503` based on backup verification state
- [ ] `GET /health/backup/detailed` returns recommendations
- [ ] `GET /api/versions` includes `upgradePath` with breaking changes and migration guide
- [ ] Request with `Accept-Version: v2` succeeds; `Accept-Version: v99` returns `406`; sunset version returns `410`
- [ ] All v1 responses include `X-Request-ID` and `Deprecation` headers