### PR TITLE
feat: Audit logging, graceful shutdown, field encryption & response filtering

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -88,6 +88,6 @@
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "5.9.3"
+    "typescript": "^5.9.3"
   }
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,7 +13,6 @@ const compression = require('compression') as ((...args: any[]) => any) & {
 };
 import pinoHttp from 'pino-http';
 import mongoSanitize from 'express-mongo-sanitize';
-import mongoose from 'mongoose';
 import { connectDB, getPoolMetrics } from './config/db';
 import { authRoutes } from './modules/auth/auth.controller';
 import { userRoutes } from './modules/users/users.controller';
@@ -107,11 +106,14 @@ import {
   cvxCodesRouter,
 } from './modules/immunizations/immunizations.controller';
 import logger from './utils/logger';
+import { registerGracefulShutdown } from './utils/graceful-shutdown';
 import apiKeyRoutes from './modules/api-keys/api-keys.routes';
 import { v2Router } from './routes/v2';
 import { SocketService } from './services/socket.service';
 import scheduleRoutes from './modules/schedules/schedules.routes';
 import { requestAuditMiddleware } from './middlewares/request-audit.middleware';
+import { mutationAuditMiddleware } from './middlewares/mutation-audit.middleware';
+import { responseFilterMiddleware } from './middlewares/response-filter.middleware';
 // npm install cookie-parser @types/cookie-parser
 import cookieParser from 'cookie-parser';
 import { csrfMiddleware } from './middlewares/csrf.middleware';
@@ -216,6 +218,7 @@ app.use(express.json({ limit: standardLimit }));
 app.use(express.urlencoded({ extended: true, limit: standardLimit }));
 app.use(mongoSanitize({ replaceWith: '_' }));
 app.use(requestAuditMiddleware);
+app.use(mutationAuditMiddleware);
 app.use(csrfMiddleware);
 
 // ── Content-Type validation (issue #351) ──────────────────────────────────────
@@ -247,6 +250,9 @@ app.get('/api/versions', (_req, res) => {
   const versions = getSupportedVersions();
   res.json(versions);
 });
+
+// ── Role-based response field filtering ──────────────────────────────────────
+app.use('/api', responseFilterMiddleware);
 
 // ── V1 API Routes (with deprecation warnings) ────────────────────────────────
 app.use('/api/v1', v1DeprecationWarning);
@@ -354,60 +360,18 @@ async function startServer() {
     mongodbPoolWaitQueueSize.set(waitQueueSize);
   }, 15_000);
 
-  // Graceful shutdown handler
-  const shutdown = async (signal: string) => {
-    logger.info(`${signal} received, starting graceful shutdown`);
-
-    // Stop accepting new connections
-    server.close(async () => {
-      logger.info('HTTP server closed');
-
-      try {
-        // Stop payment expiration job
-        stopPaymentExpirationJob();
-        stopReconciliationJob();
-        stopRiskRecalculationJob();
-        stopBalanceMonitoringJob();
-        stopWaitlistExpiryJob();
-        stopAppointmentReminderJob();
-        stopClaimableExpiryNotificationJob();
-        stopXLMRateJob();
-        stopMfaGracePeriodJob();
-        logger.info('All background jobs stopped');
-
-        // Close database connection
-        await mongoose.connection.close();
-        logger.info('MongoDB connection closed');
-
-        logger.info('Graceful shutdown completed');
-        process.exit(0);
-      } catch (err) {
-        logger.error({ err }, 'Error during graceful shutdown');
-        process.exit(1);
-      }
-    });
-
-    // Force exit after 30 seconds if graceful shutdown hangs
-    setTimeout(() => {
-      logger.error('Graceful shutdown timeout (30s), forcing exit');
-      process.exit(1);
-    }, 30000);
-  };
-
-  // Handle termination signals
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-  process.on('SIGINT', () => shutdown('SIGINT'));
-
-  // Handle uncaught exceptions
-  process.on('uncaughtException', (err: unknown) => {
-    logger.error({ err }, 'Uncaught exception');
-    shutdown('uncaughtException');
-  });
-
-  // Handle unhandled promise rejections
-  process.on('unhandledRejection', (reason: unknown) => {
-    logger.error({ reason }, 'Unhandled rejection');
-    // Log but don't exit - let the process continue
+  registerGracefulShutdown(server, {
+    stopJobs: [
+      stopPaymentExpirationJob,
+      stopReconciliationJob,
+      stopRiskRecalculationJob,
+      stopBalanceMonitoringJob,
+      stopWaitlistExpiryJob,
+      stopAppointmentReminderJob,
+      stopClaimableExpiryNotificationJob,
+      stopXLMRateJob,
+      stopMfaGracePeriodJob,
+    ],
   });
 }
 

--- a/apps/api/src/lib/encrypt.test.ts
+++ b/apps/api/src/lib/encrypt.test.ts
@@ -1,0 +1,84 @@
+import { encrypt, decrypt } from './encrypt';
+
+const TEST_KEY = 'a'.repeat(64); // 32-byte hex key for testing
+
+beforeEach(() => {
+  process.env.FIELD_ENCRYPTION_KEY = TEST_KEY;
+  process.env.FIELD_ENCRYPTION_KEY_VERSION = '1';
+  delete process.env.FIELD_ENCRYPTION_KEY_V1;
+  delete process.env.FIELD_ENCRYPTION_KEY_V2;
+});
+
+describe('encrypt', () => {
+  it('produces a versioned colon-delimited hex string', () => {
+    const result = encrypt('hello');
+    expect(result).toMatch(/^v\d+:[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/);
+  });
+
+  it('produces different ciphertext for the same input (random IV)', () => {
+    const a = encrypt('same');
+    const b = encrypt('same');
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('decrypt', () => {
+  it('round-trips plaintext', () => {
+    const plaintext = 'sensitive PHI value';
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  it('round-trips empty string', () => {
+    expect(decrypt(encrypt(''))).toBe('');
+  });
+
+  it('round-trips a string with special characters', () => {
+    const value = 'Ünïcödé & <script>alert(1)</script>';
+    expect(decrypt(encrypt(value))).toBe(value);
+  });
+
+  it('returns non-encrypted value unchanged', () => {
+    expect(decrypt('plaintext')).toBe('plaintext');
+    expect(decrypt('')).toBe('');
+  });
+
+  it('decrypts with old key during key rotation', () => {
+    // Encrypt with version 1
+    const plaintext = 'rotate me';
+    const ciphertext = encrypt(plaintext);
+
+    // Simulate rotation: bump to version 2, keep old key as V1
+    process.env.FIELD_ENCRYPTION_KEY_V1 = TEST_KEY;
+    process.env.FIELD_ENCRYPTION_KEY = 'b'.repeat(64);
+    process.env.FIELD_ENCRYPTION_KEY_VERSION = '2';
+
+    // Re-import to pick up new env vars (Jest module cache — call decrypt directly)
+    // decrypt reads env at call time, so it should resolve V1 key for v1: prefix
+    expect(decrypt(ciphertext)).toBe(plaintext);
+  });
+
+  it('encrypts new values with the current (rotated) key', () => {
+    process.env.FIELD_ENCRYPTION_KEY = 'b'.repeat(64);
+    process.env.FIELD_ENCRYPTION_KEY_VERSION = '2';
+    const plaintext = 'new value';
+    const ciphertext = encrypt(plaintext);
+    expect(ciphertext.startsWith('v2:')).toBe(true);
+    expect(decrypt(ciphertext)).toBe(plaintext);
+  });
+});
+
+describe('error handling', () => {
+  it('throws if FIELD_ENCRYPTION_KEY is missing or invalid', () => {
+    process.env.FIELD_ENCRYPTION_KEY = 'short';
+    expect(() => encrypt('x')).toThrow('FIELD_ENCRYPTION_KEY must be a 64-char hex string');
+  });
+
+  it('throws if versioned key is missing during decryption', () => {
+    const ciphertext = encrypt('x'); // encrypted with v1 (TEST_KEY)
+    // Rotate to v2 without providing V1 fallback
+    process.env.FIELD_ENCRYPTION_KEY = 'b'.repeat(64);
+    process.env.FIELD_ENCRYPTION_KEY_VERSION = '2';
+    // v1 key is not set → should throw
+    expect(() => decrypt(ciphertext)).toThrow();
+  });
+});

--- a/apps/api/src/lib/encrypt.ts
+++ b/apps/api/src/lib/encrypt.ts
@@ -3,27 +3,78 @@ import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 const ALGO = 'aes-256-gcm';
 const IV_LEN = 12;
 
-function getKey(): Buffer {
+/**
+ * Resolves the active encryption key and builds a map of all versioned keys for
+ * decryption during key rotation.
+ *
+ * Key management:
+ *   - Set FIELD_ENCRYPTION_KEY to the current (latest) key (64-char hex).
+ *   - Set FIELD_ENCRYPTION_KEY_VERSION to the numeric version of that key (default: 1).
+ *   - During rotation, keep the old key accessible via a versioned env var:
+ *       FIELD_ENCRYPTION_KEY_V<n>=<64-char hex>
+ *     e.g. FIELD_ENCRYPTION_KEY_V1=<old key>  while FIELD_ENCRYPTION_KEY=<new key>
+ *   - Encrypted values are prefixed with `v<n>:` so the correct key can be
+ *     selected at decrypt time.
+ */
+
+function getCurrentVersion(): number {
+  return parseInt(process.env.FIELD_ENCRYPTION_KEY_VERSION ?? '1', 10);
+}
+
+function getCurrentKey(): Buffer {
   const hex = process.env.FIELD_ENCRYPTION_KEY ?? '';
   if (hex.length !== 64)
     throw new Error('FIELD_ENCRYPTION_KEY must be a 64-char hex string (32 bytes)');
   return Buffer.from(hex, 'hex');
 }
 
-/** Returns `iv:ciphertext:tag` as a hex-colon string. */
-export function encrypt(plaintext: string): string {
-  const iv = randomBytes(IV_LEN);
-  const cipher = createCipheriv(ALGO, getKey(), iv);
-  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  return `${iv.toString('hex')}:${ct.toString('hex')}:${tag.toString('hex')}`;
+function getKeyForVersion(version: number): Buffer {
+  if (version === getCurrentVersion()) return getCurrentKey();
+
+  const envVar = `FIELD_ENCRYPTION_KEY_V${version}`;
+  const hex = process.env[envVar] ?? '';
+  if (hex.length !== 64)
+    throw new Error(`${envVar} must be a 64-char hex string (32 bytes) for key rotation`);
+  return Buffer.from(hex, 'hex');
 }
 
-/** Accepts the `iv:ciphertext:tag` format produced by `encrypt`. */
+/**
+ * Encrypts plaintext with the current key.
+ * Returns `v<version>:iv:ciphertext:tag` as a colon-delimited hex string.
+ */
+export function encrypt(plaintext: string): string {
+  const version = getCurrentVersion();
+  const key = getCurrentKey();
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `v${version}:${iv.toString('hex')}:${ct.toString('hex')}:${tag.toString('hex')}`;
+}
+
+/**
+ * Decrypts a value produced by `encrypt`.
+ * Accepts both the versioned `v<n>:iv:ct:tag` format and the legacy `iv:ct:tag` format.
+ * Returns the input unchanged if it does not look like an encrypted value.
+ */
 export function decrypt(encoded: string): string {
-  const [ivHex, ctHex, tagHex] = encoded.split(':');
-  if (!ivHex || !ctHex || !tagHex) return encoded; // not encrypted — return as-is
-  const decipher = createDecipheriv(ALGO, getKey(), Buffer.from(ivHex, 'hex'));
+  if (!encoded) return encoded;
+
+  let version = getCurrentVersion();
+  let rest = encoded;
+
+  const versionMatch = encoded.match(/^v(\d+):/);
+  if (versionMatch) {
+    version = parseInt(versionMatch[1], 10);
+    rest = encoded.slice(versionMatch[0].length);
+  }
+
+  const parts = rest.split(':');
+  if (parts.length < 3) return encoded; // not encrypted — return as-is
+
+  const [ivHex, ctHex, tagHex] = parts;
+  const key = getKeyForVersion(version);
+  const decipher = createDecipheriv(ALGO, key, Buffer.from(ivHex, 'hex'));
   decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
   return decipher.update(Buffer.from(ctHex, 'hex')).toString('utf8') + decipher.final('utf8');
 }

--- a/apps/api/src/middlewares/__tests__/mutation-audit.middleware.test.ts
+++ b/apps/api/src/middlewares/__tests__/mutation-audit.middleware.test.ts
@@ -1,0 +1,83 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { mutationAuditMiddleware } from '../mutation-audit.middleware';
+
+jest.mock('../../modules/audit/audit.service', () => ({
+  auditLog: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+import { auditLog } from '../../modules/audit/audit.service';
+const mockAuditLog = auditLog as jest.Mock;
+
+function makeApp(method: string, statusCode = 200) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: Request, _res, next) => {
+    (req as any).user = { userId: 'user-1', clinicId: 'clinic-1', role: 'DOCTOR' };
+    next();
+  });
+  app.use(mutationAuditMiddleware);
+  app.all('/test/:id', (_req: Request, res: Response) => res.status(statusCode).json({ ok: true }));
+  return app;
+}
+
+beforeEach(() => mockAuditLog.mockClear());
+
+describe('mutationAuditMiddleware', () => {
+  it('logs MUTATION_CREATE for POST 2xx', async () => {
+    await request(makeApp('POST')).post('/test/123').send({});
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'MUTATION_CREATE', resourceId: '123' }),
+      expect.anything(),
+    );
+  });
+
+  it('logs MUTATION_UPDATE for PUT 2xx', async () => {
+    await request(makeApp('PUT')).put('/test/456').send({});
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'MUTATION_UPDATE', resourceId: '456' }),
+      expect.anything(),
+    );
+  });
+
+  it('logs MUTATION_UPDATE for PATCH 2xx', async () => {
+    await request(makeApp('PATCH')).patch('/test/789').send({});
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'MUTATION_UPDATE' }),
+      expect.anything(),
+    );
+  });
+
+  it('logs MUTATION_DELETE for DELETE 2xx', async () => {
+    await request(makeApp('DELETE')).delete('/test/abc');
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'MUTATION_DELETE' }),
+      expect.anything(),
+    );
+  });
+
+  it('does NOT log for GET requests', async () => {
+    const app = makeApp('GET');
+    await request(app).get('/test/1');
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log for 4xx responses', async () => {
+    const app = makeApp('POST', 400);
+    await request(app).post('/test/1').send({});
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('includes userId and clinicId from req.user', async () => {
+    await request(makeApp('POST')).post('/test/1').send({});
+    expect(mockAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', clinicId: 'clinic-1' }),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/api/src/middlewares/__tests__/response-filter.middleware.test.ts
+++ b/apps/api/src/middlewares/__tests__/response-filter.middleware.test.ts
@@ -1,0 +1,92 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { responseFilterMiddleware } from '../response-filter.middleware';
+
+function makeApp(role?: string, body: unknown = {}) {
+  const app = express();
+  app.use((req: Request, _res, next) => {
+    if (role) (req as any).user = { role };
+    next();
+  });
+  app.use(responseFilterMiddleware);
+  app.get('/test', (_req: Request, res: Response) => res.json(body));
+  return app;
+}
+
+const SENSITIVE_PAYLOAD = {
+  name: 'Alice',
+  ssn: '123-45-6789',
+  policyNumber: 'POL-001',
+  groupNumber: 'GRP-001',
+  billingCode: 'B001',
+  paymentDetails: { amount: 100 },
+  internalNotes: 'private note',
+  auditTrail: ['action1'],
+};
+
+describe('responseFilterMiddleware', () => {
+  it('SUPER_ADMIN sees all fields', async () => {
+    const res = await request(makeApp('SUPER_ADMIN', SENSITIVE_PAYLOAD)).get('/test');
+    expect(res.body).toMatchObject(SENSITIVE_PAYLOAD);
+  });
+
+  it('CLINIC_ADMIN sees all except nothing (has full access)', async () => {
+    const res = await request(makeApp('CLINIC_ADMIN', SENSITIVE_PAYLOAD)).get('/test');
+    expect(res.body.ssn).toBe(SENSITIVE_PAYLOAD.ssn);
+    expect(res.body.billingCode).toBe(SENSITIVE_PAYLOAD.billingCode);
+  });
+
+  it('DOCTOR sees billing and insurance but not ssn or auditTrail', async () => {
+    const res = await request(makeApp('DOCTOR', SENSITIVE_PAYLOAD)).get('/test');
+    expect(res.body.billingCode).toBe(SENSITIVE_PAYLOAD.billingCode);
+    expect(res.body.policyNumber).toBe(SENSITIVE_PAYLOAD.policyNumber);
+    expect(res.body.ssn).toBeUndefined();
+    expect(res.body.auditTrail).toBeUndefined();
+  });
+
+  it('NURSE sees insurance fields but not billing, ssn, or auditTrail', async () => {
+    const res = await request(makeApp('NURSE', SENSITIVE_PAYLOAD)).get('/test');
+    expect(res.body.policyNumber).toBe(SENSITIVE_PAYLOAD.policyNumber);
+    expect(res.body.groupNumber).toBe(SENSITIVE_PAYLOAD.groupNumber);
+    expect(res.body.billingCode).toBeUndefined();
+    expect(res.body.ssn).toBeUndefined();
+    expect(res.body.auditTrail).toBeUndefined();
+    expect(res.body.internalNotes).toBeUndefined();
+  });
+
+  it('READ_ONLY sees no sensitive fields', async () => {
+    const res = await request(makeApp('READ_ONLY', SENSITIVE_PAYLOAD)).get('/test');
+    expect(res.body.name).toBe(SENSITIVE_PAYLOAD.name);
+    expect(res.body.ssn).toBeUndefined();
+    expect(res.body.policyNumber).toBeUndefined();
+    expect(res.body.billingCode).toBeUndefined();
+    expect(res.body.internalNotes).toBeUndefined();
+  });
+
+  it('PATIENT sees no sensitive fields', async () => {
+    const res = await request(makeApp('PATIENT', SENSITIVE_PAYLOAD)).get('/test');
+    expect(res.body.name).toBe(SENSITIVE_PAYLOAD.name);
+    expect(res.body.ssn).toBeUndefined();
+    expect(res.body.policyNumber).toBeUndefined();
+  });
+
+  it('filters nested objects', async () => {
+    const nested = { patient: { ssn: '000', name: 'Bob' } };
+    const res = await request(makeApp('READ_ONLY', nested)).get('/test');
+    expect(res.body.patient.name).toBe('Bob');
+    expect(res.body.patient.ssn).toBeUndefined();
+  });
+
+  it('filters arrays of objects', async () => {
+    const arr = { items: [{ ssn: '111', name: 'A' }, { ssn: '222', name: 'B' }] };
+    const res = await request(makeApp('READ_ONLY', arr)).get('/test');
+    expect(res.body.items[0].name).toBe('A');
+    expect(res.body.items[0].ssn).toBeUndefined();
+  });
+
+  it('passes through response unchanged when no user is set', async () => {
+    const res = await request(makeApp(undefined, SENSITIVE_PAYLOAD)).get('/test');
+    // No role — middleware skips filtering (auth middleware handles 401)
+    expect(res.body).toMatchObject(SENSITIVE_PAYLOAD);
+  });
+});

--- a/apps/api/src/middlewares/mutation-audit.middleware.ts
+++ b/apps/api/src/middlewares/mutation-audit.middleware.ts
@@ -1,0 +1,51 @@
+import { Request, Response, NextFunction } from 'express';
+import { auditLog } from '../modules/audit/audit.service';
+import { AuditAction } from '../modules/audit/audit.model';
+import logger from '../utils/logger';
+
+const METHOD_ACTION_MAP: Record<string, AuditAction> = {
+  POST: 'MUTATION_CREATE',
+  PUT: 'MUTATION_UPDATE',
+  PATCH: 'MUTATION_UPDATE',
+  DELETE: 'MUTATION_DELETE',
+};
+
+/**
+ * Automatically records a DB audit entry for every mutating request (POST/PUT/PATCH/DELETE).
+ * Only fires on 2xx responses to avoid logging failed validation attempts as successful mutations.
+ */
+export function mutationAuditMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const action = METHOD_ACTION_MAP[req.method];
+  if (!action) {
+    next();
+    return;
+  }
+
+  const originalSend = res.send.bind(res);
+
+  res.send = function (body: unknown): Response {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      const resourceId =
+        req.params.id || req.params.patientId || req.params.encounterId || undefined;
+      const resourceType = req.path.split('/').filter(Boolean)[0];
+
+      auditLog(
+        {
+          action,
+          resourceType,
+          resourceId,
+          userId: req.user?.userId,
+          clinicId: req.user?.clinicId,
+          outcome: 'SUCCESS',
+          metadata: { method: req.method, path: req.path },
+        },
+        req,
+      ).catch((err) => {
+        logger.error({ err }, 'mutation audit log failed');
+      });
+    }
+    return originalSend(body);
+  };
+
+  next();
+}

--- a/apps/api/src/middlewares/response-filter.middleware.ts
+++ b/apps/api/src/middlewares/response-filter.middleware.ts
@@ -1,0 +1,92 @@
+import { Request, Response, NextFunction } from 'express';
+import { AppRole } from '../types/express';
+
+/**
+ * Fields that are restricted to specific roles.
+ * A field listed here is REMOVED from the response for any role NOT in its allowed set.
+ *
+ * Role hierarchy (highest → lowest):
+ *   SUPER_ADMIN → CLINIC_ADMIN → DOCTOR → NURSE → ASSISTANT → READ_ONLY → PATIENT
+ */
+const FIELD_RULES: Array<{ field: string; allowedRoles: AppRole[] }> = [
+  // Financial / billing fields — admin and doctors only
+  {
+    field: 'billingCode',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  },
+  {
+    field: 'paymentDetails',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  },
+  {
+    field: 'invoiceAmount',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  },
+
+  // Insurance sensitive fields — admin, doctors, nurses
+  {
+    field: 'policyNumber',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+  },
+  {
+    field: 'groupNumber',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+  },
+
+  // Government identifier — admin only
+  {
+    field: 'ssn',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  },
+
+  // Internal audit / system fields — admin only
+  {
+    field: 'auditTrail',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  },
+  {
+    field: 'internalNotes',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  },
+];
+
+function filterFields(obj: unknown, role: AppRole): unknown {
+  if (obj === null || typeof obj !== 'object') return obj;
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => filterFields(item, role));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const rule = FIELD_RULES.find((r) => r.field === key);
+    if (rule && !rule.allowedRoles.includes(role)) {
+      continue; // strip this field
+    }
+    result[key] = filterFields(value, role);
+  }
+  return result;
+}
+
+/**
+ * Intercepts JSON responses and strips fields the requesting user's role
+ * is not permitted to see. Adds negligible overhead — only acts on JSON bodies.
+ * Must be registered after authentication middleware so `req.user` is populated.
+ */
+export function responseFilterMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const role = req.user?.role;
+  if (!role || role === 'SUPER_ADMIN') {
+    // SUPER_ADMIN sees everything; unauthenticated requests handled by auth middleware
+    next();
+    return;
+  }
+
+  const originalJson = res.json.bind(res);
+
+  res.json = function (body: unknown): Response {
+    const filtered = filterFields(body, role);
+    return originalJson(filtered);
+  };
+
+  next();
+}

--- a/apps/api/src/modules/audit/audit.model.ts
+++ b/apps/api/src/modules/audit/audit.model.ts
@@ -35,7 +35,10 @@ export type AuditAction =
   | 'CLINIC_SWITCH'
   | 'DATA_EXPORT_REQUEST'
   | 'DATA_EXPORT_FULFILLED'
-  | 'CONSENT_VERSION_ACCEPTED';
+  | 'CONSENT_VERSION_ACCEPTED'
+  | 'MUTATION_CREATE'
+  | 'MUTATION_UPDATE'
+  | 'MUTATION_DELETE';
 
 export interface AuditLog {
   userId?: Types.ObjectId;
@@ -94,6 +97,9 @@ const auditLogSchema = new Schema<AuditLog>(
         'DATA_EXPORT_REQUEST',
         'DATA_EXPORT_FULFILLED',
         'CONSENT_VERSION_ACCEPTED',
+        'MUTATION_CREATE',
+        'MUTATION_UPDATE',
+        'MUTATION_DELETE',
       ],
       index: true,
     },
@@ -140,5 +146,8 @@ auditLogSchema.index({ resourceType: 1, timestamp: -1 });
 auditLogSchema.index({ ipAddress: 1, timestamp: -1 });
 // Full-text search across action field (metadata is Mixed so not indexable as text)
 auditLogSchema.index({ action: 'text' }, { name: 'audit_text_search' });
+// Retention policy: automatically expire audit logs after 2 years (configurable via AUDIT_LOG_RETENTION_DAYS)
+const retentionDays = parseInt(process.env.AUDIT_LOG_RETENTION_DAYS ?? '730', 10);
+auditLogSchema.index({ timestamp: 1 }, { expireAfterSeconds: retentionDays * 24 * 60 * 60 });
 
 export const AuditLogModel = models.AuditLog || model<AuditLog>('AuditLog', auditLogSchema);

--- a/apps/api/src/modules/patients/phi-encryption.test.ts
+++ b/apps/api/src/modules/patients/phi-encryption.test.ts
@@ -41,8 +41,8 @@ import mongoose from 'mongoose';
 import { PatientModel } from './models/patient.model';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-// AES-256-GCM encrypted strings have the form <24-hex>:<n-hex>:<32-hex>
-const ENCRYPTED_PATTERN = /^[0-9a-f]{24}:[0-9a-f]+:[0-9a-f]{32}$/;
+// AES-256-GCM encrypted strings have the form v<n>:<24-hex>:<n-hex>:<32-hex>
+const ENCRYPTED_PATTERN = /^v\d+:[0-9a-f]{24}:[0-9a-f]+:[0-9a-f]{32}$/;
 
 let idCounter = 0;
 function makeDoc(overrides: Record<string, unknown> = {}) {

--- a/apps/api/src/utils/graceful-shutdown.test.ts
+++ b/apps/api/src/utils/graceful-shutdown.test.ts
@@ -1,0 +1,38 @@
+import { createServer } from 'http';
+import { trackConnections, registerGracefulShutdown } from './graceful-shutdown';
+
+jest.mock('./logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('mongoose', () => ({
+  connection: { close: jest.fn().mockResolvedValue(undefined) },
+}));
+
+describe('trackConnections', () => {
+  it('returns a function without throwing', () => {
+    const server = createServer();
+    const destroyIdle = trackConnections(server);
+    expect(typeof destroyIdle).toBe('function');
+    server.close();
+  });
+
+  it('destroyIdle does not throw on an empty connection set', () => {
+    const server = createServer();
+    const destroyIdle = trackConnections(server);
+    expect(() => destroyIdle()).not.toThrow();
+    server.close();
+  });
+});
+
+describe('registerGracefulShutdown', () => {
+  it('registers process signal handlers without throwing', () => {
+    const server = createServer();
+    const stopJob = jest.fn();
+    expect(() =>
+      registerGracefulShutdown(server, { stopJobs: [stopJob], timeoutMs: 100 }),
+    ).not.toThrow();
+    server.close();
+  });
+});

--- a/apps/api/src/utils/graceful-shutdown.ts
+++ b/apps/api/src/utils/graceful-shutdown.ts
@@ -1,0 +1,92 @@
+import { Server, IncomingMessage, ServerResponse } from 'http';
+import { Socket } from 'net';
+import mongoose from 'mongoose';
+import logger from './logger';
+
+/**
+ * Attaches connection tracking to an HTTP server so that keep-alive connections
+ * can be forcibly closed during shutdown, allowing in-flight requests to drain.
+ */
+export function trackConnections(server: Server): () => void {
+  const connections = new Set<Socket>();
+
+  server.on('connection', (socket: Socket) => {
+    connections.add(socket);
+    socket.once('close', () => connections.delete(socket));
+  });
+
+  // Mark each socket as idle once its response finishes so we can destroy it during drain
+  server.on('request', (req: IncomingMessage, res: ServerResponse) => {
+    const socket = req.socket as Socket & { _isIdle?: boolean };
+    socket._isIdle = false;
+    res.once('finish', () => {
+      socket._isIdle = true;
+    });
+  });
+
+  return function destroyIdleConnections() {
+    for (const socket of connections) {
+      const s = socket as Socket & { _isIdle?: boolean };
+      if (s._isIdle !== false) {
+        socket.destroy();
+        connections.delete(socket);
+      }
+    }
+  };
+}
+
+export interface ShutdownDeps {
+  stopJobs: (() => void)[];
+  timeoutMs?: number;
+}
+
+/**
+ * Registers SIGTERM / SIGINT / uncaughtException handlers.
+ * On signal: stops accepting connections, drains in-flight requests, closes the DB.
+ */
+export function registerGracefulShutdown(server: Server, deps: ShutdownDeps): void {
+  const { stopJobs, timeoutMs = 30_000 } = deps;
+  const destroyIdle = trackConnections(server);
+
+  const shutdown = async (signal: string) => {
+    logger.info(`${signal} received — starting graceful shutdown`);
+
+    // Stop accepting new connections and drain pending requests
+    server.close(async () => {
+      logger.info('HTTP server closed — all in-flight requests completed');
+
+      try {
+        for (const stop of stopJobs) stop();
+        logger.info('Background jobs stopped');
+
+        await mongoose.connection.close();
+        logger.info('MongoDB connection closed');
+
+        logger.info('Graceful shutdown complete');
+        process.exit(0);
+      } catch (err) {
+        logger.error({ err }, 'Error during graceful shutdown');
+        process.exit(1);
+      }
+    });
+
+    // Destroy idle keep-alive connections so server.close() callback fires promptly
+    destroyIdle();
+
+    // Force exit if drain takes too long
+    setTimeout(() => {
+      logger.error(`Graceful shutdown timeout (${timeoutMs}ms) — forcing exit`);
+      process.exit(1);
+    }, timeoutMs).unref();
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('uncaughtException', (err) => {
+    logger.error({ err }, 'Uncaught exception');
+    shutdown('uncaughtException');
+  });
+  process.on('unhandledRejection', (reason) => {
+    logger.error({ reason }, 'Unhandled rejection');
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "5.9.3"
+        "typescript": "^5.9.3"
       }
     },
     "apps/api/node_modules/@apidevtools/json-schema-ref-parser": {


### PR DESCRIPTION
## Summary


---

### closes #858 — Audit Logging Enhancement

- Added `MUTATION_CREATE`, `MUTATION_UPDATE`, `MUTATION_DELETE` to `AuditAction`
- New `mutationAuditMiddleware` automatically records every successful `POST`/`PUT`/`PATCH`/`DELETE` request to the DB audit log, capturing `userId`, `clinicId`, HTTP method, and path — without requiring manual decoration on each route
- Added a TTL index to `audit_logs` collection for automated retention (default 2 years, configurable via `AUDIT_LOG_RETENTION_DAYS`)

### closes #859 — Graceful Shutdown

- Extracted shutdown logic into `utils/graceful-shutdown.ts`
- `trackConnections()` maintains a live set of sockets and marks each one idle once its response finishes; `destroyIdle()` is called at shutdown to close keep-alive connections so `server.close()` can drain promptly
- `registerGracefulShutdown()` accepts the background-job stop functions as a plain array, removing the duplication from `app.ts` and making shutdown testable in isolation
- 30 s force-exit timeout retained

### closes #860 — Data Encryption at Rest

- Enhanced `lib/encrypt.ts` with a versioned ciphertext format: `v<n>:iv:ciphertext:tag`
- Key rotation: bump `FIELD_ENCRYPTION_KEY_VERSION` and provide old keys as `FIELD_ENCRYPTION_KEY_V<n>` — `decrypt()` resolves the correct key automatically from the version prefix
- Full backward compatibility: unversioned legacy ciphertext falls back to the current key
- Existing `phi-encryption.test.ts` regex updated to match the new versioned format
- New `encrypt.test.ts` covers round-trip, key rotation, error paths

### closes #861 — Field Response Filtering

- New `responseFilterMiddleware` intercepts `res.json()` and strips restricted fields based on the authenticated user's role
- Sensitive fields and their minimum required roles:

| Field | Minimum role |
|-------|-------------|
| `ssn`, `auditTrail` | `CLINIC_ADMIN` |
| `billingCode`, `paymentDetails`, `invoiceAmount`, `internalNotes` | `DOCTOR` |
| `policyNumber`, `groupNumber` | `NURSE` |

- Applied globally to `/api/*` routes; `SUPER_ADMIN` bypass adds zero overhead
- Filters recursively through nested objects and arrays

## Test plan

- [ ] Run `npm run test --workspace=apps/api` — all new suites pass (29 tests across 4 files)
- [ ] Confirm `mutationAuditMiddleware` records entries in `audit_logs` for POST/PUT/PATCH/DELETE
- [ ] Confirm SIGTERM/SIGINT gracefully drains in-flight requests before exiting
- [ ] Confirm encrypted values in DB now carry a `v1:` prefix and still decrypt correctly
- [ ] Confirm `READ_ONLY` / `PATIENT` responses no longer include `ssn`, `billingCode`, etc.