### PR TITLE
Add backend unit, integration, performance and security tests (#904 #905 #906 #907)

### DIFF
--- a/apps/api/src/__tests__/api-integration.test.ts
+++ b/apps/api/src/__tests__/api-integration.test.ts
@@ -1,0 +1,420 @@
+/**
+ * API integration tests — Issue #905
+ *
+ * Covers:
+ *  - Test fixtures: in-memory MongoDB + JWT factory
+ *  - CRUD operations: POST / GET / PUT / DELETE on /api/v1/patients
+ *  - Error scenarios: 400 validation, 401 unauthenticated, 403 forbidden, 404 not found
+ *  - Permissions: RBAC enforcement across roles
+ */
+
+// ── Environment stubs ──────────────────────────────────────────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+process.env.FIELD_ENCRYPTION_KEY = 'abcdefghijklmnopqrstuvwxyz012345';
+
+// ── Module mocks (must be before imports) ─────────────────────────────────────
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellarHorizonUrl: '',
+    stellarSecretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+  },
+}));
+
+jest.mock('@api/lib/encrypt', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('pino-http', () => () => (_req: unknown, _res: unknown, next: () => void) => next());
+jest.mock('@api/config/db', () => ({ connectDB: jest.fn().mockReturnValue(new Promise(() => {})) }));
+jest.mock('@api/docs/swagger', () => ({ setupSwagger: jest.fn() }));
+jest.mock('@api/modules/payments/services/payment-expiration-job', () => ({
+  startPaymentExpirationJob: jest.fn(),
+  stopPaymentExpirationJob: jest.fn(),
+}));
+
+// Mock unused route modules
+jest.mock('@api/modules/auth/auth.controller', () => ({ authRoutes: require('express').Router() }));
+jest.mock('@api/modules/encounters/encounters.controller', () => ({ encounterRoutes: require('express').Router() }));
+jest.mock('@api/modules/payments/payments.controller', () => ({ paymentRoutes: require('express').Router() }));
+jest.mock('@api/modules/appointments/appointments.controller', () => ({ appointmentRoutes: require('express').Router() }));
+jest.mock('@api/modules/clinics/clinics.controller', () => ({ clinicRoutes: require('express').Router() }));
+jest.mock('@api/modules/users/users.controller', () => ({ userRoutes: require('express').Router() }));
+jest.mock('@api/modules/webhooks/webhooks.controller', () => ({ webhookRoutes: require('express').Router() }));
+jest.mock('@api/modules/audit/audit-logs.controller', () => ({ auditLogRoutes: require('express').Router() }));
+jest.mock('@api/modules/ai/ai.routes', () => require('express').Router());
+jest.mock('@api/modules/dashboard/dashboard.routes', () => require('express').Router());
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '@api/app';
+import { PatientModel } from '../modules/patients/models/patient.model';
+import { signAccessToken } from '../modules/auth/token.service';
+import { AppRole } from '../types/express';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CLINIC_A = new mongoose.Types.ObjectId().toHexString();
+const CLINIC_B = new mongoose.Types.ObjectId().toHexString();
+const USER_ID = new mongoose.Types.ObjectId().toHexString();
+
+function makeToken(role: AppRole, clinicId: string = CLINIC_A): string {
+  return signAccessToken({ userId: USER_ID, role, clinicId });
+}
+
+const VALID_PATIENT = {
+  firstName: 'Jane',
+  lastName: 'Doe',
+  dateOfBirth: '1990-06-15',
+  sex: 'F',
+};
+
+let mongod: MongoMemoryServer;
+let doctorToken: string;
+let adminToken: string;
+let readOnlyToken: string;
+let patientToken: string;
+
+// ── Setup / Teardown ──────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  await PatientModel.ensureIndexes();
+
+  doctorToken = makeToken('DOCTOR');
+  adminToken = makeToken('CLINIC_ADMIN');
+  readOnlyToken = makeToken('READ_ONLY');
+  patientToken = makeToken('PATIENT');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await PatientModel.deleteMany({});
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function createPatientInDB(overrides: Record<string, unknown> = {}) {
+  const counter = await PatientModel.countDocuments();
+  return PatientModel.create({
+    systemId: `SYS-${counter}-${Date.now()}`,
+    firstName: 'John',
+    lastName: 'Smith',
+    searchName: 'john smith',
+    dateOfBirth: '1985-03-10',
+    sex: 'M',
+    clinicId: CLINIC_A,
+    isActive: true,
+    ...overrides,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/v1/patients — Create
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /api/v1/patients', () => {
+  it('201 — DOCTOR creates a patient successfully', async () => {
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send(VALID_PATIENT);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      data: expect.objectContaining({ firstName: 'Jane', lastName: 'Doe' }),
+    });
+  });
+
+  it('201 — CLINIC_ADMIN creates a patient successfully', async () => {
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send(VALID_PATIENT);
+
+    expect(res.status).toBe(201);
+  });
+
+  it('401 — rejects request without Authorization header', async () => {
+    const res = await request(app).post('/api/v1/patients').send(VALID_PATIENT);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 — READ_ONLY user cannot create a patient', async () => {
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${readOnlyToken}`)
+      .send(VALID_PATIENT);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('400 — missing required fields returns validation error', async () => {
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ firstName: 'NoLastName' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('ValidationError');
+  });
+
+  it('400 — invalid sex enum returns validation error', async () => {
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ ...VALID_PATIENT, sex: 'X' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('400 — future date of birth is rejected', async () => {
+    const future = new Date(Date.now() + 86400000 * 30).toISOString().split('T')[0];
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ ...VALID_PATIENT, dateOfBirth: future });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v1/patients — List
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/v1/patients', () => {
+  it('200 — DOCTOR retrieves patient list', async () => {
+    await createPatientInDB();
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('200 — READ_ONLY user can list patients', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${readOnlyToken}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('401 — unauthenticated request is rejected', async () => {
+    const res = await request(app).get('/api/v1/patients');
+    expect(res.status).toBe(401);
+  });
+
+  it('clinic isolation — doctor from clinic B cannot see clinic A patients', async () => {
+    await createPatientInDB({ clinicId: CLINIC_A });
+    const clinicBToken = makeToken('DOCTOR', CLINIC_B);
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${clinicBToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it('400 — invalid pagination params return validation error', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients?page=0')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v1/patients/:id — Read single
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/v1/patients/:id', () => {
+  it('200 — returns patient by ID', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .get(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data._id).toBe(String(patient._id));
+  });
+
+  it('404 — unknown ID returns not found', async () => {
+    const unknownId = new mongoose.Types.ObjectId().toHexString();
+    const res = await request(app)
+      .get(`/api/v1/patients/${unknownId}`)
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('400 — malformed ObjectId returns error', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients/not-an-objectid')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect([400, 404]).toContain(res.status);
+  });
+
+  it('403 — clinic B doctor cannot access clinic A patient', async () => {
+    const patient = await createPatientInDB({ clinicId: CLINIC_A });
+    const clinicBToken = makeToken('DOCTOR', CLINIC_B);
+    const res = await request(app)
+      .get(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${clinicBToken}`);
+
+    expect([403, 404]).toContain(res.status);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PUT /api/v1/patients/:id — Update
+// ─────────────────────────────────────────────────────────────────────────────
+describe('PUT /api/v1/patients/:id', () => {
+  it('200 — DOCTOR updates a patient', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .put(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ firstName: 'Updated' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.firstName).toBe('Updated');
+  });
+
+  it('400 — empty update body returns validation error', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .put(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('403 — READ_ONLY user cannot update a patient', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .put(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${readOnlyToken}`)
+      .send({ firstName: 'Hacked' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('404 — updating non-existent patient returns 404', async () => {
+    const unknownId = new mongoose.Types.ObjectId().toHexString();
+    const res = await request(app)
+      .put(`/api/v1/patients/${unknownId}`)
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ firstName: 'Ghost' });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/v1/patients/:id — Delete (soft)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DELETE /api/v1/patients/:id', () => {
+  it('200 — CLINIC_ADMIN deletes (deactivates) a patient', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .delete(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect([200, 204]).toContain(res.status);
+  });
+
+  it('403 — DOCTOR cannot delete a patient', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .delete(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — PATIENT role cannot delete a patient record', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app)
+      .delete(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${patientToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('401 — unauthenticated delete is rejected', async () => {
+    const patient = await createPatientInDB();
+    const res = await request(app).delete(`/api/v1/patients/${patient._id}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error scenario coverage
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Error scenarios', () => {
+  it('returns JSON error body on 404', async () => {
+    const res = await request(app)
+      .get(`/api/v1/patients/${new mongoose.Types.ObjectId()}`)
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('returns JSON error body on 400 validation failure', async () => {
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ firstName: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('ValidationError');
+    expect(res.body.details).toBeDefined();
+  });
+
+  it('returns 401 with structured error when token is missing', async () => {
+    const res = await request(app).get('/api/v1/patients');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('returns 401 with structured error when token is malformed', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', 'Bearer this.is.not.valid');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/apps/api/src/__tests__/performance-benchmarks.test.ts
+++ b/apps/api/src/__tests__/performance-benchmarks.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Performance benchmark tests — Issue #906
+ *
+ * Covers:
+ *  - Endpoint response-time baselines for /health, /patients, /appointments
+ *  - Query performance against seeded data with index verification
+ *  - Concurrent load scenarios (throughput under parallel requests)
+ *  - Cache warm vs cold baseline comparison
+ *
+ * All timing thresholds are conservative to be reliable in CI.
+ */
+
+// ── Environment stubs ──────────────────────────────────────────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+process.env.FIELD_ENCRYPTION_KEY = 'abcdefghijklmnopqrstuvwxyz012345';
+
+// ── Module mocks ───────────────────────────────────────────────────────────────
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellarHorizonUrl: '',
+    stellarSecretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+  },
+}));
+
+jest.mock('@api/lib/encrypt', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('pino-http', () => () => (_req: unknown, _res: unknown, next: () => void) => next());
+jest.mock('@api/config/db', () => ({ connectDB: jest.fn().mockReturnValue(new Promise(() => {})) }));
+jest.mock('@api/docs/swagger', () => ({ setupSwagger: jest.fn() }));
+jest.mock('@api/modules/payments/services/payment-expiration-job', () => ({
+  startPaymentExpirationJob: jest.fn(),
+  stopPaymentExpirationJob: jest.fn(),
+}));
+
+// Mock unused route modules
+jest.mock('@api/modules/auth/auth.controller', () => ({ authRoutes: require('express').Router() }));
+jest.mock('@api/modules/encounters/encounters.controller', () => ({ encounterRoutes: require('express').Router() }));
+jest.mock('@api/modules/payments/payments.controller', () => ({ paymentRoutes: require('express').Router() }));
+jest.mock('@api/modules/appointments/appointments.controller', () => ({ appointmentRoutes: require('express').Router() }));
+jest.mock('@api/modules/clinics/clinics.controller', () => ({ clinicRoutes: require('express').Router() }));
+jest.mock('@api/modules/users/users.controller', () => ({ userRoutes: require('express').Router() }));
+jest.mock('@api/modules/webhooks/webhooks.controller', () => ({ webhookRoutes: require('express').Router() }));
+jest.mock('@api/modules/audit/audit-logs.controller', () => ({ auditLogRoutes: require('express').Router() }));
+jest.mock('@api/modules/ai/ai.routes', () => require('express').Router());
+jest.mock('@api/modules/dashboard/dashboard.routes', () => require('express').Router());
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '@api/app';
+import { PatientModel } from '../modules/patients/models/patient.model';
+import { AppointmentModel } from '../modules/appointments/appointment.model';
+import { signAccessToken } from '../modules/auth/token.service';
+import { cache } from '../services/cache.service';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const CLINIC_ID = new mongoose.Types.ObjectId().toHexString();
+const USER_ID = new mongoose.Types.ObjectId().toHexString();
+
+// Threshold budgets (milliseconds)
+const BUDGET = {
+  healthCheck: 100,
+  listEndpoint: 500,
+  singleRead: 200,
+  concurrentP95: 800,
+};
+
+const SEED_PATIENTS = 500;
+const SEED_APPOINTMENTS = 200;
+const CONCURRENT_REQUESTS = 10;
+
+let mongod: MongoMemoryServer;
+let token: string;
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  await PatientModel.ensureIndexes();
+  await AppointmentModel.ensureIndexes();
+
+  // Seed patients
+  const patients = Array.from({ length: SEED_PATIENTS }, (_, i) => ({
+    systemId: `BENCH-P${i}`,
+    firstName: 'Bench',
+    lastName: `Patient${i}`,
+    searchName: `bench patient${i}`,
+    dateOfBirth: '1990-01-01',
+    sex: i % 2 === 0 ? 'M' : 'F',
+    clinicId: CLINIC_ID,
+    isActive: true,
+  }));
+  await PatientModel.insertMany(patients, { ordered: false });
+
+  // Seed appointments
+  const patientDocs = await PatientModel.find({ clinicId: CLINIC_ID }).limit(10).lean();
+  const appts = Array.from({ length: SEED_APPOINTMENTS }, (_, i) => ({
+    patientId: patientDocs[i % patientDocs.length]?._id ?? new mongoose.Types.ObjectId(),
+    clinicId: CLINIC_ID,
+    doctorId: new mongoose.Types.ObjectId(),
+    scheduledAt: new Date(Date.now() + i * 3600000),
+    status: 'scheduled',
+    type: 'consultation',
+  }));
+  await AppointmentModel.insertMany(appts, { ordered: false });
+
+  token = signAccessToken({ userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID });
+}, 60_000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function timed(fn: () => Promise<unknown>): Promise<number> {
+  const start = Date.now();
+  await fn();
+  return Date.now() - start;
+}
+
+async function concurrentRequests(fn: () => Promise<unknown>, count: number): Promise<number[]> {
+  const results = await Promise.all(Array.from({ length: count }, fn));
+  return results as number[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Benchmark: /health
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Benchmark: /health endpoint', () => {
+  it(`responds in < ${BUDGET.healthCheck}ms`, async () => {
+    const elapsed = await timed(() => request(app).get('/health'));
+    console.log(`[bench] /health: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(BUDGET.healthCheck);
+  });
+
+  it('maintains baseline across 5 repeated requests', async () => {
+    const times: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      times.push(await timed(() => request(app).get('/health')));
+    }
+    const avg = times.reduce((a, b) => a + b, 0) / times.length;
+    console.log(`[bench] /health avg: ${avg.toFixed(1)}ms, samples: ${JSON.stringify(times)}`);
+    expect(avg).toBeLessThan(BUDGET.healthCheck);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Benchmark: GET /api/v1/patients
+// ─────────────────────────────────────────────────────────────────────────────
+describe(`Benchmark: GET /api/v1/patients (${SEED_PATIENTS} records)`, () => {
+  it(`first page list completes in < ${BUDGET.listEndpoint}ms`, async () => {
+    const elapsed = await timed(() =>
+      request(app)
+        .get('/api/v1/patients?page=1&limit=25')
+        .set('Authorization', `Bearer ${token}`)
+    );
+    console.log(`[bench] GET /patients page 1: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(BUDGET.listEndpoint);
+  });
+
+  it('search query completes within budget', async () => {
+    const elapsed = await timed(() =>
+      request(app)
+        .get('/api/v1/patients/search?q=bench&limit=20')
+        .set('Authorization', `Bearer ${token}`)
+    );
+    console.log(`[bench] GET /patients/search: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(BUDGET.listEndpoint);
+  });
+
+  it('subsequent pages do not regress', async () => {
+    const pageTimes: number[] = [];
+    for (let page = 1; page <= 4; page++) {
+      pageTimes.push(
+        await timed(() =>
+          request(app)
+            .get(`/api/v1/patients?page=${page}&limit=20`)
+            .set('Authorization', `Bearer ${token}`)
+        )
+      );
+    }
+    const max = Math.max(...pageTimes);
+    console.log(`[bench] patients pagination max: ${max}ms, pages: ${JSON.stringify(pageTimes)}`);
+    expect(max).toBeLessThan(BUDGET.listEndpoint * 1.5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Benchmark: single patient read (by ID)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Benchmark: GET /api/v1/patients/:id', () => {
+  let patientId: string;
+
+  beforeAll(async () => {
+    const p = await PatientModel.findOne({ clinicId: CLINIC_ID }).lean();
+    patientId = String(p!._id);
+  });
+
+  it(`single record read completes in < ${BUDGET.singleRead}ms`, async () => {
+    const elapsed = await timed(() =>
+      request(app)
+        .get(`/api/v1/patients/${patientId}`)
+        .set('Authorization', `Bearer ${token}`)
+    );
+    console.log(`[bench] GET /patients/:id: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(BUDGET.singleRead);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Benchmark: GET /api/v1/appointments
+// ─────────────────────────────────────────────────────────────────────────────
+describe(`Benchmark: GET /api/v1/appointments (${SEED_APPOINTMENTS} records)`, () => {
+  it(`list completes in < ${BUDGET.listEndpoint}ms`, async () => {
+    const elapsed = await timed(() =>
+      request(app)
+        .get('/api/v1/appointments?page=1&limit=25')
+        .set('Authorization', `Bearer ${token}`)
+    );
+    console.log(`[bench] GET /appointments: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(BUDGET.listEndpoint);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Load test: concurrent requests
+// ─────────────────────────────────────────────────────────────────────────────
+describe(`Load test: ${CONCURRENT_REQUESTS} concurrent GET /api/v1/patients`, () => {
+  it('all requests succeed under concurrent load', async () => {
+    const responses = await Promise.all(
+      Array.from({ length: CONCURRENT_REQUESTS }, () =>
+        request(app)
+          .get('/api/v1/patients?page=1&limit=10')
+          .set('Authorization', `Bearer ${token}`)
+      )
+    );
+
+    const statuses = responses.map((r) => r.status);
+    const failed = statuses.filter((s) => s !== 200);
+    console.log(`[bench] concurrent load statuses: ${JSON.stringify(statuses)}`);
+    expect(failed).toHaveLength(0);
+  });
+
+  it(`p95 response time stays within ${BUDGET.concurrentP95}ms under load`, async () => {
+    const times = await Promise.all(
+      Array.from({ length: CONCURRENT_REQUESTS }, () =>
+        timed(() =>
+          request(app)
+            .get('/api/v1/patients?page=1&limit=10')
+            .set('Authorization', `Bearer ${token}`)
+        )
+      )
+    );
+
+    times.sort((a, b) => a - b);
+    const p95Index = Math.ceil(times.length * 0.95) - 1;
+    const p95 = times[p95Index];
+    console.log(`[bench] concurrent p95: ${p95}ms, all: ${JSON.stringify(times)}`);
+    expect(p95).toBeLessThan(BUDGET.concurrentP95);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cache warm/cold comparison baseline
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Cache baseline: warm vs cold', () => {
+  it('first request (cold) completes within budget', async () => {
+    jest.spyOn(cache, 'get').mockResolvedValueOnce(null);
+    jest.spyOn(cache, 'set').mockResolvedValueOnce(undefined);
+
+    const elapsed = await timed(() =>
+      request(app)
+        .get('/api/v1/patients?page=1&limit=10')
+        .set('Authorization', `Bearer ${token}`)
+    );
+    console.log(`[bench] cold request: ${elapsed}ms`);
+    jest.restoreAllMocks();
+    expect(elapsed).toBeLessThan(BUDGET.listEndpoint);
+  });
+
+  it('health check response time is recorded as baseline', async () => {
+    const times: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      times.push(await timed(() => request(app).get('/health')));
+    }
+    const baseline = Math.min(...times);
+    console.log(`[bench] /health baseline min: ${baseline}ms`);
+    expect(baseline).toBeGreaterThan(0);
+    expect(baseline).toBeLessThan(BUDGET.healthCheck);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Query performance: MongoDB index verification
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Query performance: index coverage', () => {
+  it('clinicId index is present on PatientModel', async () => {
+    const indexes = await PatientModel.collection.indexes();
+    const hasClinicIndex = indexes.some(
+      (idx) => idx.key && ('clinicId' in idx.key || 'clinicId_1' in idx.key || idx.key['clinicId'] !== undefined)
+    );
+    expect(hasClinicIndex).toBe(true);
+  });
+
+  it('fetching patients by clinicId uses an index (fast under 200ms)', async () => {
+    const elapsed = await timed(() =>
+      PatientModel.find({ clinicId: CLINIC_ID }).limit(50).lean()
+    );
+    console.log(`[bench] direct Mongoose clinicId query: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('counting patients by clinic is fast', async () => {
+    const elapsed = await timed(() =>
+      PatientModel.countDocuments({ clinicId: CLINIC_ID })
+    );
+    console.log(`[bench] countDocuments by clinicId: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it('searchName text query is fast', async () => {
+    const elapsed = await timed(() =>
+      PatientModel.find({
+        clinicId: CLINIC_ID,
+        searchName: { $regex: '^bench', $options: 'i' },
+      })
+        .limit(20)
+        .lean()
+    );
+    console.log(`[bench] searchName regex query: ${elapsed}ms`);
+    expect(elapsed).toBeLessThan(300);
+  });
+});

--- a/apps/api/src/__tests__/security.test.ts
+++ b/apps/api/src/__tests__/security.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Security tests — Issue #907
+ *
+ * Covers:
+ *  - Injection: NoSQL operator injection through the full Express/Mongoose stack
+ *  - Auth flows: missing token, expired token, forged token, tampered signature
+ *  - Permissions: role-based enforcement and cross-clinic data isolation
+ *  - Data exposure: sensitive fields absent from responses, security headers present
+ */
+
+// ── Environment stubs ──────────────────────────────────────────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+process.env.FIELD_ENCRYPTION_KEY = 'abcdefghijklmnopqrstuvwxyz012345';
+
+// ── Module mocks ───────────────────────────────────────────────────────────────
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellarHorizonUrl: '',
+    stellarSecretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+  },
+}));
+
+jest.mock('@api/lib/encrypt', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('pino-http', () => () => (_req: unknown, _res: unknown, next: () => void) => next());
+jest.mock('@api/config/db', () => ({ connectDB: jest.fn().mockReturnValue(new Promise(() => {})) }));
+jest.mock('@api/docs/swagger', () => ({ setupSwagger: jest.fn() }));
+jest.mock('@api/modules/payments/services/payment-expiration-job', () => ({
+  startPaymentExpirationJob: jest.fn(),
+  stopPaymentExpirationJob: jest.fn(),
+}));
+
+// Mock unused route modules
+jest.mock('@api/modules/auth/auth.controller', () => ({ authRoutes: require('express').Router() }));
+jest.mock('@api/modules/encounters/encounters.controller', () => ({ encounterRoutes: require('express').Router() }));
+jest.mock('@api/modules/payments/payments.controller', () => ({ paymentRoutes: require('express').Router() }));
+jest.mock('@api/modules/appointments/appointments.controller', () => ({ appointmentRoutes: require('express').Router() }));
+jest.mock('@api/modules/clinics/clinics.controller', () => ({ clinicRoutes: require('express').Router() }));
+jest.mock('@api/modules/users/users.controller', () => ({ userRoutes: require('express').Router() }));
+jest.mock('@api/modules/webhooks/webhooks.controller', () => ({ webhookRoutes: require('express').Router() }));
+jest.mock('@api/modules/audit/audit-logs.controller', () => ({ auditLogRoutes: require('express').Router() }));
+jest.mock('@api/modules/ai/ai.routes', () => require('express').Router());
+jest.mock('@api/modules/dashboard/dashboard.routes', () => require('express').Router());
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '@api/app';
+import { PatientModel } from '../modules/patients/models/patient.model';
+import { signAccessToken } from '../modules/auth/token.service';
+import { AppRole } from '../types/express';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const CLINIC_A = new mongoose.Types.ObjectId().toHexString();
+const CLINIC_B = new mongoose.Types.ObjectId().toHexString();
+const USER_ID = new mongoose.Types.ObjectId().toHexString();
+
+function makeToken(role: AppRole, clinicId = CLINIC_A): string {
+  return signAccessToken({ userId: USER_ID, role, clinicId });
+}
+
+let mongod: MongoMemoryServer;
+let doctorToken: string;
+
+// ── Setup / Teardown ──────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  await PatientModel.ensureIndexes();
+  doctorToken = makeToken('DOCTOR');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await PatientModel.deleteMany({});
+});
+
+// ── Seed helper ───────────────────────────────────────────────────────────────
+async function seed(overrides: Record<string, unknown> = {}) {
+  const n = await PatientModel.countDocuments();
+  return PatientModel.create({
+    systemId: `SEC-${n}-${Date.now()}`,
+    firstName: 'Secure',
+    lastName: 'Patient',
+    searchName: 'secure patient',
+    dateOfBirth: '1980-01-01',
+    sex: 'M',
+    clinicId: CLINIC_A,
+    isActive: true,
+    ...overrides,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Injection tests
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Injection tests', () => {
+  describe('NoSQL operator injection in request body', () => {
+    it('strips $gt operator from create-patient body', async () => {
+      const res = await request(app)
+        .post('/api/v1/patients')
+        .set('Authorization', `Bearer ${doctorToken}`)
+        .send({
+          firstName: { $gt: '' },
+          lastName: 'Doe',
+          dateOfBirth: '1990-01-01',
+          sex: 'F',
+        });
+
+      // Must either reject (400) or sanitise the operator — never 201 with operator preserved
+      if (res.status === 201) {
+        expect(res.body?.data?.firstName).not.toHaveProperty('$gt');
+      } else {
+        expect(res.status).toBe(400);
+      }
+    });
+
+    it('rejects $where operator in body', async () => {
+      const res = await request(app)
+        .post('/api/v1/patients')
+        .set('Authorization', `Bearer ${doctorToken}`)
+        .send({ $where: 'this.isActive === true', firstName: 'X', lastName: 'Y', dateOfBirth: '1990-01-01', sex: 'M' });
+
+      expect([400, 201]).toContain(res.status);
+      if (res.status === 201) {
+        // Operator must have been stripped
+        expect(JSON.stringify(res.body)).not.toContain('$where');
+      }
+    });
+
+    it('blocks nested $regex injection in search query', async () => {
+      const res = await request(app)
+        .get('/api/v1/patients/search?q[$regex]=.*&q[$options]=i')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      // Should either sanitise (200) or reject (400), never expose all records unfiltered
+      expect([200, 400]).toContain(res.status);
+    });
+
+    it('prevents $ne operator bypass in filters', async () => {
+      const res = await request(app)
+        .get('/api/v1/patients?active[$ne]=false')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect([200, 400]).toContain(res.status);
+      // If 200, must only return clinic-scoped results, not all records
+      if (res.status === 200) {
+        const patients = res.body?.data ?? [];
+        patients.forEach((p: { clinicId?: string }) => {
+          if (p.clinicId) expect(p.clinicId).toBe(CLINIC_A);
+        });
+      }
+    });
+  });
+
+  describe('XSS — response encoding and Content-Type', () => {
+    it('all API responses are Content-Type application/json (no HTML)', async () => {
+      const res = await request(app)
+        .get('/api/v1/patients')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect(res.headers['content-type']).toContain('application/json');
+    });
+
+    it('error responses are JSON, not HTML (no reflected HTML execution vector)', async () => {
+      const res = await request(app)
+        .get('/api/v1/patients/not-a-valid-id')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect(res.headers['content-type']).toContain('application/json');
+      // Body must be parseable JSON — not raw HTML
+      expect(() => JSON.parse(res.text)).not.toThrow();
+    });
+
+    it('404 for unknown route is JSON, not HTML page', async () => {
+      const res = await request(app)
+        .get('/api/v1/nonexistent-route')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect(res.headers['content-type']).toContain('application/json');
+    });
+
+    it('Content-Security-Policy header denies inline script execution', async () => {
+      const res = await request(app).get('/health');
+      const csp = res.headers['content-security-policy'] as string;
+      expect(csp).toBeDefined();
+      // Must not have unsafe-inline for scripts
+      expect(csp).not.toContain("script-src 'unsafe-inline'");
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Auth flow security
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Auth flow security', () => {
+  it('returns 401 when Authorization header is absent', async () => {
+    const res = await request(app).get('/api/v1/patients');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when scheme is Basic instead of Bearer', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', 'Basic dXNlcjpwYXNz');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a completely bogus token', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', 'Bearer aaaa.bbbb.cccc');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a token signed with the wrong secret', async () => {
+    const forgedToken = jwt.sign(
+      { userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_A, jti: 'fake-jti' },
+      'completely-wrong-secret-here!!!',
+      { expiresIn: '15m', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    );
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${forgedToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an expired token', async () => {
+    const expiredToken = jwt.sign(
+      { userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_A, jti: 'expired-jti' },
+      'test-access-secret-32-chars-long!!',
+      { expiresIn: -1, issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    );
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${expiredToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a tampered token payload (signature mismatch)', async () => {
+    const [header, , sig] = doctorToken.split('.');
+    const tamperedPayload = Buffer.from(
+      JSON.stringify({ userId: 'hacker', role: 'SUPER_ADMIN', clinicId: CLINIC_A })
+    ).toString('base64url');
+    const tamperedToken = `${header}.${tamperedPayload}.${sig}`;
+
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${tamperedToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns structured error body (not stack trace) on auth failure', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', 'Bearer invalid.token.here');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).toHaveProperty('message');
+    expect(res.body).not.toHaveProperty('stack');
+  });
+
+  it('security headers are present on auth-protected responses', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['x-frame-options']).toBeDefined();
+    expect(res.headers['x-powered-by']).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Permission enforcement
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Permission enforcement', () => {
+  it('PATIENT role cannot list all patients', async () => {
+    const patientRoleToken = makeToken('PATIENT');
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${patientRoleToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('READ_ONLY role cannot create a patient', async () => {
+    const readOnlyToken = makeToken('READ_ONLY');
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${readOnlyToken}`)
+      .send({ firstName: 'A', lastName: 'B', dateOfBirth: '1990-01-01', sex: 'M' });
+    expect(res.status).toBe(403);
+  });
+
+  it('READ_ONLY role cannot update a patient', async () => {
+    const patient = await seed();
+    const readOnlyToken = makeToken('READ_ONLY');
+    const res = await request(app)
+      .put(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${readOnlyToken}`)
+      .send({ firstName: 'Hijacked' });
+    expect(res.status).toBe(403);
+  });
+
+  it('DOCTOR role cannot delete a patient', async () => {
+    const patient = await seed();
+    const res = await request(app)
+      .delete(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${doctorToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('CLINIC_ADMIN can delete a patient', async () => {
+    const patient = await seed();
+    const adminToken = makeToken('CLINIC_ADMIN');
+    const res = await request(app)
+      .delete(`/api/v1/patients/${patient._id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect([200, 204]).toContain(res.status);
+  });
+
+  describe('Cross-clinic data isolation', () => {
+    it('DOCTOR from clinic B cannot read patients belonging to clinic A', async () => {
+      await seed({ clinicId: CLINIC_A });
+      const clinicBToken = makeToken('DOCTOR', CLINIC_B);
+      const res = await request(app)
+        .get('/api/v1/patients')
+        .set('Authorization', `Bearer ${clinicBToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(0);
+    });
+
+    it('DOCTOR from clinic B cannot access a specific clinic A patient by ID', async () => {
+      const patient = await seed({ clinicId: CLINIC_A });
+      const clinicBToken = makeToken('DOCTOR', CLINIC_B);
+      const res = await request(app)
+        .get(`/api/v1/patients/${patient._id}`)
+        .set('Authorization', `Bearer ${clinicBToken}`);
+
+      expect([403, 404]).toContain(res.status);
+    });
+
+    it('CLINIC_ADMIN from clinic B cannot modify clinic A patient', async () => {
+      const patient = await seed({ clinicId: CLINIC_A });
+      const clinicBAdmin = makeToken('CLINIC_ADMIN', CLINIC_B);
+      const res = await request(app)
+        .put(`/api/v1/patients/${patient._id}`)
+        .set('Authorization', `Bearer ${clinicBAdmin}`)
+        .send({ firstName: 'CrossClinicHack' });
+
+      expect([403, 404]).toContain(res.status);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Data exposure
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Data exposure', () => {
+  it('password hash is not included in patient list response', async () => {
+    await seed();
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.status).toBe(200);
+    const body = JSON.stringify(res.body);
+    expect(body).not.toMatch(/"\$2[ab]\$\d{2}\$/); // bcrypt hash pattern
+    expect(body.toLowerCase()).not.toContain('"password"');
+  });
+
+  it('MFA secrets are not exposed in any patient response', async () => {
+    await seed();
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    const body = JSON.stringify(res.body);
+    expect(body).not.toContain('mfaSecret');
+    expect(body).not.toContain('mfaBackupCodes');
+  });
+
+  it('internal server errors do not leak stack traces in production-like responses', async () => {
+    // Force a bad ObjectId to trigger a handled error path
+    const res = await request(app)
+      .get('/api/v1/patients/000000000000000000000000')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect([404, 400]).toContain(res.status);
+    expect(res.body).not.toHaveProperty('stack');
+  });
+
+  it('error responses do not reveal MongoDB internals', async () => {
+    // Send a deeply nested object to trigger a cast/validation path
+    const res = await request(app)
+      .post('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`)
+      .send({ firstName: { nested: { deep: 'value' } }, lastName: 'X', dateOfBirth: '1990-01-01', sex: 'M' });
+
+    const body = JSON.stringify(res.body);
+    expect(body.toLowerCase()).not.toContain('mongodb');
+    expect(body.toLowerCase()).not.toContain('mongoose');
+  });
+
+  it('response does not include X-Powered-By header', async () => {
+    const res = await request(app)
+      .get('/api/v1/patients')
+      .set('Authorization', `Bearer ${doctorToken}`);
+
+    expect(res.headers['x-powered-by']).toBeUndefined();
+  });
+
+  it('Content-Security-Policy header is present', async () => {
+    const res = await request(app).get('/health');
+    expect(res.headers['content-security-policy']).toBeDefined();
+    expect(res.headers['content-security-policy']).toContain("default-src 'self'");
+  });
+
+  it('Strict-Transport-Security header enforces HTTPS', async () => {
+    const res = await request(app).get('/health');
+    expect(res.headers['strict-transport-security']).toContain('max-age=31536000');
+    expect(res.headers['strict-transport-security']).toContain('includeSubDomains');
+  });
+});

--- a/apps/api/src/__tests__/unit/backend-unit-coverage.test.ts
+++ b/apps/api/src/__tests__/unit/backend-unit-coverage.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Backend unit tests — Issue #904
+ *
+ * Covers:
+ *  - CacheService (no-Redis path): get / set / del / ping / metrics
+ *  - TokenDenylistService: addToDenylist, isDenylisted, setUserInvalidatedAt, isInvalidatedForUser
+ *  - authenticate middleware: missing header, invalid token, valid token
+ *  - requireRoles middleware: correct role, wrong role, no user
+ *  - authorize (RBAC) middleware: allowed role, forbidden role, unauthenticated
+ *  - AppError factory methods and field contracts
+ *  - errorHandler: AppError, ZodError, MongooseValidationError, duplicate-key, JWT errors, unknown
+ */
+
+// ── Environment stubs ──────────────────────────────────────────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+
+// ── Module mocks ───────────────────────────────────────────────────────────────
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('@sentry/node', () => ({ captureException: jest.fn() }));
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellarHorizonUrl: '',
+    stellarSecretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+  },
+}));
+
+import { Request, Response, NextFunction } from 'express';
+import { z, ZodError } from 'zod';
+import { Error as MongooseError } from 'mongoose';
+import { TokenExpiredError, JsonWebTokenError } from 'jsonwebtoken';
+import { AppError } from '../../utils/app-error';
+import { errorHandler } from '../../middlewares/error.middleware';
+import { authenticate, requireRoles } from '../../middlewares/auth.middleware';
+import { authorize, Roles } from '../../middlewares/rbac.middleware';
+import { cache, getCacheMetrics } from '../../services/cache.service';
+import {
+  addToDenylist,
+  isDenylisted,
+  setUserInvalidatedAt,
+  isInvalidatedForUser,
+} from '../../services/token-denylist.service';
+import { AppRole } from '../../types/express';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+function mockRes() {
+  const res = { status: jest.fn(), json: jest.fn(), locals: {} } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  return res;
+}
+
+function mockReq(overrides: Partial<Request> = {}) {
+  return {
+    requestId: 'test-req-id',
+    method: 'GET',
+    path: '/test',
+    user: undefined,
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+const noop = jest.fn() as unknown as NextFunction;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. AppError
+// ─────────────────────────────────────────────────────────────────────────────
+describe('AppError', () => {
+  it('badRequest produces 400 with validation category', () => {
+    const err = AppError.badRequest('bad input');
+    expect(err.statusCode).toBe(400);
+    expect(err.category).toBe('validation');
+    expect(err.severity).toBe('low');
+  });
+
+  it('unauthorized produces 401 with authentication category', () => {
+    const err = AppError.unauthorized();
+    expect(err.statusCode).toBe(401);
+    expect(err.category).toBe('authentication');
+  });
+
+  it('forbidden produces 403 with authorization category', () => {
+    const err = AppError.forbidden();
+    expect(err.statusCode).toBe(403);
+    expect(err.category).toBe('authorization');
+  });
+
+  it('notFound produces 404 with not_found category', () => {
+    const err = AppError.notFound('Patient');
+    expect(err.statusCode).toBe(404);
+    expect(err.message).toContain('Patient');
+    expect(err.category).toBe('not_found');
+  });
+
+  it('conflict produces 409', () => {
+    const err = AppError.conflict('already exists');
+    expect(err.statusCode).toBe(409);
+    expect(err.category).toBe('conflict');
+  });
+
+  it('tooManyRequests produces 429', () => {
+    const err = AppError.tooManyRequests();
+    expect(err.statusCode).toBe(429);
+    expect(err.category).toBe('rate_limit');
+  });
+
+  it('internal produces 500 with high severity', () => {
+    const err = AppError.internal('boom');
+    expect(err.statusCode).toBe(500);
+    expect(err.severity).toBe('high');
+    expect(err.isOperational).toBe(false);
+  });
+
+  it('isOperational defaults to true for 4xx', () => {
+    const err = AppError.badRequest('x');
+    expect(err.isOperational).toBe(true);
+  });
+
+  it('attaches context when provided', () => {
+    const err = AppError.badRequest('x', { field: 'email' });
+    expect(err.context).toEqual({ field: 'email' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. errorHandler middleware
+// ─────────────────────────────────────────────────────────────────────────────
+describe('errorHandler middleware', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('handles AppError — returns its statusCode and category', () => {
+    const res = mockRes();
+    const err = AppError.notFound('Record');
+    errorHandler(err, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(404);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+      error: 'not_found',
+      message: 'Record not found',
+    });
+  });
+
+  it('handles ZodError — 400 ValidationError', () => {
+    const res = mockRes();
+    let zodErr: ZodError | null = null;
+    try {
+      z.object({ name: z.string() }).parse({});
+    } catch (e) {
+      zodErr = e as ZodError;
+    }
+    errorHandler(zodErr!, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(400);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'ValidationError' });
+  });
+
+  it('handles Mongoose ValidationError — 400', () => {
+    const res = mockRes();
+    const mongoErr = new MongooseError.ValidationError();
+    errorHandler(mongoErr, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(400);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'ValidationError' });
+  });
+
+  it('handles Mongoose CastError — 400', () => {
+    const res = mockRes();
+    const castErr = new MongooseError.CastError('ObjectId', 'bad-id', '_id');
+    errorHandler(castErr, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(400);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'BadRequest' });
+  });
+
+  it('handles MongoDB duplicate-key (code 11000) — 409', () => {
+    const res = mockRes();
+    const dupErr = Object.assign(new Error('dup'), { code: 11000, keyValue: { email: 'x' } });
+    errorHandler(dupErr, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(409);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'Conflict' });
+  });
+
+  it('handles TokenExpiredError — 401', () => {
+    const res = mockRes();
+    const expErr = new TokenExpiredError('expired', new Date());
+    errorHandler(expErr, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(401);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'TokenExpired' });
+  });
+
+  it('handles JsonWebTokenError — 401', () => {
+    const res = mockRes();
+    const jwtErr = new JsonWebTokenError('invalid signature');
+    errorHandler(jwtErr, mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(401);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'InvalidToken' });
+  });
+
+  it('handles unknown errors — 500', () => {
+    const res = mockRes();
+    errorHandler(new Error('unexpected'), mockReq(), res, noop);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(500);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({ error: 'InternalServerError' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. authenticate middleware
+// ─────────────────────────────────────────────────────────────────────────────
+describe('authenticate middleware', () => {
+  it('returns 401 when Authorization header is absent', async () => {
+    const res = mockRes();
+    const next = jest.fn();
+    await authenticate(mockReq({ headers: {} }), res, next);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when header does not start with Bearer', async () => {
+    const res = mockRes();
+    const next = jest.fn();
+    await authenticate(
+      mockReq({ headers: { authorization: 'Basic abc123' } }),
+      res,
+      next
+    );
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    const res = mockRes();
+    const next = jest.fn();
+    await authenticate(
+      mockReq({ headers: { authorization: 'Bearer not.a.valid.token' } }),
+      res,
+      next
+    );
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. requireRoles middleware
+// ─────────────────────────────────────────────────────────────────────────────
+describe('requireRoles middleware', () => {
+  it('calls next() when user has an allowed role', () => {
+    const next = jest.fn();
+    const res = mockRes();
+    const req = mockReq({
+      user: { userId: 'u1', role: 'DOCTOR' as AppRole, clinicId: 'c1', isSuperAdmin: false },
+    });
+    requireRoles('DOCTOR', 'NURSE')(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when user role is not in allowed list', () => {
+    const next = jest.fn();
+    const res = mockRes();
+    const req = mockReq({
+      user: { userId: 'u1', role: 'READ_ONLY' as AppRole, clinicId: 'c1', isSuperAdmin: false },
+    });
+    requireRoles('DOCTOR', 'CLINIC_ADMIN')(req, res, next);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when req.user is not set', () => {
+    const next = jest.fn();
+    const res = mockRes();
+    requireRoles('DOCTOR')(mockReq(), res, next);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. authorize (RBAC) middleware
+// ─────────────────────────────────────────────────────────────────────────────
+describe('authorize middleware', () => {
+  it('calls next() when user role is in allowedRoles', () => {
+    const next = jest.fn();
+    const res = mockRes();
+    const req = mockReq({
+      user: { userId: 'u1', role: Roles.CLINIC_ADMIN, clinicId: 'c1', isSuperAdmin: false },
+    });
+    authorize([Roles.CLINIC_ADMIN, Roles.SUPER_ADMIN])(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 when user role is not allowed', () => {
+    const next = jest.fn();
+    const res = mockRes();
+    const req = mockReq({
+      user: { userId: 'u1', role: Roles.PATIENT, clinicId: 'c1', isSuperAdmin: false },
+    });
+    authorize([Roles.DOCTOR, Roles.NURSE])(req, res, next);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when req.user is absent', () => {
+    const next = jest.fn();
+    const res = mockRes();
+    authorize([Roles.DOCTOR])(mockReq(), res, next);
+    expect((res.status as jest.Mock).mock.calls[0][0]).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('all roles in hierarchy can be authorized', () => {
+    const allRoles = Object.values(Roles) as AppRole[];
+    allRoles.forEach((role) => {
+      const next = jest.fn();
+      const res = mockRes();
+      const req = mockReq({
+        user: { userId: 'u1', role, clinicId: 'c1', isSuperAdmin: role === 'SUPER_ADMIN' },
+      });
+      authorize(allRoles)(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. CacheService (no-Redis fallback)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CacheService — no-Redis fallback', () => {
+  beforeEach(() => {
+    delete process.env.REDIS_URL;
+  });
+
+  it('get() returns null when Redis is not configured', async () => {
+    const val = await cache.get('some-key');
+    expect(val).toBeNull();
+  });
+
+  it('set() resolves without error when Redis is not configured', async () => {
+    await expect(cache.set('some-key', { data: 1 }, 60)).resolves.toBeUndefined();
+  });
+
+  it('del() resolves without error when Redis is not configured', async () => {
+    await expect(cache.del('some-key')).resolves.toBeUndefined();
+  });
+
+  it('delPattern() resolves without error when Redis is not configured', async () => {
+    await expect(cache.delPattern('prefix:*')).resolves.toBeUndefined();
+  });
+
+  it('ping() returns {status: "disabled"} when Redis is not configured', async () => {
+    const result = await cache.ping();
+    expect(result).toEqual({ status: 'disabled' });
+  });
+
+  it('getCacheMetrics() returns numeric hit/miss counts and hitRate', () => {
+    const metrics = getCacheMetrics();
+    expect(typeof metrics.hits).toBe('number');
+    expect(typeof metrics.misses).toBe('number');
+    expect(typeof metrics.hitRate).toBe('number');
+    expect(metrics.hitRate).toBeGreaterThanOrEqual(0);
+    expect(metrics.hitRate).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. TokenDenylistService (cache-backed)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('TokenDenylistService', () => {
+  beforeEach(() => {
+    jest.spyOn(cache, 'set').mockResolvedValue(undefined);
+    jest.spyOn(cache, 'get').mockResolvedValue(null);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('addToDenylist calls cache.set with the correct key prefix', async () => {
+    await addToDenylist('jti-abc', 300);
+    expect(cache.set).toHaveBeenCalledWith('token-denylist:jti-abc', 1, 300);
+  });
+
+  it('addToDenylist does NOT call cache.set when ttl <= 0', async () => {
+    await addToDenylist('jti-zero', 0);
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it('isDenylisted returns false when cache returns null', async () => {
+    const result = await isDenylisted('jti-clean');
+    expect(result).toBe(false);
+  });
+
+  it('isDenylisted returns true when cache has the jti', async () => {
+    (cache.get as jest.Mock).mockResolvedValueOnce(1);
+    const result = await isDenylisted('jti-revoked');
+    expect(result).toBe(true);
+  });
+
+  it('setUserInvalidatedAt stores timestamp under user key with 7-day TTL', async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    await setUserInvalidatedAt('user-1', ts);
+    expect(cache.set).toHaveBeenCalledWith(
+      'user-invalidated:user-1',
+      ts,
+      7 * 24 * 60 * 60
+    );
+  });
+
+  it('isInvalidatedForUser returns false when no invalidation record exists', async () => {
+    const result = await isInvalidatedForUser('user-1', 1000);
+    expect(result).toBe(false);
+  });
+
+  it('isInvalidatedForUser returns true when token iat is before invalidation timestamp', async () => {
+    const invalidatedAt = 2000;
+    (cache.get as jest.Mock).mockResolvedValueOnce(invalidatedAt);
+    const result = await isInvalidatedForUser('user-1', 1500); // iat < invalidatedAt
+    expect(result).toBe(true);
+  });
+
+  it('isInvalidatedForUser returns false when token iat is after invalidation timestamp', async () => {
+    const invalidatedAt = 1000;
+    (cache.get as jest.Mock).mockResolvedValueOnce(invalidatedAt);
+    const result = await isInvalidatedForUser('user-1', 2000); // iat > invalidatedAt
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **#904 — Backend Unit Tests**: Unit tests for `AppError`, `errorHandler`, `authenticate`, `requireRoles`, `authorize` (RBAC), `CacheService` (no-Redis path), and `TokenDenylistService`. Covers all error types (Zod, Mongoose, JWT, duplicate-key, unknown) and 80%+ of tested service/middleware logic.
- **#905 — API Integration Tests**: End-to-end integration tests for the patient CRUD API (`POST`, `GET list`, `GET :id`, `PUT`, `DELETE`) using `MongoMemoryServer`. Covers 400/401/403/404 error scenarios, JWT-based auth, and multi-tenant clinic isolation.
- **#906 — Performance Benchmark Tests**: Response-time baseline assertions for `/health`, patient list/search/pagination, single-record reads, and appointments. Includes a 10-concurrent-request load test with p95 budget, and MongoDB index coverage verification.
- **#907 — Security Tests**: NoSQL operator injection sanitisation, auth attack vectors (forged/expired/tampered tokens), RBAC enforcement across all roles, cross-clinic data isolation, sensitive-field leakage checks, and security-header assertions (CSP, HSTS, X-Powered-By).

## Test plan

- [ ] `npm run test` passes in `apps/api` with no new failures
- [ ] Coverage for `auth`, `payments`, and `patients` modules remains ≥ 80%
- [ ] Performance baselines are logged to console for future regression tracking
- [ ] All four issues are closed via `closes #NNN` in the commit message

closes #904
closes #905
closes #906
closes #907