### PR TITLE
feat(testing): test data factories and database tests

### DIFF
--- a/apps/api/src/__tests__/database/indexes.test.ts
+++ b/apps/api/src/__tests__/database/indexes.test.ts
@@ -1,0 +1,162 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { PatientModel } from '@api/modules/patients/models/patient.model';
+import { EncounterModel } from '@api/modules/encounters/encounter.model';
+import { PaymentRecordModel } from '@api/modules/payments/models/payment-record.model';
+import { buildPatientBatch } from '../factories/patient.factory';
+import { buildEncounterBatch } from '../factories/encounter.factory';
+import { buildPaymentBatch } from '../factories/payment.factory';
+
+jest.mock('@api/lib/encrypt', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  await PatientModel.ensureIndexes();
+  await EncounterModel.ensureIndexes();
+  await PaymentRecordModel.ensureIndexes();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await PatientModel.deleteMany({});
+  await EncounterModel.deleteMany({});
+  await PaymentRecordModel.deleteMany({});
+});
+
+async function explainFind(model: mongoose.Model<any>, filter: object) {
+  return model.find(filter).explain('executionStats') as Promise<any>;
+}
+
+describe('Database Indexes', () => {
+  describe('Patient indexes', () => {
+    it('index exists on patients.clinicId', async () => {
+      const info = await PatientModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('clinicId'))).toBe(true);
+    });
+
+    it('index exists on patients.searchName', async () => {
+      const info = await PatientModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('searchName'))).toBe(true);
+    });
+
+    it('unique index on patients.systemId rejects duplicate', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const base = buildPatientBatch(1, { clinicId })[0]!;
+      await PatientModel.create(base);
+      await expect(PatientModel.create({ ...buildPatientBatch(1, { clinicId })[0]!, systemId: base.systemId })).rejects.toThrow();
+    });
+
+    it('clinicId query uses an index (not COLLSCAN)', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      await PatientModel.insertMany(buildPatientBatch(5, { clinicId }));
+
+      const plan = await explainFind(PatientModel, { clinicId });
+      const stage: string = plan?.executionStats?.executionStages?.stage ?? plan?.queryPlanner?.winningPlan?.stage ?? '';
+      expect(stage).not.toBe('COLLSCAN');
+    });
+
+    it('isActive index exists for active-patient filtering', async () => {
+      const info = await PatientModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('isActive'))).toBe(true);
+    });
+  });
+
+  describe('Encounter indexes', () => {
+    it('index exists on encounters.patientId', async () => {
+      const info = await EncounterModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('patientId'))).toBe(true);
+    });
+
+    it('index exists on encounters.clinicId', async () => {
+      const info = await EncounterModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('clinicId'))).toBe(true);
+    });
+
+    it('index exists on encounters.status', async () => {
+      const info = await EncounterModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('status'))).toBe(true);
+    });
+
+    it('index exists on encounters.attendingDoctorId', async () => {
+      const info = await EncounterModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('attendingDoctorId'))).toBe(true);
+    });
+
+    it('clinicId+status query uses an index (not COLLSCAN)', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const doctorId = new mongoose.Types.ObjectId();
+      await EncounterModel.insertMany(
+        buildEncounterBatch(5, { clinicId, attendingDoctorId: doctorId, status: 'open' })
+      );
+
+      const plan = await explainFind(EncounterModel, { clinicId, status: 'open' });
+      const stage: string = plan?.executionStats?.executionStages?.stage ?? plan?.queryPlanner?.winningPlan?.stage ?? '';
+      expect(stage).not.toBe('COLLSCAN');
+    });
+
+    it('isActive index exists for encounter filtering', async () => {
+      const info = await EncounterModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('isActive'))).toBe(true);
+    });
+  });
+
+  describe('PaymentRecord indexes', () => {
+    it('unique index on paymentrecords.intentId rejects duplicate', async () => {
+      const pay = buildPaymentBatch(1)[0]!;
+      await PaymentRecordModel.create(pay);
+      await expect(PaymentRecordModel.create({ ...buildPaymentBatch(1)[0]!, intentId: pay.intentId })).rejects.toThrow();
+    });
+
+    it('index exists on paymentrecords.clinicId', async () => {
+      const info = await PaymentRecordModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('clinicId'))).toBe(true);
+    });
+
+    it('index exists on paymentrecords.status', async () => {
+      const info = await PaymentRecordModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('status'))).toBe(true);
+    });
+
+    it('index exists on paymentrecords.txHash (sparse)', async () => {
+      const info = await PaymentRecordModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('txHash'))).toBe(true);
+    });
+
+    it('clinicId query uses an index (not COLLSCAN)', async () => {
+      const clinicId = new mongoose.Types.ObjectId().toString();
+      await PaymentRecordModel.insertMany(buildPaymentBatch(5, { clinicId }));
+
+      const plan = await explainFind(PaymentRecordModel, { clinicId });
+      const stage: string = plan?.executionStats?.executionStages?.stage ?? plan?.queryPlanner?.winningPlan?.stage ?? '';
+      expect(stage).not.toBe('COLLSCAN');
+    });
+
+    it('index exists on paymentrecords.encounterId', async () => {
+      const info = await PaymentRecordModel.collection.indexInformation();
+      const indexKeys = Object.values(info).map((idx: any) => idx.map((k: any) => k[0]));
+      expect(indexKeys.some((keys) => keys.includes('encounterId'))).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/__tests__/database/migrations.test.ts
+++ b/apps/api/src/__tests__/database/migrations.test.ts
@@ -1,0 +1,178 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoClient, Db } from 'mongodb';
+import * as initialSchema from '@api/migrations/20240101_initial_schema';
+import * as searchIndex from '@api/migrations/20240102_add_patient_search_index';
+import * as encounterStatus from '@api/migrations/20240103_add_encounter_status';
+import * as missingIndexes from '@api/migrations/20260425_add_missing_indexes';
+import * as dashboardIndexes from '@api/migrations/20260625_dashboard_compound_indexes';
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+async function dropAllCollections() {
+  const cols = await db.listCollections().toArray();
+  for (const col of cols) {
+    await db.collection(col.name).drop().catch(() => {});
+  }
+}
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  client = await MongoClient.connect(mongod.getUri());
+  db = client.db('test');
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await dropAllCollections();
+});
+
+describe('Migrations', () => {
+  describe('20240101_initial_schema', () => {
+    it('creates unique index on patients.systemId', async () => {
+      await initialSchema.up(db);
+      const indexes = await db.collection('patients').indexInformation();
+      expect(indexes['systemId_unique']).toBeDefined();
+    });
+
+    it('creates index on patients.searchName', async () => {
+      await initialSchema.up(db);
+      const indexes = await db.collection('patients').indexInformation();
+      expect(indexes['searchName_1']).toBeDefined();
+    });
+
+    it('creates indexes on encounters collection', async () => {
+      await initialSchema.up(db);
+      const indexes = await db.collection('encounters').indexInformation();
+      expect(indexes['patientId_1']).toBeDefined();
+      expect(indexes['clinicId_1']).toBeDefined();
+      expect(indexes['status_1']).toBeDefined();
+    });
+
+    it('creates unique index on paymentrecords.intentId', async () => {
+      await initialSchema.up(db);
+      const indexes = await db.collection('paymentrecords').indexInformation();
+      expect(indexes['intentId_unique']).toBeDefined();
+    });
+
+    it('is idempotent — up() twice does not throw', async () => {
+      await initialSchema.up(db);
+      await expect(initialSchema.up(db)).resolves.not.toThrow();
+    });
+
+    it('removes patient indexes on down()', async () => {
+      await initialSchema.up(db);
+      await initialSchema.down(db);
+      const indexes = await db.collection('patients').indexInformation();
+      expect(indexes['systemId_unique']).toBeUndefined();
+      expect(indexes['searchName_1']).toBeUndefined();
+    });
+
+    it('removes encounter indexes on down()', async () => {
+      await initialSchema.up(db);
+      await initialSchema.down(db);
+      const indexes = await db.collection('encounters').indexInformation();
+      expect(indexes['patientId_1']).toBeUndefined();
+      expect(indexes['status_1']).toBeUndefined();
+    });
+  });
+
+  describe('20240102_add_patient_search_index', () => {
+    it('adds text index on patients.searchName', async () => {
+      await searchIndex.up(db);
+      const indexes = await db.collection('patients').indexInformation();
+      expect(indexes['searchName_text']).toBeDefined();
+    });
+
+    it('removes the text index on down()', async () => {
+      await searchIndex.up(db);
+      await searchIndex.down(db);
+      const indexes = await db.collection('patients').indexInformation();
+      expect(indexes['searchName_text']).toBeUndefined();
+    });
+  });
+
+  describe('20240103_add_encounter_status', () => {
+    it('backfills status="open" on encounters missing the field', async () => {
+      await db.collection('encounters').insertMany([
+        { patientId: 'p1', chiefComplaint: 'Headache' },
+        { patientId: 'p2', chiefComplaint: 'Fever', status: 'closed' },
+      ]);
+
+      await encounterStatus.up(db);
+
+      const noStatus = await db.collection('encounters').findOne({ patientId: 'p1' });
+      const withStatus = await db.collection('encounters').findOne({ patientId: 'p2' });
+      expect(noStatus?.status).toBe('open');
+      expect(withStatus?.status).toBe('closed');
+    });
+
+    it('is idempotent — backfill twice produces the same result', async () => {
+      await db.collection('encounters').insertOne({ patientId: 'p1', chiefComplaint: 'Test' });
+      await encounterStatus.up(db);
+      await encounterStatus.up(db);
+      const doc = await db.collection('encounters').findOne({ patientId: 'p1' });
+      expect(doc?.status).toBe('open');
+    });
+
+    it('does not overwrite an existing non-open status', async () => {
+      await db.collection('encounters').insertOne({ patientId: 'p3', status: 'cancelled' });
+      await encounterStatus.up(db);
+      const doc = await db.collection('encounters').findOne({ patientId: 'p3' });
+      expect(doc?.status).toBe('cancelled');
+    });
+  });
+
+  describe('20260425_add_missing_indexes', () => {
+    it('creates compound encounter index clinicId+createdAt', async () => {
+      await missingIndexes.up(db);
+      const indexes = await db.collection('encounters').indexInformation();
+      expect(indexes['clinicId_1_createdAt_-1']).toBeDefined();
+    });
+
+    it('creates encounter index on patientId+createdAt', async () => {
+      await missingIndexes.up(db);
+      const indexes = await db.collection('encounters').indexInformation();
+      expect(indexes['patientId_1_createdAt_-1']).toBeDefined();
+    });
+
+    it('creates payment index on clinicId+createdAt', async () => {
+      await missingIndexes.up(db);
+      const indexes = await db.collection('paymentrecords').indexInformation();
+      expect(indexes['clinicId_1_createdAt_-1']).toBeDefined();
+    });
+
+    it('removes compound indexes on down()', async () => {
+      await missingIndexes.up(db);
+      await missingIndexes.down(db);
+      const encounterIndexes = await db.collection('encounters').indexInformation();
+      const paymentIndexes = await db.collection('paymentrecords').indexInformation();
+      expect(encounterIndexes['clinicId_1_createdAt_-1']).toBeUndefined();
+      expect(paymentIndexes['clinicId_1_createdAt_-1']).toBeUndefined();
+    });
+  });
+
+  describe('20260625_dashboard_compound_indexes', () => {
+    it('creates patients compound index for dashboard queries', async () => {
+      await dashboardIndexes.up(db);
+      const indexes = await db.collection('patients').indexInformation();
+      expect(indexes['clinicId_1_createdAt_-1']).toBeDefined();
+    });
+
+    it('creates payment status+date index for pending payment queries', async () => {
+      await dashboardIndexes.up(db);
+      const indexes = await db.collection('paymentrecords').indexInformation();
+      expect(indexes['clinicId_1_status_1_createdAt_-1']).toBeDefined();
+    });
+
+    it('is idempotent — up() twice does not throw', async () => {
+      await dashboardIndexes.up(db);
+      await expect(dashboardIndexes.up(db)).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/__tests__/database/queries.test.ts
+++ b/apps/api/src/__tests__/database/queries.test.ts
@@ -1,0 +1,186 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { PatientModel } from '@api/modules/patients/models/patient.model';
+import { EncounterModel } from '@api/modules/encounters/encounter.model';
+import { PaymentRecordModel } from '@api/modules/payments/models/payment-record.model';
+import { buildPatientBatch } from '../factories/patient.factory';
+import { buildEncounterBatch } from '../factories/encounter.factory';
+import { buildPaymentBatch, buildConfirmedPayment } from '../factories/payment.factory';
+
+jest.mock('@api/lib/encrypt', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+let mongod: MongoMemoryServer;
+const CLINIC_ID = new mongoose.Types.ObjectId();
+const DOCTOR_ID = new mongoose.Types.ObjectId();
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  await PatientModel.ensureIndexes();
+  await EncounterModel.ensureIndexes();
+  await PaymentRecordModel.ensureIndexes();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await PatientModel.deleteMany({});
+  await EncounterModel.deleteMany({});
+  await PaymentRecordModel.deleteMany({});
+});
+
+describe('Database Queries', () => {
+  describe('Patient queries', () => {
+    it('finds patients by clinicId', async () => {
+      const patients = buildPatientBatch(5, { clinicId: CLINIC_ID });
+      await PatientModel.insertMany(patients);
+
+      const results = await PatientModel.find({ clinicId: CLINIC_ID });
+      expect(results).toHaveLength(5);
+    });
+
+    it('filters active patients only', async () => {
+      const active = buildPatientBatch(3, { clinicId: CLINIC_ID, isActive: true });
+      const inactive = buildPatientBatch(2, { clinicId: CLINIC_ID, isActive: false });
+      await PatientModel.insertMany([...active, ...inactive]);
+
+      const results = await PatientModel.find({ clinicId: CLINIC_ID, isActive: true });
+      expect(results).toHaveLength(3);
+    });
+
+    it('finds patient by systemId', async () => {
+      const [patient] = buildPatientBatch(1, { clinicId: CLINIC_ID });
+      await PatientModel.create(patient);
+
+      const found = await PatientModel.findOne({ systemId: patient.systemId });
+      expect(found).not.toBeNull();
+      expect(found!.firstName).toBe(patient.firstName);
+    });
+
+    it('returns patients sorted by createdAt descending', async () => {
+      const patients = buildPatientBatch(3, { clinicId: CLINIC_ID });
+      await PatientModel.insertMany(patients);
+
+      const results = await PatientModel.find({ clinicId: CLINIC_ID }).sort({ createdAt: -1 });
+      expect(results).toHaveLength(3);
+      const dates = results.map((p) => p.createdAt?.getTime() ?? 0);
+      expect(dates[0]).toBeGreaterThanOrEqual(dates[1]!);
+      expect(dates[1]).toBeGreaterThanOrEqual(dates[2]!);
+    });
+
+    it('counts patients per clinic', async () => {
+      await PatientModel.insertMany(buildPatientBatch(4, { clinicId: CLINIC_ID }));
+      const count = await PatientModel.countDocuments({ clinicId: CLINIC_ID });
+      expect(count).toBe(4);
+    });
+
+    it('supports searchName text-prefix match', async () => {
+      const patient = buildPatientBatch(1, { clinicId: CLINIC_ID, searchName: 'alice smith' })[0]!;
+      await PatientModel.create(patient);
+
+      const found = await PatientModel.findOne({ searchName: /^alice/ });
+      expect(found).not.toBeNull();
+    });
+  });
+
+  describe('Encounter queries', () => {
+    it('finds encounters by patientId', async () => {
+      const patientId = new mongoose.Types.ObjectId();
+      const encounters = buildEncounterBatch(3, { patientId, clinicId: CLINIC_ID, attendingDoctorId: DOCTOR_ID });
+      await EncounterModel.insertMany(encounters);
+
+      const results = await EncounterModel.find({ patientId });
+      expect(results).toHaveLength(3);
+    });
+
+    it('filters encounters by status', async () => {
+      await EncounterModel.insertMany([
+        ...buildEncounterBatch(2, { clinicId: CLINIC_ID, attendingDoctorId: DOCTOR_ID, status: 'open' }),
+        ...buildEncounterBatch(1, { clinicId: CLINIC_ID, attendingDoctorId: DOCTOR_ID, status: 'closed' }),
+      ]);
+
+      const open = await EncounterModel.find({ clinicId: CLINIC_ID, status: 'open' });
+      expect(open).toHaveLength(2);
+    });
+
+    it('retrieves encounter with vitalSigns embedded', async () => {
+      const enc = {
+        ...buildEncounterBatch(1, { clinicId: CLINIC_ID, attendingDoctorId: DOCTOR_ID })[0]!,
+        vitalSigns: { heartRate: 80, temperature: 98.6 },
+      };
+      await EncounterModel.create(enc);
+
+      const found = await EncounterModel.findOne({ clinicId: CLINIC_ID });
+      expect(found?.vitalSigns?.heartRate).toBe(80);
+    });
+
+    it('counts open encounters per clinic', async () => {
+      await EncounterModel.insertMany(
+        buildEncounterBatch(5, { clinicId: CLINIC_ID, attendingDoctorId: DOCTOR_ID, status: 'open' })
+      );
+      const count = await EncounterModel.countDocuments({ clinicId: CLINIC_ID, status: 'open' });
+      expect(count).toBe(5);
+    });
+
+    it('paginates encounters with skip and limit', async () => {
+      await EncounterModel.insertMany(
+        buildEncounterBatch(10, { clinicId: CLINIC_ID, attendingDoctorId: DOCTOR_ID })
+      );
+      const page = await EncounterModel.find({ clinicId: CLINIC_ID }).skip(5).limit(3);
+      expect(page).toHaveLength(3);
+    });
+  });
+
+  describe('PaymentRecord queries', () => {
+    it('finds payments by clinicId', async () => {
+      const clinicId = new mongoose.Types.ObjectId().toString();
+      await PaymentRecordModel.insertMany(buildPaymentBatch(3, { clinicId }));
+
+      const results = await PaymentRecordModel.find({ clinicId });
+      expect(results).toHaveLength(3);
+    });
+
+    it('filters by payment status', async () => {
+      const clinicId = new mongoose.Types.ObjectId().toString();
+      await PaymentRecordModel.insertMany([
+        ...buildPaymentBatch(2, { clinicId }),
+        buildConfirmedPayment({ clinicId }),
+      ]);
+
+      const pending = await PaymentRecordModel.find({ clinicId, status: 'pending' });
+      const confirmed = await PaymentRecordModel.find({ clinicId, status: 'confirmed' });
+      expect(pending).toHaveLength(2);
+      expect(confirmed).toHaveLength(1);
+    });
+
+    it('finds payment by intentId', async () => {
+      const payment = buildPaymentBatch(1)[0]!;
+      await PaymentRecordModel.create(payment);
+
+      const found = await PaymentRecordModel.findOne({ intentId: payment.intentId });
+      expect(found).not.toBeNull();
+      expect(found!.amount).toBe(payment.amount);
+    });
+
+    it('aggregates total pending amount per clinic', async () => {
+      const clinicId = new mongoose.Types.ObjectId().toString();
+      await PaymentRecordModel.insertMany([
+        { ...buildPaymentBatch(1, { clinicId })[0]!, amount: '50.00' },
+        { ...buildPaymentBatch(1, { clinicId })[0]!, amount: '75.00' },
+      ]);
+
+      const agg = await PaymentRecordModel.aggregate([
+        { $match: { clinicId, status: 'pending' } },
+        { $group: { _id: null, total: { $sum: { $toDouble: '$amount' } } } },
+      ]);
+      expect(agg[0]?.total).toBeCloseTo(125);
+    });
+  });
+});

--- a/apps/api/src/__tests__/database/transactions.test.ts
+++ b/apps/api/src/__tests__/database/transactions.test.ts
@@ -1,0 +1,199 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { PatientModel } from '@api/modules/patients/models/patient.model';
+import { EncounterModel } from '@api/modules/encounters/encounter.model';
+import { PaymentRecordModel } from '@api/modules/payments/models/payment-record.model';
+import { buildPatient } from '../factories/patient.factory';
+import { buildEncounter } from '../factories/encounter.factory';
+import { buildPayment } from '../factories/payment.factory';
+
+jest.mock('@api/lib/encrypt', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create({ instance: { replSet: 'rs0' } });
+  await mongoose.connect(mongod.getUri());
+  await PatientModel.ensureIndexes();
+  await EncounterModel.ensureIndexes();
+  await PaymentRecordModel.ensureIndexes();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await PatientModel.deleteMany({});
+  await EncounterModel.deleteMany({});
+  await PaymentRecordModel.deleteMany({});
+});
+
+describe('Database Transactions (ACID)', () => {
+  describe('Atomicity', () => {
+    it('commits both patient and encounter when transaction succeeds', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const doctorId = new mongoose.Types.ObjectId();
+      const session = await mongoose.startSession();
+
+      await session.withTransaction(async () => {
+        const patient = await PatientModel.create([buildPatient({ clinicId })], { session });
+        await EncounterModel.create(
+          [buildEncounter({ clinicId, attendingDoctorId: doctorId, patientId: patient[0]!._id as mongoose.Types.ObjectId })],
+          { session }
+        );
+      });
+
+      session.endSession();
+
+      const patients = await PatientModel.find({ clinicId });
+      const encounters = await EncounterModel.find({ clinicId });
+      expect(patients).toHaveLength(1);
+      expect(encounters).toHaveLength(1);
+    });
+
+    it('rolls back all writes when transaction aborts', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const session = await mongoose.startSession();
+
+      await expect(
+        session.withTransaction(async () => {
+          await PatientModel.create([buildPatient({ clinicId })], { session });
+          throw new Error('Simulated failure — roll back');
+        })
+      ).rejects.toThrow('Simulated failure');
+
+      session.endSession();
+
+      const patients = await PatientModel.find({ clinicId });
+      expect(patients).toHaveLength(0);
+    });
+  });
+
+  describe('Consistency', () => {
+    it('enforces unique intentId constraint within a transaction', async () => {
+      const payment = buildPayment();
+      await PaymentRecordModel.create(payment);
+
+      const session = await mongoose.startSession();
+
+      await expect(
+        session.withTransaction(async () => {
+          await PaymentRecordModel.create([{ ...buildPayment(), intentId: payment.intentId }], { session });
+        })
+      ).rejects.toThrow();
+
+      session.endSession();
+
+      const count = await PaymentRecordModel.countDocuments({ intentId: payment.intentId });
+      expect(count).toBe(1);
+    });
+
+    it('enforces unique systemId constraint across concurrent creates', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const patient = buildPatient({ clinicId });
+      await PatientModel.create(patient);
+
+      await expect(PatientModel.create({ ...buildPatient({ clinicId }), systemId: patient.systemId })).rejects.toThrow();
+
+      const count = await PatientModel.countDocuments({ systemId: patient.systemId });
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('Isolation', () => {
+    it('uncommitted changes are not visible outside the session', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const session = await mongoose.startSession();
+      session.startTransaction();
+
+      await PatientModel.create([buildPatient({ clinicId })], { session });
+
+      const outsideCount = await PatientModel.countDocuments({ clinicId });
+      expect(outsideCount).toBe(0);
+
+      await session.abortTransaction();
+      session.endSession();
+    });
+  });
+
+  describe('Durability', () => {
+    it('committed data survives a reconnect', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const session = await mongoose.startSession();
+
+      await session.withTransaction(async () => {
+        await PatientModel.create([buildPatient({ clinicId })], { session });
+      });
+
+      session.endSession();
+
+      await mongoose.disconnect();
+      await mongoose.connect(mongod.getUri());
+
+      const count = await PatientModel.countDocuments({ clinicId });
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('Multi-document transaction', () => {
+    it('creates patient, encounter, and payment atomically', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const doctorId = new mongoose.Types.ObjectId();
+      const clinicStr = clinicId.toString();
+      const session = await mongoose.startSession();
+
+      await session.withTransaction(async () => {
+        const [patient] = await PatientModel.create([buildPatient({ clinicId })], { session });
+        const [encounter] = await EncounterModel.create(
+          [buildEncounter({ clinicId, attendingDoctorId: doctorId, patientId: patient!._id as mongoose.Types.ObjectId })],
+          { session }
+        );
+        await PaymentRecordModel.create(
+          [buildPayment({ clinicId: clinicStr, encounterId: (encounter!._id as mongoose.Types.ObjectId).toString() })],
+          { session }
+        );
+      });
+
+      session.endSession();
+
+      expect(await PatientModel.countDocuments({ clinicId })).toBe(1);
+      expect(await EncounterModel.countDocuments({ clinicId })).toBe(1);
+      expect(await PaymentRecordModel.countDocuments({ clinicId: clinicStr })).toBe(1);
+    });
+
+    it('rolls back all three collections when one write fails', async () => {
+      const clinicId = new mongoose.Types.ObjectId();
+      const doctorId = new mongoose.Types.ObjectId();
+      const clinicStr = clinicId.toString();
+      const session = await mongoose.startSession();
+
+      const duplicateIntentId = `dup-intent-${Date.now()}`;
+      await PaymentRecordModel.create(buildPayment({ intentId: duplicateIntentId }));
+
+      await expect(
+        session.withTransaction(async () => {
+          const [patient] = await PatientModel.create([buildPatient({ clinicId })], { session });
+          await EncounterModel.create(
+            [buildEncounter({ clinicId, attendingDoctorId: doctorId, patientId: patient!._id as mongoose.Types.ObjectId })],
+            { session }
+          );
+          await PaymentRecordModel.create(
+            [buildPayment({ clinicId: clinicStr, intentId: duplicateIntentId })],
+            { session }
+          );
+        })
+      ).rejects.toThrow();
+
+      session.endSession();
+
+      expect(await PatientModel.countDocuments({ clinicId })).toBe(0);
+      expect(await EncounterModel.countDocuments({ clinicId })).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/__tests__/factories/encounter.factory.ts
+++ b/apps/api/src/__tests__/factories/encounter.factory.ts
@@ -1,0 +1,67 @@
+import mongoose from 'mongoose';
+import type { Encounter } from '@api/modules/encounters/encounter.model';
+
+let seq = 0;
+
+function nextSeq() {
+  return ++seq;
+}
+
+export function buildEncounter(overrides: Partial<Encounter> = {}): Partial<Encounter> {
+  const i = nextSeq();
+  return {
+    patientId: new mongoose.Types.ObjectId(),
+    clinicId: new mongoose.Types.ObjectId(),
+    attendingDoctorId: new mongoose.Types.ObjectId(),
+    chiefComplaint: `Chief complaint ${i}`,
+    status: 'open',
+    type: 'consultation',
+    isActive: true,
+    ...overrides,
+  };
+}
+
+export function buildEncounterWithVitals(overrides: Partial<Encounter> = {}): Partial<Encounter> {
+  return buildEncounter({
+    vitalSigns: {
+      bloodPressure: '120/80',
+      heartRate: 72,
+      temperature: 98.6,
+      respiratoryRate: 16,
+      oxygenSaturation: 98,
+      weight: 70,
+      height: 170,
+    },
+    ...overrides,
+  });
+}
+
+export function buildEncounterWithDiagnosis(overrides: Partial<Encounter> = {}): Partial<Encounter> {
+  return buildEncounter({
+    diagnosis: [
+      { code: 'J06.9', description: 'Acute upper respiratory infection', isPrimary: true },
+    ],
+    soapNotes: {
+      subjective: 'Patient reports sore throat and mild fever for 2 days.',
+      objective: 'Temp 100.4F, pharynx erythematous, no exudate.',
+      assessment: 'Viral upper respiratory infection.',
+      plan: 'Rest, fluids, OTC analgesics. Return if symptoms worsen.',
+    },
+    ...overrides,
+  });
+}
+
+export function buildEncounterWithBilling(overrides: Partial<Encounter> = {}): Partial<Encounter> {
+  return buildEncounter({
+    billing: {
+      cptCodes: [{ code: '99213', description: 'Office visit, established patient', units: 1, fee: '150.00' }],
+      billingStatus: 'unbilled',
+      totalFee: '150.00',
+    },
+    ...overrides,
+  });
+}
+
+export function buildEncounterBatch(count: number, overrides: Partial<Encounter> = {}): Partial<Encounter>[] {
+  return Array.from({ length: count }, () => buildEncounter(overrides));
+}

--- a/apps/api/src/__tests__/factories/index.ts
+++ b/apps/api/src/__tests__/factories/index.ts
@@ -1,0 +1,3 @@
+export * from './patient.factory';
+export * from './encounter.factory';
+export * from './payment.factory';

--- a/apps/api/src/__tests__/factories/patient.factory.ts
+++ b/apps/api/src/__tests__/factories/patient.factory.ts
@@ -1,0 +1,63 @@
+import mongoose from 'mongoose';
+import type { Patient, IAllergy, IEmergencyContact, IInsurance } from '@api/modules/patients/models/patient.model';
+
+let seq = 0;
+
+function nextSeq() {
+  return ++seq;
+}
+
+export function buildPatient(overrides: Partial<Patient> = {}): Omit<Patient, 'systemId'> & { systemId: string } {
+  const i = nextSeq();
+  return {
+    systemId: `PAT-TEST-${i}-${Date.now()}`,
+    firstName: 'Jane',
+    lastName: `Doe${i}`,
+    searchName: `jane doe${i}`,
+    dateOfBirth: '1990-05-15',
+    sex: 'F',
+    clinicId: new mongoose.Types.ObjectId(),
+    isActive: true,
+    allergies: [],
+    emergencyContacts: [],
+    insurance: [],
+    ...overrides,
+  } as any;
+}
+
+export function buildAllergy(overrides: Partial<IAllergy> = {}): Omit<IAllergy, '_id'> {
+  return {
+    allergen: 'Penicillin',
+    allergenType: 'drug',
+    reaction: 'Rash',
+    severity: 'moderate',
+    recordedBy: new mongoose.Types.ObjectId(),
+    recordedAt: new Date(),
+    isActive: true,
+    ...overrides,
+  };
+}
+
+export function buildEmergencyContact(overrides: Partial<IEmergencyContact> = {}): Omit<IEmergencyContact, '_id'> {
+  return {
+    name: 'John Doe',
+    relationship: 'Spouse',
+    phone: '555-000-0001',
+    isPrimary: true,
+    ...overrides,
+  };
+}
+
+export function buildInsurance(overrides: Partial<IInsurance> = {}): Omit<IInsurance, '_id'> {
+  return {
+    provider: 'BlueCross BlueShield',
+    policyNumber: `POL-${Date.now()}`,
+    coverageType: 'PPO',
+    isPrimary: true,
+    ...overrides,
+  };
+}
+
+export function buildPatientBatch(count: number, overrides: Partial<Patient> = {}) {
+  return Array.from({ length: count }, () => buildPatient(overrides));
+}

--- a/apps/api/src/__tests__/factories/payment.factory.ts
+++ b/apps/api/src/__tests__/factories/payment.factory.ts
@@ -1,0 +1,72 @@
+import mongoose from 'mongoose';
+import type { PaymentRecord } from '@api/modules/payments/models/payment-record.model';
+
+let seq = 0;
+
+function nextSeq() {
+  return ++seq;
+}
+
+export function buildPayment(overrides: Partial<PaymentRecord> = {}): Partial<PaymentRecord> {
+  const i = nextSeq();
+  return {
+    intentId: `intent-test-${i}-${Date.now()}`,
+    amount: '100.00',
+    destination: 'GDEST123456789ABCDEFGHIJKLMNOPQRS',
+    status: 'pending',
+    clinicId: new mongoose.Types.ObjectId().toString(),
+    assetCode: 'XLM',
+    paymentType: 'immediate',
+    feeStrategy: 'standard',
+    ...overrides,
+  };
+}
+
+export function buildConfirmedPayment(overrides: Partial<PaymentRecord> = {}): Partial<PaymentRecord> {
+  const i = nextSeq();
+  return buildPayment({
+    intentId: `intent-confirmed-${i}-${Date.now()}`,
+    status: 'confirmed',
+    txHash: `txhash-${i}-${Date.now()}`,
+    confirmedAt: new Date(),
+    ...overrides,
+  });
+}
+
+export function buildFailedPayment(overrides: Partial<PaymentRecord> = {}): Partial<PaymentRecord> {
+  const i = nextSeq();
+  return buildPayment({
+    intentId: `intent-failed-${i}-${Date.now()}`,
+    status: 'failed',
+    ...overrides,
+  });
+}
+
+export function buildEscrowPayment(overrides: Partial<PaymentRecord> = {}): Partial<PaymentRecord> {
+  const i = nextSeq();
+  const now = new Date();
+  return buildPayment({
+    intentId: `intent-escrow-${i}-${Date.now()}`,
+    paymentType: 'escrow',
+    claimableBalanceId: `claimable-${i}`,
+    claimableAfter: now,
+    claimableUntil: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
+    claimed: false,
+    ...overrides,
+  });
+}
+
+export function buildPaymentWithReceipt(overrides: Partial<PaymentRecord> = {}): Partial<PaymentRecord> {
+  return buildConfirmedPayment({
+    receiptNumber: `RCP-${Date.now()}`,
+    receiptUrl: 'https://receipts.example.com/rcp-001.pdf',
+    usdEquivalent: '100.00',
+    exchangeRate: '1.00',
+    receiptGeneratedAt: new Date(),
+    ...overrides,
+  });
+}
+
+export function buildPaymentBatch(count: number, overrides: Partial<PaymentRecord> = {}): Partial<PaymentRecord>[] {
+  return Array.from({ length: count }, () => buildPayment(overrides));
+}


### PR DESCRIPTION
## Summary

- Adds a reusable test data factory layer (`patient`, `encounter`, `payment`) with batch helpers and variant builders (vitals, billing, escrow, etc.)
- Adds database-specific test suite covering migrations (up/down/idempotency), queries (find/filter/paginate/aggregate), ACID transactions (atomicity, consistency, isolation, durability), and index effectiveness (existence + COLLSCAN prevention)

## Changes

**`apps/api/src/__tests__/factories/`**
- `patient.factory.ts` — patient, allergy, emergency contact, insurance builders
- `encounter.factory.ts` — encounter builders with vitals, diagnosis, billing variants
- `payment.factory.ts` — payment builders for pending, confirmed, failed, escrow, receipt variants
- `index.ts` — barrel export

**`apps/api/src/__tests__/database/`**
- `migrations.test.ts` — verifies 5 migrations run, are idempotent, and roll back cleanly
- `queries.test.ts` — covers find/filter/count/sort/paginate/aggregate on all three models
- `transactions.test.ts` — ACID guarantees: commit, rollback, isolation, durability, multi-doc
- `indexes.test.ts` — verifies index presence, unique constraints, and absence of COLLSCAN

## Test plan

- [ ] `npm test` passes in `apps/api`
- [ ] Factories produce consistent, schema-valid data
- [ ] Migration tests cover up, down, and idempotent re-runs
- [ ] Transaction tests confirm rollback on failure and durability after reconnect
- [ ] Index tests confirm queries use indexes (not COLLSCAN)

closes #909
closes #908