### PR TITLE
feat(auth): explicit JWT claim validation with typed error codes

### DIFF
--- a/apps/api/src/modules/auth/jwt-claim-validator.test.ts
+++ b/apps/api/src/modules/auth/jwt-claim-validator.test.ts
@@ -1,0 +1,213 @@
+import jwt from 'jsonwebtoken';
+import {
+  validateJwtClaims,
+  validateAccessTokenClaims,
+  validateRefreshTokenClaims,
+} from './jwt-claim-validator';
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      tempTokenSecret: 'test-temp-secret',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+  },
+}));
+
+const SECRET = 'test-access-secret-32-chars-long!!';
+const ISSUER = 'health-watchers-api';
+const AUDIENCE = 'health-watchers-client';
+
+function makeToken(payload: object, secret = SECRET, options: jwt.SignOptions = {}): string {
+  return jwt.sign(payload, secret, {
+    expiresIn: '15m',
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    ...options,
+  });
+}
+
+describe('validateJwtClaims', () => {
+  const basePayload = { userId: 'user-1', role: 'DOCTOR', clinicId: 'clinic-1' };
+
+  describe('valid token', () => {
+    it('returns valid=true with payload for a correctly signed token', () => {
+      const token = makeToken(basePayload);
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(result.payload).toMatchObject(basePayload);
+    });
+  });
+
+  describe('issuer (iss) validation', () => {
+    it('returns MISSING_ISSUER when token has no iss claim', () => {
+      const token = jwt.sign(basePayload, SECRET, {
+        expiresIn: '15m',
+        audience: AUDIENCE,
+      });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('MISSING_ISSUER');
+    });
+
+    it('returns INVALID_ISSUER when token iss does not match expected issuer', () => {
+      const token = makeToken(basePayload, SECRET, { issuer: 'rogue-service' });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('INVALID_ISSUER');
+    });
+
+    it('rejects tokens from other services even when they share the same secret', () => {
+      const token = makeToken(
+        { userId: 'attacker', role: 'SUPER_ADMIN', clinicId: 'any' },
+        SECRET,
+        { issuer: 'other-service' }
+      );
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('INVALID_ISSUER');
+    });
+  });
+
+  describe('audience (aud) validation', () => {
+    it('returns MISSING_AUDIENCE when token has no aud claim', () => {
+      const token = jwt.sign(basePayload, SECRET, {
+        expiresIn: '15m',
+        issuer: ISSUER,
+      });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('MISSING_AUDIENCE');
+    });
+
+    it('returns INVALID_AUDIENCE when token aud does not match expected audience', () => {
+      const token = makeToken(basePayload, SECRET, { audience: 'wrong-client' });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('INVALID_AUDIENCE');
+    });
+
+    it('rejects tokens with multiple audiences when the expected one is absent', () => {
+      const token = jwt.sign(basePayload, SECRET, {
+        expiresIn: '15m',
+        issuer: ISSUER,
+        audience: ['other-client-a', 'other-client-b'],
+      });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('INVALID_AUDIENCE');
+    });
+  });
+
+  describe('expiry (exp) validation', () => {
+    it('returns MISSING_EXPIRY when token has no exp claim', () => {
+      const token = jwt.sign(basePayload, SECRET, {
+        issuer: ISSUER,
+        audience: AUDIENCE,
+      });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('MISSING_EXPIRY');
+    });
+
+    it('returns TOKEN_EXPIRED for tokens whose exp is in the past', () => {
+      const token = makeToken(basePayload, SECRET, { expiresIn: '-1s' });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('TOKEN_EXPIRED');
+    });
+  });
+
+  describe('signature verification', () => {
+    it('returns INVALID_SIGNATURE when signature is tampered', () => {
+      const token = makeToken(basePayload);
+      const tampered = token.slice(0, -10) + 'AAAAAAAAAA';
+      const result = validateJwtClaims(tampered, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('INVALID_SIGNATURE');
+    });
+
+    it('returns INVALID_SIGNATURE when a different secret is used', () => {
+      const token = jwt.sign(basePayload, 'some-other-secret', {
+        expiresIn: '15m',
+        issuer: ISSUER,
+        audience: AUDIENCE,
+      });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('INVALID_SIGNATURE');
+    });
+  });
+
+  describe('malformed token', () => {
+    it('returns MALFORMED_TOKEN for a completely invalid token string', () => {
+      const result = validateJwtClaims('not.a.jwt', SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('MALFORMED_TOKEN');
+    });
+
+    it('returns MALFORMED_TOKEN for an empty string', () => {
+      const result = validateJwtClaims('', SECRET, ISSUER, AUDIENCE);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('MALFORMED_TOKEN');
+    });
+  });
+
+  describe('claim priority order', () => {
+    it('reports MISSING_ISSUER before MISSING_AUDIENCE when both are absent', () => {
+      const token = jwt.sign(basePayload, SECRET, { expiresIn: '15m' });
+      const result = validateJwtClaims(token, SECRET, ISSUER, AUDIENCE);
+      expect(result.error).toBe('MISSING_ISSUER');
+    });
+  });
+});
+
+describe('validateAccessTokenClaims', () => {
+  it('validates a correctly minted access token', () => {
+    const token = jwt.sign(
+      { userId: 'u1', role: 'NURSE', clinicId: 'c1', jti: 'abc' },
+      'test-access-secret-32-chars-long!!',
+      { expiresIn: '15m', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    );
+    const result = validateAccessTokenClaims(token);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an access token signed with the refresh secret', () => {
+    const token = jwt.sign(
+      { userId: 'u1', role: 'NURSE', clinicId: 'c1', jti: 'abc' },
+      'test-refresh-secret-32-chars-long!',
+      { expiresIn: '15m', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    );
+    const result = validateAccessTokenClaims(token);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('INVALID_SIGNATURE');
+  });
+});
+
+describe('validateRefreshTokenClaims', () => {
+  it('validates a correctly minted refresh token', () => {
+    const token = jwt.sign(
+      { userId: 'u1', role: 'NURSE', clinicId: 'c1', jti: 'xyz', family: 'fam1' },
+      'test-refresh-secret-32-chars-long!',
+      { expiresIn: '7d', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    );
+    const result = validateRefreshTokenClaims(token);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a refresh token signed with the access secret', () => {
+    const token = jwt.sign(
+      { userId: 'u1', role: 'NURSE', clinicId: 'c1', jti: 'xyz', family: 'fam1' },
+      'test-access-secret-32-chars-long!!',
+      { expiresIn: '7d', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    );
+    const result = validateRefreshTokenClaims(token);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('INVALID_SIGNATURE');
+  });
+});

--- a/apps/api/src/modules/auth/jwt-claim-validator.ts
+++ b/apps/api/src/modules/auth/jwt-claim-validator.ts
@@ -1,0 +1,111 @@
+import jwt from 'jsonwebtoken';
+import { config } from '@health-watchers/config';
+
+export type JwtClaimError =
+  | 'MISSING_ISSUER'
+  | 'INVALID_ISSUER'
+  | 'MISSING_AUDIENCE'
+  | 'INVALID_AUDIENCE'
+  | 'TOKEN_EXPIRED'
+  | 'MISSING_EXPIRY'
+  | 'INVALID_SIGNATURE'
+  | 'MALFORMED_TOKEN'
+  | 'MISSING_JTI';
+
+export interface JwtValidationResult {
+  valid: boolean;
+  error?: JwtClaimError;
+  payload?: jwt.JwtPayload;
+}
+
+/**
+ * Validates all required JWT claims explicitly.
+ * Checks iss, aud, exp, and signature independently
+ * so failures can be diagnosed with a specific error code.
+ */
+export function validateJwtClaims(
+  token: string,
+  secret: string,
+  expectedIssuer: string,
+  expectedAudience: string
+): JwtValidationResult {
+  // First decode without verification to inspect claims before signature check
+  let decoded: jwt.Jwt | null;
+  try {
+    decoded = jwt.decode(token, { complete: true });
+  } catch {
+    return { valid: false, error: 'MALFORMED_TOKEN' };
+  }
+
+  if (!decoded || typeof decoded.payload === 'string') {
+    return { valid: false, error: 'MALFORMED_TOKEN' };
+  }
+
+  const payload = decoded.payload as jwt.JwtPayload;
+
+  // Validate issuer claim
+  if (!payload.iss) {
+    return { valid: false, error: 'MISSING_ISSUER' };
+  }
+  if (payload.iss !== expectedIssuer) {
+    return { valid: false, error: 'INVALID_ISSUER' };
+  }
+
+  // Validate audience claim
+  const aud = Array.isArray(payload.aud) ? payload.aud : payload.aud ? [payload.aud] : [];
+  if (aud.length === 0) {
+    return { valid: false, error: 'MISSING_AUDIENCE' };
+  }
+  if (!aud.includes(expectedAudience)) {
+    return { valid: false, error: 'INVALID_AUDIENCE' };
+  }
+
+  // Validate expiry claim presence
+  if (payload.exp === undefined || payload.exp === null) {
+    return { valid: false, error: 'MISSING_EXPIRY' };
+  }
+
+  // Validate expiry (exp)
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (payload.exp <= nowSeconds) {
+    return { valid: false, error: 'TOKEN_EXPIRED' };
+  }
+
+  // Verify signature (this also re-checks iss, aud, exp via the library)
+  try {
+    const verified = jwt.verify(token, secret, {
+      issuer: expectedIssuer,
+      audience: expectedAudience,
+    }) as jwt.JwtPayload;
+    return { valid: true, payload: verified };
+  } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      return { valid: false, error: 'TOKEN_EXPIRED' };
+    }
+    return { valid: false, error: 'INVALID_SIGNATURE' };
+  }
+}
+
+/**
+ * Validates an access token using the configured issuer and audience.
+ */
+export function validateAccessTokenClaims(token: string): JwtValidationResult {
+  return validateJwtClaims(
+    token,
+    config.jwt.accessTokenSecret,
+    config.jwt.issuer,
+    config.jwt.audience
+  );
+}
+
+/**
+ * Validates a refresh token using the configured issuer and audience.
+ */
+export function validateRefreshTokenClaims(token: string): JwtValidationResult {
+  return validateJwtClaims(
+    token,
+    config.jwt.refreshTokenSecret,
+    config.jwt.issuer,
+    config.jwt.audience
+  );
+}


### PR DESCRIPTION
Closes #913

## Summary

- Adds `jwt-claim-validator.ts` — a dedicated validator that checks each JWT claim (`iss`, `aud`, `exp`) **before** calling `jwt.verify()`, and returns a typed `JwtClaimError` discriminant so callers can distinguish between a missing issuer, an invalid audience, an expired token, or a bad signature.
- Exports `validateAccessTokenClaims` and `validateRefreshTokenClaims` helpers that use the application's configured issuer/audience automatically.
- Adds `jwt-claim-validator.test.ts` with 16 unit tests covering valid tokens, each invalid-claim scenario, token-confusion attacks (same secret, different iss/aud), multi-audience rejection, and malformed input.

## Test plan

- [ ] `npm test --workspace=api` passes (new tests are picked up by the existing Jest config)
- [ ] All 16 new tests in `jwt-claim-validator.test.ts` pass
- [ ] Existing token-service tests continue to pass (no production code changed)
- [ ] CI green