### PR TITLE
feat(security): CSRF tests, CSP reporting, HIPAA PHI report, anonymiz…

### DIFF
--- a/apps/api/src/__tests__/security-headers.test.ts
+++ b/apps/api/src/__tests__/security-headers.test.ts
@@ -14,4 +14,106 @@ describe('Security headers', () => {
     expect(response.headers['content-security-policy']).toContain("frame-ancestors 'none'");
     expect(response.headers['x-powered-by']).toBeUndefined();
   });
+
+  describe('Content-Security-Policy directives', () => {
+    let csp: string;
+
+    beforeAll(async () => {
+      const response = await request(app).get('/health');
+      csp = response.headers['content-security-policy'] as string;
+    });
+
+    it('restricts default-src to self', () => {
+      expect(csp).toContain("default-src 'self'");
+    });
+
+    it('restricts script-src to self', () => {
+      expect(csp).toContain("script-src 'self'");
+    });
+
+    it('restricts style-src to self with unsafe-inline', () => {
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    });
+
+    it('restricts img-src to self and data URIs', () => {
+      expect(csp).toContain("img-src 'self' data:");
+    });
+
+    it('restricts connect-src to self', () => {
+      expect(csp).toContain("connect-src 'self'");
+    });
+
+    it('restricts font-src to self', () => {
+      expect(csp).toContain("font-src 'self'");
+    });
+
+    it('blocks object-src entirely', () => {
+      expect(csp).toContain("object-src 'none'");
+    });
+
+    it('blocks frame embedding via frame-ancestors', () => {
+      expect(csp).toContain("frame-ancestors 'none'");
+    });
+
+    it('includes report-uri for violation reporting', () => {
+      expect(csp).toContain('report-uri /api/v1/csp-report');
+    });
+  });
+
+  describe('HSTS header', () => {
+    let hsts: string;
+
+    beforeAll(async () => {
+      const response = await request(app).get('/health');
+      hsts = response.headers['strict-transport-security'] as string;
+    });
+
+    it('sets max-age to one year', () => {
+      expect(hsts).toContain('max-age=31536000');
+    });
+
+    it('includes includeSubDomains', () => {
+      expect(hsts).toContain('includeSubDomains');
+    });
+
+    it('includes preload', () => {
+      expect(hsts).toContain('preload');
+    });
+  });
+
+  describe('CSP violation reporting endpoint', () => {
+    it('accepts CSP reports and returns 204', async () => {
+      const report = {
+        'csp-report': {
+          'document-uri': 'https://example.com/',
+          'violated-directive': 'script-src',
+          'blocked-uri': 'https://evil.com/script.js',
+        },
+      };
+
+      const response = await request(app)
+        .post('/api/v1/csp-report')
+        .set('Content-Type', 'application/csp-report')
+        .send(JSON.stringify(report));
+
+      expect(response.status).toBe(204);
+    });
+
+    it('accepts JSON-formatted CSP reports', async () => {
+      const report = {
+        'csp-report': {
+          'document-uri': 'https://example.com/',
+          'violated-directive': 'img-src',
+          'blocked-uri': 'data:',
+        },
+      };
+
+      const response = await request(app)
+        .post('/api/v1/csp-report')
+        .set('Content-Type', 'application/json')
+        .send(report);
+
+      expect(response.status).toBe(204);
+    });
+  });
 });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -129,6 +129,7 @@ import { requestIdPropagationMiddleware } from './middlewares/request-id-propaga
 import { correlationMiddleware } from './middlewares/correlation.middleware';
 import { breachIncidentRoutes } from './modules/breach-incidents/breach-incidents.controller';
 import { backupHealthRoutes } from './modules/health/backup-health.controller';
+import { cspReportRoutes } from './modules/security/csp-report.controller';
 
 const app = express();
 const server = createServer(app);
@@ -152,6 +153,7 @@ app.use(
         fontSrc: ["'self'"],
         objectSrc: ["'none'"],
         frameAncestors: ["'none'"],
+        reportUri: ['/api/v1/csp-report'],
       },
     },
     hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
@@ -228,11 +230,12 @@ app.use(csrfMiddleware);
 
 // ── Content-Type validation (issue #351) ──────────────────────────────────────
 // Reject non-JSON bodies on mutating requests (POST/PUT/PATCH)
-// Bypass for multipart/form-data routes (e.g. CSV import)
+// Bypass for multipart/form-data routes (e.g. CSV import) and CSP violation reports
 const MULTIPART_BYPASS = ['/api/v1/patients/import', '/api/v1/patients/'];
 app.use((req, res, next) => {
   if (['POST', 'PUT', 'PATCH'].includes(req.method) && req.headers['content-length'] !== '0') {
     if (MULTIPART_BYPASS.some((p) => req.path.startsWith(p))) return next();
+    if (req.path.startsWith('/api/v1/csp-report')) return next();
     if (!req.is('application/json') && !req.is('application/x-www-form-urlencoded')) {
       return res
         .status(415)
@@ -313,6 +316,9 @@ app.use('/api/v1/pre-auth', paymentLimiter, preAuthRoutes);
 app.use('/api/v1/peer-reviews', peerReviewsRouter);
 app.use('/api/v1/compliance', complianceRoutes);
 app.use('/api/v1/admin/breach-incidents', breachIncidentRoutes);
+
+// ── CSP violation reporting (public, no auth, no CSRF) ───────────────────────
+app.use('/api/v1/csp-report', cspReportRoutes);
 
 // ── Stellar federation (public, no auth) ──────────────────────────────────────
 app.use('/.well-known', federationRouter);

--- a/apps/api/src/middlewares/__tests__/csrf.middleware.test.ts
+++ b/apps/api/src/middlewares/__tests__/csrf.middleware.test.ts
@@ -24,6 +24,8 @@ describe('csrfMiddleware', () => {
   const next = jest.fn() as unknown as NextFunction;
   beforeEach(() => jest.clearAllMocks());
 
+  // ── Safe methods bypass ────────────────────────────────────────────────────
+
   it('allows GET requests without CSRF token', () => {
     const req = makeReq({ method: 'GET', cookies: { 'csrf-token': 'abc' } });
     const res = makeRes();
@@ -31,6 +33,74 @@ describe('csrfMiddleware', () => {
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
   });
+
+  it('allows HEAD requests without CSRF token', () => {
+    const req = makeReq({ method: 'HEAD', cookies: { 'csrf-token': 'abc' } });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows OPTIONS requests without CSRF token', () => {
+    const req = makeReq({ method: 'OPTIONS', cookies: { 'csrf-token': 'abc' } });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  // ── Auth route bypass ──────────────────────────────────────────────────────
+
+  it('bypasses CSRF check for /api/v1/auth/login', () => {
+    const req = makeReq({
+      method: 'POST',
+      path: '/api/v1/auth/login',
+      cookies: {},
+      headers: {},
+    });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('bypasses CSRF check for /api/v1/auth/register', () => {
+    const req = makeReq({
+      method: 'POST',
+      path: '/api/v1/auth/register',
+      cookies: {},
+      headers: {},
+    });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  // ── Token generation ───────────────────────────────────────────────────────
+
+  it('generates and sets csrf-token cookie when none exists on GET', () => {
+    const req = makeReq({ method: 'GET', cookies: {} });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(res.cookie).toHaveBeenCalledWith(
+      'csrf-token',
+      expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect.objectContaining({ httpOnly: false, sameSite: 'strict' })
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not overwrite existing csrf-token cookie on GET', () => {
+    const req = makeReq({ method: 'GET', cookies: { 'csrf-token': 'existing' } });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  // ── Mutating method validation ─────────────────────────────────────────────
 
   it('rejects POST without X-CSRF-Token header (returns 403)', () => {
     const req = makeReq({
@@ -66,5 +136,51 @@ describe('csrfMiddleware', () => {
     csrfMiddleware(req, res, next);
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects PUT without X-CSRF-Token header', () => {
+    const req = makeReq({
+      method: 'PUT',
+      cookies: { 'csrf-token': 'tok' },
+      headers: {},
+    });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('rejects DELETE without X-CSRF-Token header', () => {
+    const req = makeReq({
+      method: 'DELETE',
+      cookies: { 'csrf-token': 'tok' },
+      headers: {},
+    });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('rejects PATCH without X-CSRF-Token header', () => {
+    const req = makeReq({
+      method: 'PATCH',
+      cookies: { 'csrf-token': 'tok' },
+      headers: {},
+    });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns CSRF_TOKEN_INVALID error code on rejection', () => {
+    const req = makeReq({
+      method: 'POST',
+      cookies: { 'csrf-token': 'tok' },
+      headers: {},
+    });
+    const res = makeRes();
+    csrfMiddleware(req, res, next);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'CSRF_TOKEN_INVALID' })
+    );
   });
 });

--- a/apps/api/src/middlewares/csrf.middleware.ts
+++ b/apps/api/src/middlewares/csrf.middleware.ts
@@ -29,8 +29,13 @@ export function csrfMiddleware(req: Request, res: Response, next: NextFunction):
     return next();
   }
 
-  // Skip CSRF check for auth endpoints (login/register) since no session exists yet
-  if (req.path.startsWith('/api/v1/auth/login') || req.path.startsWith('/api/v1/auth/register')) {
+  // Skip CSRF check for auth endpoints (login/register) since no session exists yet,
+  // and for CSP reports which are browser-generated with no user session.
+  if (
+    req.path.startsWith('/api/v1/auth/login') ||
+    req.path.startsWith('/api/v1/auth/register') ||
+    req.path.startsWith('/api/v1/csp-report')
+  ) {
     return next();
   }
 

--- a/apps/api/src/modules/audit/audit.controller.ts
+++ b/apps/api/src/modules/audit/audit.controller.ts
@@ -312,4 +312,110 @@ router.get('/export', authenticate, async (req: Request, res: Response) => {
   }
 });
 
+// PHI access actions per HIPAA §164.312(b) audit controls
+const PHI_ACTIONS = [
+  'PATIENT_VIEW',
+  'PATIENT_CREATE',
+  'PATIENT_UPDATE',
+  'PATIENT_DELETE',
+  'ENCOUNTER_VIEW',
+  'ENCOUNTER_CREATE',
+  'ENCOUNTER_UPDATE',
+  'PATIENT_PHOTO_UPLOAD',
+  'PATIENT_PHOTO_ACCESS',
+  'PATIENT_PHOTO_DELETE',
+  'EXPORT_PATIENT_DATA',
+  'DATA_EXPORT_REQUEST',
+  'DATA_EXPORT_FULFILLED',
+] as const;
+
+/**
+ * @swagger
+ * /audit-logs/hipaa-report:
+ *   get:
+ *     summary: HIPAA PHI access report — all PHI-touching actions grouped by user (SUPER_ADMIN only)
+ *     tags: [Audit]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: dateFrom
+ *         schema: { type: string, format: date-time }
+ *       - in: query
+ *         name: dateTo
+ *         schema: { type: string, format: date-time }
+ *       - in: query
+ *         name: clinicId
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: HIPAA PHI access report
+ */
+router.get('/hipaa-report', authenticate, async (req: Request, res: Response) => {
+  if (req.user?.role !== 'SUPER_ADMIN') {
+    return res.status(403).json({ error: 'Forbidden', message: 'SUPER_ADMIN role required' });
+  }
+
+  const match: Record<string, unknown> = { action: { $in: PHI_ACTIONS } };
+  if (req.query.clinicId) match.clinicId = new Types.ObjectId(req.query.clinicId as string);
+  if (req.query.dateFrom || req.query.dateTo) {
+    const range: Record<string, Date> = {};
+    if (req.query.dateFrom) range.$gte = new Date(req.query.dateFrom as string);
+    if (req.query.dateTo) range.$lte = new Date(req.query.dateTo as string);
+    match.timestamp = range;
+  }
+
+  try {
+    const [byUser, byAction, totals] = await Promise.all([
+      AuditLogModel.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: '$userId',
+            accessCount: { $sum: 1 },
+            actions: { $addToSet: '$action' },
+            lastAccess: { $max: '$timestamp' },
+          },
+        },
+        { $sort: { accessCount: -1 } },
+        { $limit: 100 },
+      ]),
+      AuditLogModel.aggregate([
+        { $match: match },
+        { $group: { _id: '$action', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ]),
+      AuditLogModel.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            failures: { $sum: { $cond: [{ $eq: ['$outcome', 'FAILURE'] }, 1, 0] } },
+          },
+        },
+      ]),
+    ]);
+
+    return res.json({
+      status: 'success',
+      data: {
+        summary: totals[0] ?? { total: 0, failures: 0 },
+        byAction: byAction.map((r) => ({ action: r._id, count: r.count })),
+        byUser: byUser.map((r) => ({
+          userId: r._id,
+          accessCount: r.accessCount,
+          actions: r.actions,
+          lastAccess: r.lastAccess,
+        })),
+      },
+    });
+  } catch (error) {
+    logger.error({ err: error }, 'Error generating HIPAA PHI report');
+    return res
+      .status(500)
+      .json({ error: 'InternalServerError', message: 'Failed to generate HIPAA report' });
+  }
+});
+
 export const auditRoutes = router;

--- a/apps/api/src/modules/security/csp-report.controller.ts
+++ b/apps/api/src/modules/security/csp-report.controller.ts
@@ -1,0 +1,49 @@
+import express, { Request, Response, Router } from 'express';
+import logger from '../../utils/logger';
+
+const router = Router();
+
+const cspBodyParser = express.json({
+  type: ['application/json', 'application/csp-report'],
+});
+
+/**
+ * @swagger
+ * /csp-report:
+ *   post:
+ *     summary: Receive Content Security Policy violation reports
+ *     tags: [Security]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/csp-report:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               csp-report:
+ *                 type: object
+ *     responses:
+ *       204:
+ *         description: Report received
+ */
+router.post('/', cspBodyParser, (req: Request, res: Response) => {
+  const report = req.body?.['csp-report'] ?? req.body;
+
+  logger.warn(
+    {
+      type: 'CSP_VIOLATION',
+      documentUri: report?.['document-uri'],
+      violatedDirective: report?.['violated-directive'],
+      blockedUri: report?.['blocked-uri'],
+      referrer: report?.['referrer'],
+      ip:
+        (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ??
+        req.socket.remoteAddress,
+    },
+    'CSP violation reported'
+  );
+
+  res.status(204).end();
+});
+
+export const cspReportRoutes = router;


### PR DESCRIPTION
…ation validation

Closes #918 — CSRF: expands test coverage to include HEAD/OPTIONS safe-method bypass, auth-route bypass, token generation on first request, and mutating-method (PUT/DELETE/PATCH) validation with correct CSRF_TOKEN_INVALID error code. Also adds /api/v1/csp-report to the CSRF bypass list since browser CSP reports carry no user session.

Closes #919 — CSP: adds a /api/v1/csp-report POST endpoint (application/csp-report and application/json) that logs violations via pino and returns 204. Wires report-uri into the helmet CSP directives. Expands security-headers tests to assert every directive (script-src, style-src, img-src, connect-src, font-src, object-src, frame-ancestors, report-uri) and all HSTS fields (max-age, includeSubDomains, preload). Adds content-type bypass so the 415 middleware does not reject CSP reports.

Closes #920 — HIPAA: adds GET /audit-logs/hipaa-report (SUPER_ADMIN) that aggregates PHI-touching actions (PATIENT_VIEW, ENCOUNTER_VIEW, EXPORT_PATIENT_DATA, etc.) and returns a summary of total/failure counts, a breakdown by action, and per-user access counts with last-access timestamp — satisfying HIPAA §164.312(b) audit controls.

Closes #921 — Anonymization: implementation and comprehensive tests (18 HIPAA Safe Harbor identifiers, de-identification, pseudonymization, aggregation, property-based PII pattern tests, performance benchmarks, audit log creation) were already complete in packages/anonymize; no further changes required.

closes #918 closes #919 closes #920 closes #921