### PR TITLE
fix(ci): run accessibility tests from web workspace

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -54,7 +54,7 @@ jobs:
           npx wait-on http://localhost:3000 http://localhost:3001 --timeout 60000
 
       - name: Run accessibility tests
-        run: npm run test:a11y
+        run: npm run test:a11y --workspace=web
         env:
           PLAYWRIGHT_JUNIT_OUTPUT_NAME: accessibility-results.xml
 
@@ -64,14 +64,15 @@ jobs:
         with:
           name: accessibility-test-results
           path: |
-            accessibility-results.xml
+            apps/web/accessibility-results.xml
+            apps/web/playwright-a11y-report/
             test-results/
 
       - name: Publish test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@567cc7f8dcea3537eb1537e6f3ef671cead07cc4 # v2.18.0
         with:
-          files: accessibility-results.xml
+          files: apps/web/accessibility-results.xml
           check_name: Accessibility Test Results
 
       - name: Fail if violations found


### PR DESCRIPTION
# PR Draft: Run accessibility tests from the web workspace

Target issue: https://github.com/Health-watchers/health_watchers/issues/1036

## Title

fix(ci): run accessibility tests from web workspace

## Summary

- run the existing `test:a11y` script through the `web` npm workspace
- upload the JUnit accessibility result from `apps/web/accessibility-results.xml`
- include the generated Playwright accessibility HTML report folder in the workflow artifact

## Why

The repository already has an automated accessibility suite in `apps/web/tests/accessibility.spec.ts` and a workspace script:

```bash
npm run test:a11y --workspace=web
```

But the accessibility workflow currently runs `npm run test:a11y` from the monorepo root. The root `package.json` does not define that script, so the workflow cannot invoke the existing web accessibility tests as intended.

## Verification

```bash
npm ci
npm run test:a11y --workspace=web -- --list
npx prettier --check .github/workflows/accessibility.yml
git diff --check -- .github/workflows/accessibility.yml
```

Observed:

- Playwright listed 25 accessibility tests from `apps/web/tests/accessibility.spec.ts`.
- Prettier passed for `.github/workflows/accessibility.yml`.
- `git diff --check` passed for the workflow file.

## Scope Notes

- This PR only fixes the accessibility workflow command and report paths.
- It does not change application code or the accessibility test assertions.
- Full test execution still depends on the workflow starting the API and web servers.
