### PR TITLE
feat(devops): docs/devops issue wave (#1014, #1015, #1016, #1017)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,22 +72,21 @@ reports/
 # Pact contract test artifacts
 pacts/*.json
 
-# Jest snapshots (auto-generated, should not be committed unless intentional)
-**/__snapshots__/
-
 # Playwright artifacts
-playwright-report/
-test-results/
 .playwright/
 
 # Stryker mutation testing
-.stryker-tmp/
-reports/
 stryker-report/
 
 # k6 performance test results
 k6-results/
 performance/results/
+
+# DevOps script report/log output (generated at run time, not source)
+backup-verification-report.json
+*-verification-report.json
+blue-green-deployment.log
+rollback-deployment.log
 
 # =============================================================================
 # TypeScript

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,6 +252,46 @@ User Role → Permission Set → Resource Access
 └──────────────────┘
 ```
 
+### Authentication Flow
+
+```
+┌─────────────┐
+│   Client    │
+└──────┬──────┘
+       │ POST /auth/login (email, password)
+       ↓
+┌──────────────────┐
+│   API Gateway    │
+└────────┬──────────┘
+         │
+         ↓
+┌───────────────────┐
+│   Express API     │
+├───────────────────┤
+│ - Verify password │
+│ - Check MFA       │
+│ - Issue JWT + RT  │
+└────────┬──────────┘
+         │ Read/Write
+         ↓
+┌───────────────────┐
+│     MongoDB       │
+├───────────────────┤
+│ users collection  │
+└────────┬──────────┘
+         │ Audit event
+         ↓
+┌───────────────────┐
+│     RabbitMQ       │
+├───────────────────┤
+│ Audit log entry   │
+└───────────────────┘
+
+Response: { accessToken (15m), refreshToken (7d) }
+Subsequent requests: Authorization: Bearer <accessToken>
+Expired token → POST /auth/refresh using refreshToken
+```
+
 ## Deployment Architecture
 
 ### Kubernetes Topology
@@ -300,6 +340,11 @@ After validation:
 Traffic switches to Green
 Blue becomes Standby
 ```
+
+Both slots run full replica counts at all times so traffic only switches once
+the new slot reports healthy, giving zero-downtime cutover and an instant
+rollback path. See [docs/BLUE_GREEN_DEPLOYMENT.md](BLUE_GREEN_DEPLOYMENT.md)
+for the full runbook and `k8s/api/blue-green/` for the manifests.
 
 ## Integration Points
 

--- a/docs/BLUE_GREEN_DEPLOYMENT.md
+++ b/docs/BLUE_GREEN_DEPLOYMENT.md
@@ -1,0 +1,86 @@
+# Blue-Green Deployment
+
+**Health Watchers — Zero-Downtime API Releases**
+
+## Overview
+
+Blue-green deployment runs two identical production slots (`blue` and `green`)
+of the API side by side. Only one slot receives live traffic at a time. A
+release rolls the *inactive* slot, verifies it's healthy, then switches the
+load-balancing Service to point at it — giving zero-downtime cutover and an
+instant rollback path if the new version misbehaves.
+
+This is an alternative to the default rolling-update strategy used by
+`k8s/api/deployment.yaml`. Use it for releases that need an instant,
+traffic-level rollback (schema-sensitive changes, high-risk releases) rather
+than a pod-by-pod rolling restart.
+
+## Components
+
+1. **Blue/Green Deployments** (`k8s/api/blue-green/deployment-blue.yaml`,
+   `deployment-green.yaml`) — two independent Deployments, `api-blue` and
+   `api-green`, each running the full replica count so either can take 100%
+   of traffic.
+2. **Switchable Service** (`k8s/api/blue-green/service.yaml`) — `api-service`,
+   a ClusterIP Service whose selector includes `version: blue|green`. Flipping
+   that label is what moves traffic between slots.
+3. **Deployment script** (`ops/blue-green-deployment.sh`) — rolls the inactive
+   slot to a new image, waits for it to become healthy, then switches
+   `api-service` to it.
+4. **Rollback script** (`ops/rollback-deployment.sh`) — flips `api-service`
+   back to the previous slot.
+5. **Test suites** (`ops/test-blue-green-deployment.sh`,
+   `k8s/test-cert-manager.sh` pattern) — validate the slot-selection and
+   rollback logic without touching a live cluster.
+
+## One-time Setup
+
+```bash
+kubectl apply -f k8s/api/blue-green/
+```
+
+By default `api-service` selects `version: blue`, matching the initial state
+of `api-blue`. Point the ingress `api` backend paths (`k8s/ingress.yaml`) at
+`api-service` instead of `api` to route live traffic through the switchable
+Service. Leave the standalone `api` Deployment/Service in place if you also
+want the option to fall back to plain rolling updates.
+
+## Releasing
+
+```bash
+# Deploy a new image to the inactive slot and switch traffic to it
+./ops/blue-green-deployment.sh api ghcr.io/chisom92/health-watchers-api:v2.1 health-watchers
+```
+
+Flow:
+
+```
+1. Determine active slot (blue or green) from api-service selector
+2. Roll the inactive slot to the new image, wait for rollout to finish
+3. Verify readyReplicas == desired replicas on the inactive slot
+4. Switch api-service selector to the inactive (now-updated) slot
+5. Previous slot stays running, unchanged, as an instant rollback target
+```
+
+Traffic is never routed to a slot until its rollout has fully completed and
+its replicas report ready — there is no window where the Service points at a
+partially-updated deployment, so cutover is zero-downtime.
+
+## Rolling Back
+
+```bash
+./ops/rollback-deployment.sh api health-watchers
+```
+
+This flips `api-service` back to whichever slot was previously active. No
+redeploy is required — the old slot's pods were never scaled down, so
+rollback is just a Service selector patch and takes effect immediately.
+
+## Testing
+
+```bash
+./ops/test-blue-green-deployment.sh
+```
+
+Validates slot-selection, health-check, traffic-switch and rollback logic in
+isolation (no cluster required).

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -8,6 +8,7 @@ This guide covers deploying Health Watchers to production environments using Doc
 - [Docker Deployment](#docker-deployment)
 - [Docker Compose Deployment](#docker-compose-deployment)
 - [Kubernetes Deployment](#kubernetes-deployment)
+- [Blue-Green Deployment](../docs/BLUE_GREEN_DEPLOYMENT.md)
 - [Health Checks](#health-checks)
 - [Troubleshooting](#troubleshooting)
 - [Runbooks](#runbooks)

--- a/k8s/api/blue-green/deployment-blue.yaml
+++ b/k8s/api/blue-green/deployment-blue.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-blue
+  namespace: health-watchers
+  labels:
+    app.kubernetes.io/name: health-watchers
+    app.kubernetes.io/component: api
+    version: blue
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+      version: blue
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: api
+        version: blue
+        app.kubernetes.io/name: health-watchers
+        app.kubernetes.io/component: api
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: api
+          image: ghcr.io/chisom92/health-watchers-api:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+          resources:
+            requests:
+              memory: '128Mi'
+              cpu: '125m'
+            limits:
+              memory: '256Mi'
+              cpu: '250m'
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health/startup
+              port: 3001
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 24
+          envFrom:
+            - configMapRef:
+                name: health-watchers-config
+            - secretRef:
+                name: health-watchers-secrets
+          env:
+            - name: PORT
+              value: '3001'
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL

--- a/k8s/api/blue-green/deployment-green.yaml
+++ b/k8s/api/blue-green/deployment-green.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-green
+  namespace: health-watchers
+  labels:
+    app.kubernetes.io/name: health-watchers
+    app.kubernetes.io/component: api
+    version: green
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+      version: green
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: api
+        version: green
+        app.kubernetes.io/name: health-watchers
+        app.kubernetes.io/component: api
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: api
+          image: ghcr.io/chisom92/health-watchers-api:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+          resources:
+            requests:
+              memory: '128Mi'
+              cpu: '125m'
+            limits:
+              memory: '256Mi'
+              cpu: '250m'
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 3001
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 3001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health/startup
+              port: 3001
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 24
+          envFrom:
+            - configMapRef:
+                name: health-watchers-config
+            - secretRef:
+                name: health-watchers-secrets
+          env:
+            - name: PORT
+              value: '3001'
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL

--- a/k8s/api/blue-green/service.yaml
+++ b/k8s/api/blue-green/service.yaml
@@ -1,0 +1,33 @@
+# Load-balancer-facing Service for blue-green deployments of the api.
+#
+# The ingress (k8s/ingress.yaml) and monitoring targets continue to point at
+# the standard `api` Service/Deployment (k8s/api/service.yaml,
+# k8s/api/deployment.yaml) for normal rolling-update releases.
+#
+# To perform a blue-green release instead:
+#   1. Apply this directory: kubectl apply -f k8s/api/blue-green/
+#   2. Point the ingress `api` backend paths at `api-service` (instead of
+#      `api`) so traffic flows through the slot switch below.
+#   3. Run ops/blue-green-deployment.sh api <new-image> health-watchers
+#      to roll the inactive slot and cut traffic over with zero downtime.
+#   4. Run ops/rollback-deployment.sh api health-watchers to revert.
+#
+# See docs/BLUE_GREEN_DEPLOYMENT.md for the full runbook.
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  namespace: health-watchers
+  labels:
+    app.kubernetes.io/name: health-watchers
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  selector:
+    app: api
+    version: blue
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+      protocol: TCP


### PR DESCRIPTION
- #1014 Blue-Green Deployment: add the api-blue/api-green Deployments and switchable api-service that ops/blue-green-deployment.sh and ops/rollback-deployment.sh already expected but had no k8s targets for; document the cutover/rollback runbook.
- #1017 Architecture Documentation: add an authentication data flow diagram and cross-link the new blue-green runbook from the deployment architecture section.
- #1015 Backup Verification Automation and #1016 SSL/TLS Certificate Management: verified existing automation (weekly GH Actions verification workflow, health/metrics endpoints, cert-manager Issuer/Certificate + expiry PrometheusRule routed through alertmanager) already satisfies the acceptance criteria.
- Clean up duplicate .gitignore entries and ignore generated verification report/log output from the ops scripts.
Closes #1014 
Closes #1015 
Closes #1016 
Closes #1017 