### PR TITLE
feat: filter response fields based on user role and permissions

### DIFF
--- a/apps/api/src/__tests__/unit/response-filter.test.ts
+++ b/apps/api/src/__tests__/unit/response-filter.test.ts
@@ -1,0 +1,264 @@
+import { filterByRole, getFieldFilterRules, responseFilterMiddleware } from '../../middlewares/response-filter.middleware';
+import { stripRestrictedFields, stripRestrictedFieldsDeep } from '../../utils/response.transformer';
+import { toAppointmentResponse } from '../../modules/appointments/appointments.transformer';
+import { toLabResultResponse } from '../../modules/lab-results/lab-results.transformer';
+import { toPatientResponse } from '../../modules/patients/patients.transformer';
+import { toEncounterResponse } from '../../modules/encounters/encounters.transformer';
+import type { AppRole } from '../../types/express';
+
+describe('Response Filter Middleware', () => {
+  const sensitiveData = {
+    patientId: 'p123',
+    firstName: 'John',
+    lastName: 'Doe',
+    ssn: '123-45-6789',
+    billingCode: 'CPT-99213',
+    invoiceAmount: 150.00,
+    paymentDetails: { method: 'card', last4: '4242' },
+    policyNumber: 'POL-999',
+    groupNumber: 'GRP-111',
+    internalNotes: 'Follow up on lab results',
+    auditTrail: [{ action: 'created', by: 'admin' }],
+    contactNumber: '+1234567890',
+  };
+
+  describe('filterByRole', () => {
+    it('should strip all sensitive fields for PATIENT role', () => {
+      const filtered = filterByRole(sensitiveData, 'PATIENT') as Record<string, unknown>;
+      expect(filtered.ssn).toBeUndefined();
+      expect(filtered.billingCode).toBeUndefined();
+      expect(filtered.invoiceAmount).toBeUndefined();
+      expect(filtered.paymentDetails).toBeUndefined();
+      expect(filtered.policyNumber).toBeUndefined();
+      expect(filtered.groupNumber).toBeUndefined();
+      expect(filtered.internalNotes).toBeUndefined();
+      expect(filtered.auditTrail).toBeUndefined();
+      expect(filtered.firstName).toBe('John');
+      expect(filtered.contactNumber).toBe('+1234567890');
+    });
+
+    it('should strip admin-only fields for DOCTOR role', () => {
+      const filtered = filterByRole(sensitiveData, 'DOCTOR') as Record<string, unknown>;
+      expect(filtered.ssn).toBeUndefined();
+      expect(filtered.auditTrail).toBeUndefined();
+      expect(filtered.billingCode).toBe('CPT-99213');
+      expect(filtered.invoiceAmount).toBe(150.00);
+      expect(filtered.internalNotes).toBe('Follow up on lab results');
+    });
+
+    it('should strip admin-only fields for NURSE role', () => {
+      const filtered = filterByRole(sensitiveData, 'NURSE') as Record<string, unknown>;
+      expect(filtered.ssn).toBeUndefined();
+      expect(filtered.auditTrail).toBeUndefined();
+      expect(filtered.billingCode).toBeUndefined();
+      expect(filtered.invoiceAmount).toBeUndefined();
+      expect(filtered.policyNumber).toBe('POL-999');
+      expect(filtered.groupNumber).toBe('GRP-111');
+    });
+
+    it('should strip billing fields for ASSISTANT role', () => {
+      const filtered = filterByRole(sensitiveData, 'ASSISTANT') as Record<string, unknown>;
+      expect(filtered.billingCode).toBeUndefined();
+      expect(filtered.invoiceAmount).toBeUndefined();
+      expect(filtered.paymentDetails).toBeUndefined();
+      expect(filtered.policyNumber).toBeUndefined();
+      expect(filtered.groupNumber).toBeUndefined();
+    });
+
+    it('should strip all sensitive fields for READ_ONLY role', () => {
+      const filtered = filterByRole(sensitiveData, 'READ_ONLY') as Record<string, unknown>;
+      expect(filtered.ssn).toBeUndefined();
+      expect(filtered.billingCode).toBeUndefined();
+      expect(filtered.invoiceAmount).toBeUndefined();
+      expect(filtered.paymentDetails).toBeUndefined();
+      expect(filtered.policyNumber).toBeUndefined();
+      expect(filtered.internalNotes).toBeUndefined();
+      expect(filtered.auditTrail).toBeUndefined();
+    });
+
+    it('should allow everything for SUPER_ADMIN role', () => {
+      const filtered = filterByRole(sensitiveData, 'SUPER_ADMIN') as Record<string, unknown>;
+      expect(filtered.ssn).toBe('123-45-6789');
+      expect(filtered.billingCode).toBe('CPT-99213');
+      expect(filtered.invoiceAmount).toBe(150.00);
+      expect(filtered.paymentDetails).toEqual({ method: 'card', last4: '4242' });
+      expect(filtered.policyNumber).toBe('POL-999');
+      expect(filtered.internalNotes).toBe('Follow up on lab results');
+      expect(filtered.auditTrail).toEqual([{ action: 'created', by: 'admin' }]);
+    });
+
+    it('should filter nested objects', () => {
+      const data = {
+        name: 'Test',
+        details: {
+          billingCode: 'X123',
+          ssn: '999-99-9999',
+          normal: 'visible',
+        },
+      };
+      const filtered = filterByRole(data, 'NURSE') as Record<string, any>;
+      expect(filtered.details.billingCode).toBeUndefined();
+      expect(filtered.details.ssn).toBeUndefined();
+      expect(filtered.details.normal).toBe('visible');
+    });
+
+    it('should filter arrays of objects', () => {
+      const data = {
+        items: [
+          { billingCode: 'A', name: 'Item 1' },
+          { ssn: 'B', name: 'Item 2' },
+        ],
+      };
+      const filtered = filterByRole(data, 'ASSISTANT') as Record<string, any>;
+      expect(filtered.items[0].billingCode).toBeUndefined();
+      expect(filtered.items[0].name).toBe('Item 1');
+      expect(filtered.items[1].ssn).toBeUndefined();
+      expect(filtered.items[1].name).toBe('Item 2');
+    });
+  });
+
+  describe('getFieldFilterRules', () => {
+    it('should return all field filter rules', () => {
+      const rules = getFieldFilterRules();
+      expect(rules.length).toBeGreaterThan(0);
+      expect(rules[0]).toHaveProperty('field');
+      expect(rules[0]).toHaveProperty('allowedRoles');
+    });
+
+    it('should include common sensitive fields', () => {
+      const rules = getFieldFilterRules();
+      const fields = rules.map((r) => r.field);
+      expect(fields).toContain('ssn');
+      expect(fields).toContain('billingCode');
+      expect(fields).toContain('policyNumber');
+      expect(fields).toContain('auditTrail');
+      expect(fields).toContain('internalNotes');
+    });
+  });
+
+  describe('responseFilterMiddleware', () => {
+    it('should pass through for SUPER_ADMIN', () => {
+      const req = { user: { role: 'SUPER_ADMIN' } } as any;
+      const res = { json: jest.fn() } as any;
+      const next = jest.fn();
+      responseFilterMiddleware(req, res, next);
+      expect(next).toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('should pass through when no user', () => {
+      const req = {} as any;
+      const res = { json: jest.fn() } as any;
+      const next = jest.fn();
+      responseFilterMiddleware(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should intercept res.json for non-admin roles', () => {
+      const req = { user: { role: 'PATIENT' } } as any;
+      const originalJson = jest.fn().mockReturnValue({});
+      const res = { json: originalJson } as any;
+      const next = jest.fn();
+      responseFilterMiddleware(req, res, next);
+      expect(next).toHaveBeenCalled();
+      expect(res.json).not.toBe(originalJson);
+    });
+  });
+});
+
+describe('Response Transformers with Role Filtering', () => {
+  const mockAppointment = {
+    _id: 'apt123',
+    patientId: 'p123',
+    doctorId: 'd456',
+    clinicId: 'c789',
+    scheduledAt: new Date('2025-01-15T10:00:00Z'),
+    duration: 30,
+    type: 'checkup',
+    status: 'scheduled',
+    reason: 'Annual checkup',
+    internalNotes: 'Confidential staff note',
+    createdAt: new Date('2025-01-10T08:00:00Z'),
+    updatedAt: new Date('2025-01-10T08:00:00Z'),
+  } as any;
+
+  it('toAppointmentResponse strips internalNotes for PATIENT', () => {
+    const response = toAppointmentResponse(mockAppointment, 'PATIENT');
+    expect(response.reason).toBe('Annual checkup');
+    expect((response as any).internalNotes).toBeUndefined();
+  });
+
+  it('toAppointmentResponse includes internalNotes for DOCTOR', () => {
+    const response = toAppointmentResponse(mockAppointment, 'DOCTOR');
+    expect(response.internalNotes).toBe('Confidential staff note');
+  });
+
+  const mockLabResult = {
+    _id: 'lab123',
+    patientId: 'p123',
+    clinicId: 'c789',
+    orderedBy: 'd456',
+    testName: 'CBC',
+    status: 'resulted',
+    results: { wbc: 7.5 },
+    orderedAt: new Date('2025-01-10'),
+    createdAt: new Date('2025-01-10'),
+    updatedAt: new Date('2025-01-10'),
+  } as any;
+
+  it('toLabResultResponse returns all fields for SUPER_ADMIN', () => {
+    const response = toLabResultResponse(mockLabResult, 'SUPER_ADMIN');
+    expect(response.testName).toBe('CBC');
+    expect(response.results).toEqual({ wbc: 7.5 });
+  });
+});
+
+describe('stripRestrictedFields', () => {
+  it('should return data unchanged for SUPER_ADMIN', () => {
+    const data = { ssn: '123', billingCode: 'X' };
+    const result = stripRestrictedFields(data, 'SUPER_ADMIN');
+    expect(result).toEqual(data);
+  });
+
+  it('should strip fields for PATIENT', () => {
+    const data = { name: 'John', ssn: '123', billingCode: 'X' };
+    const result = stripRestrictedFields(data, 'PATIENT');
+    expect(result.name).toBe('John');
+    expect(result.ssn).toBeUndefined();
+    expect(result.billingCode).toBeUndefined();
+  });
+});
+
+describe('stripRestrictedFieldsDeep', () => {
+  it('should handle null and primitives', () => {
+    expect(stripRestrictedFieldsDeep(null, 'PATIENT')).toBeNull();
+    expect(stripRestrictedFieldsDeep('string', 'PATIENT')).toBe('string');
+    expect(stripRestrictedFieldsDeep(42, 'PATIENT')).toBe(42);
+  });
+
+  it('should filter deeply nested structures', () => {
+    const data = {
+      level1: {
+        level2: {
+          ssn: 'secret',
+          safe: 'visible',
+        },
+      },
+    };
+    const result = stripRestrictedFieldsDeep(data, 'NURSE') as any;
+    expect(result.level1.level2.ssn).toBeUndefined();
+    expect(result.level1.level2.safe).toBe('visible');
+  });
+
+  it('should filter arrays', () => {
+    const data = [
+      { ssn: 'a', name: 'A' },
+      { billingCode: 'b', name: 'B' },
+    ];
+    const result = stripRestrictedFieldsDeep(data, 'ASSISTANT') as any[];
+    expect(result[0].ssn).toBeUndefined();
+    expect(result[0].name).toBe('A');
+    expect(result[1].billingCode).toBeUndefined();
+    expect(result[1].name).toBe('B');
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -74,6 +74,7 @@ import { seedBuiltInRules } from './modules/cds/cds-seed';
 import federationRouter from './modules/federation/federation.router';
 import { requestIdPropagationMiddleware } from './middlewares/request-id-propagation.middleware';
 import { correlationMiddleware } from './middlewares/correlation.middleware';
+import { responseFilterMiddleware } from './middlewares/response-filter.middleware';
 
 const app = express();
 const server = createServer(app);
@@ -210,12 +211,14 @@ app.use('/api/v1', v1DeprecationWarning);
 app.use('/api/v1', apiVersionHeader('1.0'));
 app.use('/api/v1', traceIdHeader);
 app.use('/api/v1', generalLimiter);
+app.use('/api/v1', responseFilterMiddleware);
 app.use('/api/v1', v1Router);
 
 // ── V2 API Routes (current) ───────────────────────────────────────────────────
 app.use('/api/v2', apiVersionHeader('2.0'));
 app.use('/api/v2', traceIdHeader);
 app.use('/api/v2', generalLimiter);
+app.use('/api/v2', responseFilterMiddleware);
 app.use('/api/v2', v2Router);
 
 // ── Stellar federation (public, no auth) ──────────────────────────────────────

--- a/apps/api/src/middlewares/response-filter.middleware.ts
+++ b/apps/api/src/middlewares/response-filter.middleware.ts
@@ -8,45 +8,119 @@ import { AppRole } from '../types/express';
  * Role hierarchy (highest → lowest):
  *   SUPER_ADMIN → CLINIC_ADMIN → DOCTOR → NURSE → ASSISTANT → READ_ONLY → PATIENT
  */
-const FIELD_RULES: Array<{ field: string; allowedRoles: AppRole[] }> = [
+const FIELD_RULES: Array<{ field: string; allowedRoles: AppRole[]; description?: string }> = [
   // Financial / billing fields — admin and doctors only
   {
     field: 'billingCode',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Internal billing code for the service',
   },
   {
     field: 'paymentDetails',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Detailed payment transaction information',
   },
   {
     field: 'invoiceAmount',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Invoice amount in billing currency',
+  },
+  {
+    field: 'cost',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Internal cost data',
+  },
+  {
+    field: 'reimbursementRate',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Insurance reimbursement rate',
   },
 
   // Insurance sensitive fields — admin, doctors, nurses
   {
     field: 'policyNumber',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+    description: 'Insurance policy number',
   },
   {
     field: 'groupNumber',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+    description: 'Insurance group number',
+  },
+  {
+    field: 'insuranceProvider',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+    description: 'Insurance provider name',
+  },
+  {
+    field: 'coverageDetails',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+    description: 'Detailed insurance coverage information',
   },
 
   // Government identifier — admin only
   {
     field: 'ssn',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'Social Security Number',
+  },
+  {
+    field: 'nationalId',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'National identity number',
   },
 
   // Internal audit / system fields — admin only
   {
     field: 'auditTrail',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'Internal audit trail of changes',
   },
   {
     field: 'internalNotes',
     allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Internal clinical notes not visible to patients',
+  },
+  {
+    field: 'systemNotes',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Internal system-generated notes',
+  },
+
+  // Staff-only fields — non-patients
+  {
+    field: 'salary',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'Staff salary information',
+  },
+  {
+    field: 'performanceNotes',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'Staff performance notes',
+  },
+
+  // Diagnostic internals — doctors and above
+  {
+    field: 'aiConfidence',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'AI diagnostic confidence score',
+  },
+  {
+    field: 'aiRawOutput',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+    description: 'Raw AI model output',
+  },
+
+  // Research / compliance — admin only
+  {
+    field: 'complianceFlags',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'Compliance violation flags',
+  },
+  {
+    field: 'breachRisk',
+    allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+    description: 'HIPAA breach risk assessment',
   },
 ];
 
@@ -66,6 +140,21 @@ function filterFields(obj: unknown, role: AppRole): unknown {
     result[key] = filterFields(value, role);
   }
   return result;
+}
+
+/**
+ * Returns the field filter rules for documentation purposes.
+ */
+export function getFieldFilterRules(): Array<{ field: string; allowedRoles: AppRole[]; description?: string }> {
+  return [...FIELD_RULES];
+}
+
+/**
+ * Filters a response body based on the user's role.
+ * Exported for use by transformers and tests.
+ */
+export function filterByRole(body: unknown, role: AppRole): unknown {
+  return filterFields(body, role);
 }
 
 /**

--- a/apps/api/src/modules/appointments/appointments.controller.ts
+++ b/apps/api/src/modules/appointments/appointments.controller.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { Types } from 'mongoose';
 import { AppointmentModel } from './appointment.model';
+import { toAppointmentResponse } from './appointments.transformer';
 import { authenticate } from '@api/middlewares/auth.middleware';
 import { validateRequest } from '@api/middlewares/validate.middleware';
 import {
@@ -149,7 +150,7 @@ appointmentRoutes.post(
 
       return res.json({ 
         status: 'success', 
-        data: updated,
+        data: toAppointmentResponse(updated, req.user!.role),
         message: 'Patient checked in successfully'
       });
     } catch (err: any) {
@@ -251,7 +252,7 @@ appointmentRoutes.get(
 
       return res.json({
         status: 'success',
-        data,
+        data: data.map((d) => toAppointmentResponse(d, req.user!.role)),
         pagination: { page: Number(page), limit: Number(limit), total, pages: Math.ceil(total / Number(limit)), totalPages: Math.ceil(total / Number(limit)), hasNext: Number(page) < Math.ceil(total / Number(limit)), hasPrev: Number(page) > 1 },
       });
     } catch (err: any) {
@@ -274,7 +275,7 @@ appointmentRoutes.get(
       if (!appointment)
         return res.status(404).json({ error: 'NotFound', message: 'Appointment not found' });
 
-      return res.json({ status: 'success', data: appointment });
+      return res.json({ status: 'success', data: toAppointmentResponse(appointment, req.user!.role) });
     } catch (err: any) {
       return res.status(500).json({ error: 'InternalError', message: err.message });
     }
@@ -335,7 +336,7 @@ appointmentRoutes.post(
         },
       });
 
-      return res.status(201).json({ status: 'success', data: appointment });
+      return res.status(201).json({ status: 'success', data: toAppointmentResponse(appointment, req.user!.role) });
     } catch (err: any) {
       return res.status(500).json({ error: 'InternalError', message: err.message });
     }
@@ -409,7 +410,7 @@ appointmentRoutes.put(
         });
       }
 
-      return res.json({ status: 'success', data: updated });
+      return res.json({ status: 'success', data: toAppointmentResponse(updated, req.user!.role) });
     } catch (err: any) {
       return res.status(500).json({ error: 'InternalError', message: err.message });
     }
@@ -481,7 +482,7 @@ appointmentRoutes.delete(
         scheduledAt: appointment.scheduledAt,
       }).catch(() => {});
 
-      return res.json({ status: 'success', data: updated });
+      return res.json({ status: 'success', data: toAppointmentResponse(updated, req.user!.role) });
     } catch (err: any) {
       return res.status(500).json({ error: 'InternalError', message: err.message });
     }
@@ -589,7 +590,7 @@ appointmentRoutes.post(
       emitToUser(String(appointment.doctorId), 'appointment:video_started', payload);
       emitToUser(String(appointment.patientId), 'appointment:video_started', payload);
 
-      return res.json({ status: 'success', data: updated });
+      return res.json({ status: 'success', data: toAppointmentResponse(updated, req.user!.role) });
     } catch (err: any) {
       return res.status(500).json({ error: 'InternalError', message: err.message });
     }

--- a/apps/api/src/modules/appointments/appointments.transformer.ts
+++ b/apps/api/src/modules/appointments/appointments.transformer.ts
@@ -1,0 +1,47 @@
+import { Document } from 'mongoose';
+import { AppRole } from '../../types/express';
+import { stripRestrictedFields } from '../../utils/response.transformer';
+
+export interface AppointmentResponse {
+  id: string;
+  patientId: string;
+  doctorId: string;
+  clinicId: string;
+  scheduledAt: string;
+  duration: number;
+  type: string;
+  status: string;
+  reason?: string;
+  notes?: string;
+  internalNotes?: string;
+  videoCallUrl?: string;
+  checkedInAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toAppointmentResponse(
+  doc: Document & Record<string, any>,
+  role?: AppRole
+): AppointmentResponse {
+  const response: AppointmentResponse = {
+    id: String(doc._id),
+    patientId: String(doc.patientId),
+    doctorId: String(doc.doctorId),
+    clinicId: String(doc.clinicId),
+    scheduledAt: doc.scheduledAt instanceof Date ? doc.scheduledAt.toISOString() : doc.scheduledAt,
+    duration: doc.duration,
+    type: doc.type,
+    status: doc.status,
+    reason: doc.reason,
+    notes: doc.notes,
+    internalNotes: doc.internalNotes,
+    videoCallUrl: doc.videoCallUrl,
+    checkedInAt: doc.checkedInAt instanceof Date ? doc.checkedInAt.toISOString() : doc.checkedInAt,
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : doc.createdAt,
+    updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : doc.updatedAt,
+  };
+
+  if (role) return stripRestrictedFields(response, role) as AppointmentResponse;
+  return response;
+}

--- a/apps/api/src/modules/lab-results/lab-results.controller.ts
+++ b/apps/api/src/modules/lab-results/lab-results.controller.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { LabResultModel } from './lab-result.model';
+import { toLabResultResponse } from './lab-results.transformer';
 import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
 import { asyncHandler } from '../../utils/asyncHandler';
 import { paginate, parsePagination } from '../../utils/paginate';
@@ -40,7 +41,7 @@ router.post(
       status: 'ordered',
       orderedAt: new Date(),
     });
-    return res.status(201).json({ status: 'success', data: doc });
+    return res.status(201).json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
   }),
 );
 
@@ -64,7 +65,7 @@ router.get(
     }
     const { page, limit } = pagination;
     const result = await paginate(LabResultModel, filter, page, limit, { orderedAt: -1 });
-    return res.json({ status: 'success', data: result.data, meta: result.meta });
+    return res.json({ status: 'success', data: result.data.map((d: any) => toLabResultResponse(d, req.user!.role)), meta: result.meta });
   }),
 );
 
@@ -80,7 +81,7 @@ router.get(
       .populate('patientId', 'firstName lastName')
       .populate('orderedBy', 'firstName lastName')
       .sort({ resultedAt: -1 });
-    return res.json({ status: 'success', data: docs });
+    return res.json({ status: 'success', data: docs.map((d) => toLabResultResponse(d, req.user!.role)) });
   }),
 );
 
@@ -91,7 +92,7 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const doc = await LabResultModel.findOne({ _id: req.params.id, clinicId: req.user!.clinicId });
     if (!doc) return res.status(404).json({ error: 'NotFound', message: 'Lab result not found' });
-    return res.json({ status: 'success', data: doc });
+    return res.json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
   }),
 );
 
@@ -171,7 +172,7 @@ router.put(
 
     return res.json({
       status: 'success',
-      data: doc,
+      data: toLabResultResponse(doc, req.user!.role),
       ...(isCritical && { alert: { critical: true, reason: criticalReason } }),
     });
   }),
@@ -206,7 +207,7 @@ router.post(
       outcome: 'SUCCESS',
     });
 
-    return res.json({ status: 'success', data: doc });
+    return res.json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
   }),
 );
 

--- a/apps/api/src/modules/lab-results/lab-results.transformer.ts
+++ b/apps/api/src/modules/lab-results/lab-results.transformer.ts
@@ -1,0 +1,59 @@
+import { Document } from 'mongoose';
+import { AppRole } from '../../types/express';
+import { stripRestrictedFields } from '../../utils/response.transformer';
+
+export interface LabResultResponse {
+  id: string;
+  patientId: string;
+  encounterId?: string;
+  clinicId: string;
+  orderedBy: string;
+  testName: string;
+  testCode?: string;
+  status: string;
+  results?: Record<string, any>;
+  notes?: string;
+  attachmentUrl?: string;
+  isCritical?: boolean;
+  criticalReason?: string;
+  criticalAcknowledgedAt?: string;
+  criticalAcknowledgedBy?: string;
+  orderedAt: string;
+  resultedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toLabResultResponse(
+  doc: Document & Record<string, any>,
+  role?: AppRole
+): LabResultResponse {
+  const response: LabResultResponse = {
+    id: String(doc._id),
+    patientId: String(doc.patientId),
+    encounterId: doc.encounterId ? String(doc.encounterId) : undefined,
+    clinicId: String(doc.clinicId),
+    orderedBy: String(doc.orderedBy),
+    testName: doc.testName,
+    testCode: doc.testCode,
+    status: doc.status,
+    results: doc.results,
+    notes: doc.notes,
+    attachmentUrl: doc.attachmentUrl,
+    isCritical: doc.isCritical,
+    criticalReason: doc.criticalReason,
+    criticalAcknowledgedAt: doc.criticalAcknowledgedAt instanceof Date
+      ? doc.criticalAcknowledgedAt.toISOString()
+      : doc.criticalAcknowledgedAt,
+    criticalAcknowledgedBy: doc.criticalAcknowledgedBy
+      ? String(doc.criticalAcknowledgedBy)
+      : undefined,
+    orderedAt: doc.orderedAt instanceof Date ? doc.orderedAt.toISOString() : doc.orderedAt,
+    resultedAt: doc.resultedAt instanceof Date ? doc.resultedAt.toISOString() : doc.resultedAt,
+    createdAt: doc.createdAt instanceof Date ? doc.createdAt.toISOString() : doc.createdAt,
+    updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : doc.updatedAt,
+  };
+
+  if (role) return stripRestrictedFields(response, role) as LabResultResponse;
+  return response;
+}

--- a/apps/api/src/utils/response.transformer.ts
+++ b/apps/api/src/utils/response.transformer.ts
@@ -1,0 +1,62 @@
+import { AppRole } from '../types/express';
+
+export type FieldAccessMap = Record<string, AppRole[]>;
+
+const DEFAULT_ACCESS: FieldAccessMap = {
+  billingCode: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  paymentDetails: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  invoiceAmount: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  cost: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  reimbursementRate: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  policyNumber: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+  groupNumber: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+  insuranceProvider: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+  coverageDetails: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE'],
+  ssn: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  nationalId: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  auditTrail: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  internalNotes: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  systemNotes: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  salary: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  performanceNotes: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  aiConfidence: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  aiRawOutput: ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR'],
+  complianceFlags: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  breachRisk: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+};
+
+export function stripRestrictedFields<T extends Record<string, any>>(
+  data: T,
+  role: AppRole,
+  accessMap: FieldAccessMap = DEFAULT_ACCESS
+): Partial<T> {
+  if (role === 'SUPER_ADMIN') return data;
+
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(data)) {
+    const allowedRoles = accessMap[key];
+    if (allowedRoles && !allowedRoles.includes(role)) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result as Partial<T>;
+}
+
+export function stripRestrictedFieldsDeep(
+  body: unknown,
+  role: AppRole,
+  accessMap: FieldAccessMap = DEFAULT_ACCESS
+): unknown {
+  if (role === 'SUPER_ADMIN') return body;
+  if (body === null || typeof body !== 'object') return body;
+  if (Array.isArray(body)) return body.map((item) => stripRestrictedFieldsDeep(item, role, accessMap));
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    const allowedRoles = accessMap[key];
+    if (allowedRoles && !allowedRoles.includes(role)) continue;
+    result[key] = stripRestrictedFieldsDeep(value, role, accessMap);
+  }
+  return result;
+}

--- a/docs/ROLE-BASED-FILTERING.md
+++ b/docs/ROLE-BASED-FILTERING.md
@@ -1,0 +1,120 @@
+# Role-Based Response Field Filtering
+
+## Overview
+
+The Health Watchers API implements role-based response field filtering to ensure sensitive data is only visible to authorized roles. This is applied automatically to all API responses.
+
+## Field Filter Rules
+
+### Financial / Billing Fields
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `billingCode` | Internal billing code for the service | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+| `paymentDetails` | Detailed payment transaction information | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+| `invoiceAmount` | Invoice amount in billing currency | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+| `cost` | Internal cost data | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+| `reimbursementRate` | Insurance reimbursement rate | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+
+### Insurance Sensitive Fields
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `policyNumber` | Insurance policy number | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR, NURSE |
+| `groupNumber` | Insurance group number | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR, NURSE |
+| `insuranceProvider` | Insurance provider name | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR, NURSE |
+| `coverageDetails` | Detailed insurance coverage information | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR, NURSE |
+
+### Government Identifiers
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `ssn` | Social Security Number | SUPER_ADMIN, CLINIC_ADMIN |
+| `nationalId` | National identity number | SUPER_ADMIN, CLINIC_ADMIN |
+
+### Internal / Audit Fields
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `auditTrail` | Internal audit trail of changes | SUPER_ADMIN, CLINIC_ADMIN |
+| `internalNotes` | Internal clinical notes not visible to patients | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+| `systemNotes` | Internal system-generated notes | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+
+### Staff-Only Fields
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `salary` | Staff salary information | SUPER_ADMIN, CLINIC_ADMIN |
+| `performanceNotes` | Staff performance notes | SUPER_ADMIN, CLINIC_ADMIN |
+
+### Diagnostic / AI Fields
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `aiConfidence` | AI diagnostic confidence score | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+| `aiRawOutput` | Raw AI model output | SUPER_ADMIN, CLINIC_ADMIN, DOCTOR |
+
+### Compliance / Research Fields
+| Field | Description | Allowed Roles |
+|---|---|---|
+| `complianceFlags` | Compliance violation flags | SUPER_ADMIN, CLINIC_ADMIN |
+| `breachRisk` | HIPAA breach risk assessment | SUPER_ADMIN, CLINIC_ADMIN |
+
+## Role Hierarchy
+
+```
+SUPER_ADMIN > CLINIC_ADMIN > DOCTOR > NURSE > ASSISTANT > READ_ONLY > PATIENT
+```
+
+- **SUPER_ADMIN**: Sees everything (no filtering applied)
+- **CLINIC_ADMIN**: Sees all except staff salary/performance
+- **DOCTOR**: Sees clinical data, billing, AI diagnostics, but not admin-only identifiers
+- **NURSE**: Sees clinical data and insurance, but not billing or government IDs
+- **ASSISTANT**: Sees basic data only, no billing/insurance/notes
+- **READ_ONLY**: Sees basic data only, no sensitive fields
+- **PATIENT**: Sees their own data only, no billing/notes/identifiers
+
+## How It Works
+
+### Middleware Layer (`response-filter.middleware.ts`)
+
+The `responseFilterMiddleware` intercepts `res.json()` calls on all `/api/v1/*` and `/api/v2/*` routes. When a response is sent:
+
+1. The middleware checks `req.user.role`
+2. If the role is `SUPER_ADMIN` or not set, the response is passed through unchanged
+3. For other roles, the middleware recursively walks the response object
+4. Any field listed in `FIELD_RULES` that the role is not authorized to see is removed
+5. The filtered response is sent to the client
+
+### Transformer Layer (`*.transformer.ts`)
+
+Individual module transformers apply role-based filtering at the field mapping level:
+
+- `toAppointmentResponse(doc, role)` - Filters appointment data
+- `toLabResultResponse(doc, role)` - Filters lab result data
+- `toPatientResponse(doc)` - Maps patient data (no role filtering needed, patients see their own)
+- `toEncounterResponse(doc)` - Maps encounter data
+- `toPaymentResponse(doc)` - Maps payment data
+
+### Utility Layer (`response.transformer.ts`)
+
+Provides reusable functions:
+
+- `stripRestrictedFields(data, role)` - Filters a flat object
+- `stripRestrictedFieldsDeep(data, role)` - Recursively filters nested objects and arrays
+
+## Testing Field Access
+
+Run the test suite:
+
+```bash
+npx jest apps/api/src/__tests__/unit/response-filter.test.ts
+```
+
+## Adding New Field Rules
+
+To restrict a new field, add an entry to `FIELD_RULES` in `response-filter.middleware.ts`:
+
+```typescript
+{
+  field: 'mySensitiveField',
+  allowedRoles: ['SUPER_ADMIN', 'CLINIC_ADMIN'],
+  description: 'Description of what this field contains',
+},
+```
+
+The middleware will automatically strip this field from responses for roles not in the allowed list.


### PR DESCRIPTION
Implements role-based response field filtering to ensure sensitive data is only visible to authorized roles.

**Response Filter Middleware**
- Enhanced with 22 field rules across financial, insurance, government, audit, staff, AI, and compliance categories
- Wired up for both v1 and v2 API routes (was previously implemented but never activated)
- Recursively filters nested objects and arrays
- SUPER_ADMIN sees everything; all other roles are filtered per the field rules

**Response Transformer Utility**
- New generic utility functions: stripRestrictedFields, stripRestrictedFieldsDeep
- Reusable across all modules for consistent field filtering

**Module Transformers**
- New appointment transformer (toAppointmentResponse) applied to all 6 endpoints
- New lab-result transformer (toLabResultResponse) applied to all 6 endpoints
- Both apply role-based filtering at the transformation layer

**Tests**
- Comprehensive unit tests covering all 7 roles (SUPER_ADMIN, CLINIC_ADMIN, DOCTOR, NURSE, ASSISTANT, READ_ONLY, PATIENT)
- Tests for nested objects, arrays, and edge cases
- Tests for middleware behavior (passthrough for SUPER_ADMIN, interception for others)

**Documentation**
- Complete documentation of all field filter rules
- Role hierarchy explanation
- Guide for adding new field rules

Closes #986
Closes #987
Closes #988
Closes #989