### PR TITLE
fix(security): harden account lockout, password rules, and PHI docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,8 +95,8 @@ Cross-origin requests from a malicious site cannot read the `csrf-token` cookie 
 - Clinic-scoped data isolation — providers can only access patients within their own clinic
 
 ### Data Protection
-- AES-256-GCM field-level encryption for all PHI (name, DOB, diagnoses, contact info)
-- Encryption keys managed in AWS Secrets Manager with quarterly rotation
+- AES-256-GCM field-level encryption for PHI (DOB, contact number, address, insurance policy/group numbers); see `docs/SECURITY_POLICY.md` for full field coverage
+- Encryption keys managed in AWS Secrets Manager, with versioned key rotation supported at the application layer
 - TLS 1.3 enforced for all data in transit
 - MongoDB encryption at rest enabled in production
 

--- a/apps/api/src/__mocks__/sentry-profiling-node.ts
+++ b/apps/api/src/__mocks__/sentry-profiling-node.ts
@@ -1,2 +1,2 @@
 // Stub for @sentry/profiling-node — the native binary is not available in test environments.
-export const nodeProfilingIntegration = () => ({});
+export const nodeProfilingIntegration = () => ({ name: 'ProfilingIntegration' });

--- a/apps/api/src/modules/audit/audit.model.ts
+++ b/apps/api/src/modules/audit/audit.model.ts
@@ -44,7 +44,9 @@ export type AuditAction =
   | 'API_KEY_REVOKE'
   | 'API_KEY_UPDATE'
   | 'COMMUNICATION_LOG_CREATED'
-  | 'COMMUNICATION_LOG_VIEWED';
+  | 'COMMUNICATION_LOG_VIEWED'
+  | 'ACCOUNT_LOCKED'
+  | 'ACCOUNT_UNLOCKED';
 
 export interface AuditLog {
   userId?: Types.ObjectId;
@@ -112,6 +114,8 @@ const auditLogSchema = new Schema<AuditLog>(
         'API_KEY_UPDATE',
         'COMMUNICATION_LOG_CREATED',
         'COMMUNICATION_LOG_VIEWED',
+        'ACCOUNT_LOCKED',
+        'ACCOUNT_UNLOCKED',
       ],
       index: true,
     },
@@ -128,7 +132,7 @@ const auditLogSchema = new Schema<AuditLog>(
     timestamps: false,
     versionKey: false,
     collection: 'audit_logs',
-  },
+  }
 );
 
 // Prevent updates and deletes - immutable logs

--- a/apps/api/src/modules/auth/account-lockout.test.ts
+++ b/apps/api/src/modules/auth/account-lockout.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Integration tests for account lockout behavior:
+ *   - failed login attempt tracking
+ *   - lockout enforcement after MAX_FAILED_ATTEMPTS
+ *   - lockout notification email
+ *   - audit log entries for lockout/unlock
+ *   - POST /api/v1/auth/unlock (SUPER_ADMIN manual unlock)
+ */
+
+// ── Environment stubs (must be before any module that reads process.env) ──────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_ACCESS_TOKEN_SECRET = 'test-access-secret-32-chars-long!!';
+process.env.JWT_REFRESH_TOKEN_SECRET = 'test-refresh-secret-32-chars-long!';
+process.env.API_PORT = '3001';
+
+// ── Mocks (must be before imports) ────────────────────────────────────────────
+
+jest.mock('@health-watchers/config', () => ({
+  config: {
+    jwt: {
+      accessTokenSecret: 'test-access-secret-32-chars-long!!',
+      refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+    },
+    apiPort: '3001',
+    nodeEnv: 'test',
+    mongoUri: '',
+    stellarNetwork: 'testnet',
+    stellarHorizonUrl: '',
+    stellarSecretKey: '',
+    stellar: { network: 'testnet', horizonUrl: '', secretKey: '', platformPublicKey: '' },
+    supportedAssets: ['XLM'],
+    stellarServiceUrl: '',
+    geminiApiKey: '',
+    fieldEncryptionKey: 'abcdefghijklmnopqrstuvwxyz012345',
+  },
+}));
+
+jest.mock('@api/config/db', () => ({
+  connectDB: jest.fn().mockReturnValue(new Promise(() => {})),
+}));
+jest.mock('@api/docs/swagger', () => ({ setupSwagger: jest.fn() }));
+jest.mock('@api/modules/payments/services/payment-expiration-job', () => ({
+  startPaymentExpirationJob: jest.fn(),
+  stopPaymentExpirationJob: jest.fn(),
+}));
+jest.mock('@api/utils/logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('@api/lib/email.service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+  sendAccountLockedEmail: jest.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: jest.fn().mockResolvedValue(undefined),
+  sendMfaBackupCodesRegeneratedEmail: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@api/modules/audit/audit.service', () => ({
+  auditLog: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@api/modules/auth/models/user.model', () => ({
+  UserModel: {
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/auth/models/refresh-token.model', () => ({
+  RefreshTokenModel: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    deleteOne: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('@api/modules/auth/totp.service', () => ({
+  totpService: {
+    setup: jest.fn(),
+    verify: jest.fn(),
+  },
+}));
+
+// Mock the rate-limit middleware so the auth limiter doesn't block test requests
+jest.mock('@api/middlewares/rate-limit.middleware', () => {
+  const passThrough = (_req: unknown, _res: unknown, next: () => void) => next();
+  return {
+    authLimiter: passThrough,
+    forgotPasswordLimiter: passThrough,
+    aiLimiter: passThrough,
+    paymentLimiter: passThrough,
+    generalLimiter: passThrough,
+  };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import express from 'express';
+import request from 'supertest';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { authRoutes } from '@api/modules/auth/auth.controller';
+import { UserModel } from '@api/modules/auth/models/user.model';
+import { sendAccountLockedEmail } from '@api/lib/email.service';
+import { auditLog } from '@api/modules/audit/audit.service';
+
+// This suite exercises only the /auth routes directly (rather than importing
+// the full app from '@api/app'), so it stays isolated from unrelated domain
+// modules (patients, payments, schedules, etc.) pulled in by the full app.
+const app = express();
+app.use(express.json());
+app.use('/api/v1/auth', authRoutes);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const CLINIC_ID = '507f1f77bcf86cd799439011';
+const USER_ID = '507f1f77bcf86cd799439022';
+const ADMIN_ID = '507f1f77bcf86cd799439099';
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: USER_ID,
+    _id: USER_ID,
+    email: 'doctor@clinic.com',
+    fullName: 'Dr. Test',
+    password: '$2a$12$hashedpassword',
+    role: 'DOCTOR',
+    clinicId: CLINIC_ID,
+    isActive: true,
+    mfaEnabled: false,
+    failedLoginAttempts: 0,
+    failedMfaAttempts: 0,
+    lockedUntil: undefined as Date | undefined,
+    preferences: { language: 'en' },
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeAdminToken(): string {
+  return jwt.sign(
+    { userId: ADMIN_ID, role: 'SUPER_ADMIN', clinicId: CLINIC_ID },
+    'test-access-secret-32-chars-long!!',
+    {
+      expiresIn: '15m',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+      jwtid: 'admin-jti-1',
+    }
+  );
+}
+
+function makeNonAdminToken(): string {
+  return jwt.sign(
+    { userId: USER_ID, role: 'DOCTOR', clinicId: CLINIC_ID },
+    'test-access-secret-32-chars-long!!',
+    {
+      expiresIn: '15m',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+      jwtid: 'doctor-jti-1',
+    }
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Account lockout', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('Failed attempt tracking', () => {
+    it('increments failedLoginAttempts on wrong password', async () => {
+      const user = makeUser({ failedLoginAttempts: 2 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'WrongPass1!' });
+
+      expect(user.failedLoginAttempts).toBe(3);
+      expect(user.lockedUntil).toBeUndefined();
+      expect(user.save).toHaveBeenCalled();
+    });
+
+    it('resets failedLoginAttempts and lockedUntil on successful login', async () => {
+      const user = makeUser({ failedLoginAttempts: 3 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'CorrectPass1!' });
+
+      expect(user.failedLoginAttempts).toBe(0);
+      expect(user.lockedUntil).toBeUndefined();
+    });
+  });
+
+  describe('Lockout enforcement', () => {
+    it('locks the account and returns 423 once MAX_FAILED_ATTEMPTS is reached', async () => {
+      const user = makeUser({ failedLoginAttempts: 4 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'WrongPass1!' });
+
+      expect(user.failedLoginAttempts).toBe(5);
+      expect(user.lockedUntil).toBeInstanceOf(Date);
+      expect(user.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('rejects login attempts with 423 + Retry-After while locked, without checking the password', async () => {
+      const lockedUntil = new Date(Date.now() + 10 * 60 * 1000);
+      const user = makeUser({ lockedUntil });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      const compareSpy = jest.spyOn(bcrypt, 'compare');
+
+      const res = await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'AnyPass1!' });
+
+      expect(res.status).toBe(423);
+      expect(res.body.error).toBe('AccountLocked');
+      expect(res.body).toHaveProperty('retryAfter');
+      expect(res.headers).toHaveProperty('retry-after');
+      expect(compareSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Lockout notification', () => {
+    it('sends an account-locked email when the account transitions to locked', async () => {
+      const user = makeUser({ failedLoginAttempts: 4 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'WrongPass1!' });
+
+      expect(sendAccountLockedEmail).toHaveBeenCalledWith(
+        user.email,
+        user.fullName,
+        expect.any(Number),
+        user.preferences.language
+      );
+    });
+
+    it('does not send an email for failed attempts below the threshold', async () => {
+      const user = makeUser({ failedLoginAttempts: 0 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'WrongPass1!' });
+
+      expect(sendAccountLockedEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Audit logging', () => {
+    it('writes an ACCOUNT_LOCKED audit entry when the account is locked', async () => {
+      const user = makeUser({ failedLoginAttempts: 4 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'WrongPass1!' });
+
+      expect(auditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'ACCOUNT_LOCKED',
+          userId: USER_ID,
+          metadata: expect.objectContaining({ email: user.email }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('does not write an audit entry for failed attempts below the threshold', async () => {
+      const user = makeUser({ failedLoginAttempts: 0 });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+
+      await request(app)
+        .post('/api/v1/auth/login')
+        .send({ email: 'doctor@clinic.com', password: 'WrongPass1!' });
+
+      expect(auditLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/v1/auth/unlock', () => {
+    it('returns 401 without a valid token', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/unlock')
+        .send({ email: 'doctor@clinic.com' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 when the caller is not a SUPER_ADMIN', async () => {
+      const res = await request(app)
+        .post('/api/v1/auth/unlock')
+        .set('Authorization', `Bearer ${makeNonAdminToken()}`)
+        .send({ email: 'doctor@clinic.com' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('Forbidden');
+    });
+
+    it('returns 404 when the target user does not exist', async () => {
+      (UserModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const res = await request(app)
+        .post('/api/v1/auth/unlock')
+        .set('Authorization', `Bearer ${makeAdminToken()}`)
+        .send({ email: 'nobody@nowhere.com' });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('resets failedLoginAttempts, failedMfaAttempts and lockedUntil for a SUPER_ADMIN caller', async () => {
+      const user = makeUser({
+        failedLoginAttempts: 5,
+        failedMfaAttempts: 3,
+        lockedUntil: new Date(Date.now() + 10 * 60 * 1000),
+      });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+      const res = await request(app)
+        .post('/api/v1/auth/unlock')
+        .set('Authorization', `Bearer ${makeAdminToken()}`)
+        .send({ email: user.email });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual({ unlocked: true, email: user.email });
+      expect(user.failedLoginAttempts).toBe(0);
+      expect(user.failedMfaAttempts).toBe(0);
+      expect(user.lockedUntil).toBeUndefined();
+      expect(user.save).toHaveBeenCalled();
+    });
+
+    it('writes an ACCOUNT_UNLOCKED audit entry', async () => {
+      const user = makeUser({
+        failedLoginAttempts: 5,
+        lockedUntil: new Date(Date.now() + 10 * 60 * 1000),
+      });
+      (UserModel.findOne as jest.Mock).mockResolvedValue(user);
+
+      await request(app)
+        .post('/api/v1/auth/unlock')
+        .set('Authorization', `Bearer ${makeAdminToken()}`)
+        .send({ email: user.email });
+
+      expect(auditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'ACCOUNT_UNLOCKED',
+          userId: USER_ID,
+          metadata: expect.objectContaining({ email: user.email }),
+        }),
+        expect.anything()
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -171,6 +171,16 @@ router.post(
           Math.round(LOCK_DURATION_MS / 60_000),
           user.preferences?.language
         );
+        await auditLog(
+          {
+            action: 'ACCOUNT_LOCKED',
+            userId: user.id,
+            clinicId: String(user.clinicId),
+            outcome: 'SUCCESS',
+            metadata: { email: user.email, failedLoginAttempts: user.failedLoginAttempts },
+          },
+          req
+        );
       }
       await user.save();
       return res.status(401).json({ error: 'Unauthorized', message: INVALID });
@@ -457,6 +467,16 @@ router.post(
       user.failedMfaAttempts = (user.failedMfaAttempts ?? 0) + 1;
       if (user.failedMfaAttempts >= MAX_MFA_ATTEMPTS) {
         user.lockedUntil = new Date(Date.now() + LOCK_DURATION_MS);
+        await auditLog(
+          {
+            action: 'ACCOUNT_LOCKED',
+            userId: user.id,
+            clinicId: String(user.clinicId),
+            outcome: 'SUCCESS',
+            metadata: { email: user.email, failedMfaAttempts: user.failedMfaAttempts },
+          },
+          req
+        );
       }
       await user.save();
       return res.status(400).json({ error: 'InvalidCode', message: 'Invalid TOTP code' });
@@ -625,8 +645,20 @@ router.post('/unlock', authenticate, async (req: Request, res: Response) => {
   if (!user) return res.status(404).json({ error: 'NotFound', message: 'User not found' });
 
   user.failedLoginAttempts = 0;
+  user.failedMfaAttempts = 0;
   user.lockedUntil = undefined;
   await user.save();
+
+  await auditLog(
+    {
+      action: 'ACCOUNT_UNLOCKED',
+      userId: user.id,
+      clinicId: String(user.clinicId),
+      outcome: 'SUCCESS',
+      metadata: { email: user.email, unlockedBy: req.user!.userId },
+    },
+    req
+  );
 
   return res.json({ status: 'success', data: { unlocked: true, email: user.email } });
 });

--- a/apps/api/src/modules/auth/change-password.test.ts
+++ b/apps/api/src/modules/auth/change-password.test.ts
@@ -82,11 +82,19 @@ jest.mock('@api/middlewares/rate-limit.middleware', () => {
 
 // ── Imports ───────────────────────────────────────────────────────────────────
 
+import express from 'express';
 import request from 'supertest';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import app from '@api/app';
+import { userRoutes } from '@api/modules/users/users.controller';
 import { UserModel } from '@api/modules/auth/models/user.model';
+
+// This suite exercises only the /users routes directly (rather than importing
+// the full app from '@api/app'), so it stays isolated from unrelated domain
+// modules (patients, payments, schedules, etc.) pulled in by the full app.
+const app = express();
+app.use(express.json());
+app.use('/api/v1/users', userRoutes);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -96,7 +104,12 @@ function makeToken(): string {
   return jwt.sign(
     { userId: TEST_USER_ID, role: 'DOCTOR', clinicId: 'clinic123' },
     'test-access-secret',
-    { expiresIn: '15m', issuer: 'health-watchers-api', audience: 'health-watchers-client' }
+    {
+      expiresIn: '15m',
+      issuer: 'health-watchers-api',
+      audience: 'health-watchers-client',
+      jwtid: 'test-jti-1',
+    }
   );
 }
 
@@ -199,6 +212,26 @@ describe('POST /api/v1/users/me/password', () => {
         .post('/api/v1/users/me/password')
         .set('Authorization', `Bearer ${token}`)
         .send({ currentPassword: 'OldPass1!', newPassword: 'Ab1!' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('ValidationError');
+    });
+
+    it('returns 400 when newPassword is 8+ characters but lacks complexity (e.g. no uppercase/special char)', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/me/password')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ currentPassword: 'OldPass1!', newPassword: 'lowercase1' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('ValidationError');
+    });
+
+    it('returns 400 when newPassword is a common password', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/me/password')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ currentPassword: 'OldPass1!', newPassword: 'Password123!' });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('ValidationError');

--- a/apps/api/src/modules/invoices/invoices.controller.ts
+++ b/apps/api/src/modules/invoices/invoices.controller.ts
@@ -9,15 +9,12 @@ import { ClinicSettingsModel } from '../clinics/clinic-settings.model';
 import { PatientModel } from '../patients/models/patient.model';
 import { PaymentRecordModel } from '../payments/models/payment-record.model';
 import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
+import { validateRequest } from '@api/middlewares/validate.middleware';
 import { asyncHandler } from '@api/utils/asyncHandler';
 import { paginate, parsePagination } from '@api/utils/paginate';
 import { sendInvoiceEmail } from '@api/lib/email.service';
 import { randomUUID } from 'crypto';
-import {
-  createInvoiceSchema,
-  listInvoicesQuerySchema,
-  idParamSchema,
-} from './invoices.validation';
+import { createInvoiceSchema, listInvoicesQuerySchema, idParamSchema } from './invoices.validation';
 import { z } from 'zod';
 
 const router = Router();
@@ -26,7 +23,12 @@ router.use(authenticate);
 const WRITE_ROLES = requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN');
 
 /** Build a Stellar payment URI per SEP-0007 */
-function stellarPayURI(destination: string, amount: string, assetCode: string, memo: string): string {
+function stellarPayURI(
+  destination: string,
+  amount: string,
+  assetCode: string,
+  memo: string
+): string {
   const params = new URLSearchParams({
     destination,
     amount,
@@ -56,13 +58,17 @@ router.post(
 
     const destination = settings?.stellarPublicKey ?? clinic?.stellarPublicKey;
     if (!destination) {
-      return res.status(400).json({ error: 'BadRequest', message: 'Clinic has no Stellar public key configured' });
+      return res
+        .status(400)
+        .json({ error: 'BadRequest', message: 'Clinic has no Stellar public key configured' });
     }
 
     const resolvedCurrency: 'XLM' | 'USDC' = currency ?? settings?.currency ?? 'XLM';
 
     // Compute totals
-    const computedItems = (lineItems as { description: string; quantity: number; unitPrice: string }[]).map((item) => ({
+    const computedItems = (
+      lineItems as { description: string; quantity: number; unitPrice: string }[]
+    ).map((item) => ({
       ...item,
       total: (item.quantity * parseFloat(item.unitPrice)).toFixed(7),
     }));
@@ -87,7 +93,7 @@ router.post(
     });
 
     return res.status(201).json({ status: 'success', data: invoice });
-  }),
+  })
 );
 
 // GET /invoices
@@ -107,7 +113,7 @@ router.get(
       data: result.data,
       pagination: result.meta,
     });
-  }),
+  })
 );
 
 // GET /invoices/:id
@@ -120,11 +126,19 @@ router.get(
       .lean();
     if (!invoice) return res.status(404).json({ error: 'NotFound', message: 'Invoice not found' });
 
-    const uri = stellarPayURI(invoice.stellarDestination, invoice.total, invoice.currency, invoice.stellarMemo);
+    const uri = stellarPayURI(
+      invoice.stellarDestination,
+      invoice.total,
+      invoice.currency,
+      invoice.stellarMemo
+    );
     const qrDataUrl = await buildQRDataUrl(uri);
 
-    return res.json({ status: 'success', data: { ...invoice, stellarPayURI: uri, qrCodeDataUrl: qrDataUrl } });
-  }),
+    return res.json({
+      status: 'success',
+      data: { ...invoice, stellarPayURI: uri, qrCodeDataUrl: qrDataUrl },
+    });
+  })
 );
 
 // GET /invoices/:id/pdf
@@ -132,7 +146,10 @@ router.get(
   '/:id/pdf',
   validateRequest({ params: idParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const invoice = await InvoiceModel.findOne({ _id: req.params.id, clinicId: req.user!.clinicId });
+    const invoice = await InvoiceModel.findOne({
+      _id: req.params.id,
+      clinicId: req.user!.clinicId,
+    });
     if (!invoice) return res.status(404).json({ error: 'NotFound', message: 'Invoice not found' });
 
     const [clinic, settings, patient] = await Promise.all([
@@ -141,10 +158,17 @@ router.get(
       PatientModel.findById(invoice.patientId).lean(),
     ]);
 
-    const uri = stellarPayURI(invoice.stellarDestination, invoice.total, invoice.currency, invoice.stellarMemo);
+    const uri = stellarPayURI(
+      invoice.stellarDestination,
+      invoice.total,
+      invoice.currency,
+      invoice.stellarMemo
+    );
     const qrDataUrl = await buildQRDataUrl(uri);
 
-    const patientName = patient ? `${(patient as any).firstName} ${(patient as any).lastName}` : 'Unknown';
+    const patientName = patient
+      ? `${(patient as any).firstName} ${(patient as any).lastName}`
+      : 'Unknown';
 
     const pdfStream = await generateInvoicePDF({
       invoice,
@@ -160,7 +184,7 @@ router.get(
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="${invoice.invoiceNumber}.pdf"`);
     pdfStream.pipe(res);
-  }),
+  })
 );
 
 // GET /invoices/:id/preview
@@ -168,7 +192,10 @@ router.get(
   '/:id/preview',
   validateRequest({ params: idParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const invoice = await InvoiceModel.findOne({ _id: req.params.id, clinicId: req.user!.clinicId });
+    const invoice = await InvoiceModel.findOne({
+      _id: req.params.id,
+      clinicId: req.user!.clinicId,
+    });
     if (!invoice) return res.status(404).json({ error: 'NotFound', message: 'Invoice not found' });
 
     const [clinic, settings, patient] = await Promise.all([
@@ -177,10 +204,17 @@ router.get(
       PatientModel.findById(invoice.patientId).lean(),
     ]);
 
-    const uri = stellarPayURI(invoice.stellarDestination, invoice.total, invoice.currency, invoice.stellarMemo);
+    const uri = stellarPayURI(
+      invoice.stellarDestination,
+      invoice.total,
+      invoice.currency,
+      invoice.stellarMemo
+    );
     const qrDataUrl = await buildQRDataUrl(uri);
 
-    const patientName = patient ? `${(patient as any).firstName} ${(patient as any).lastName}` : 'Unknown';
+    const patientName = patient
+      ? `${(patient as any).firstName} ${(patient as any).lastName}`
+      : 'Unknown';
 
     const pdfStream = await generateInvoicePDF({
       invoice,
@@ -196,7 +230,7 @@ router.get(
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `inline; filename="${invoice.invoiceNumber}.pdf"`);
     pdfStream.pipe(res);
-  }),
+  })
 );
 
 // POST /invoices/:id/send — email invoice to patient
@@ -205,19 +239,31 @@ router.post(
   WRITE_ROLES,
   validateRequest({ params: idParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const invoice = await InvoiceModel.findOne({ _id: req.params.id, clinicId: req.user!.clinicId });
+    const invoice = await InvoiceModel.findOne({
+      _id: req.params.id,
+      clinicId: req.user!.clinicId,
+    });
     if (!invoice) return res.status(404).json({ error: 'NotFound', message: 'Invoice not found' });
     if (invoice.status === 'cancelled') {
-      return res.status(400).json({ error: 'BadRequest', message: 'Cannot send a cancelled invoice' });
+      return res
+        .status(400)
+        .json({ error: 'BadRequest', message: 'Cannot send a cancelled invoice' });
     }
 
     const patient = await PatientModel.findById(invoice.patientId).lean();
     const patientEmail = (patient as any)?.email;
     if (!patientEmail) {
-      return res.status(400).json({ error: 'BadRequest', message: 'Patient has no email address on file' });
+      return res
+        .status(400)
+        .json({ error: 'BadRequest', message: 'Patient has no email address on file' });
     }
 
-    const uri = stellarPayURI(invoice.stellarDestination, invoice.total, invoice.currency, invoice.stellarMemo);
+    const uri = stellarPayURI(
+      invoice.stellarDestination,
+      invoice.total,
+      invoice.currency,
+      invoice.stellarMemo
+    );
     const qrDataUrl = await buildQRDataUrl(uri);
 
     sendInvoiceEmail(patientEmail, {
@@ -234,7 +280,7 @@ router.post(
     }
 
     return res.json({ status: 'success', message: 'Invoice sent' });
-  }),
+  })
 );
 
 const markPaidSchema = z.object({ txHash: z.string().min(1, 'txHash is required') });
@@ -247,9 +293,13 @@ router.post(
   asyncHandler(async (req: Request, res: Response) => {
     const { txHash } = req.body;
 
-    const invoice = await InvoiceModel.findOne({ _id: req.params.id, clinicId: req.user!.clinicId });
+    const invoice = await InvoiceModel.findOne({
+      _id: req.params.id,
+      clinicId: req.user!.clinicId,
+    });
     if (!invoice) return res.status(404).json({ error: 'NotFound', message: 'Invoice not found' });
-    if (invoice.status === 'paid') return res.status(409).json({ error: 'AlreadyPaid', message: 'Invoice already paid' });
+    if (invoice.status === 'paid')
+      return res.status(409).json({ error: 'AlreadyPaid', message: 'Invoice already paid' });
 
     // Create a linked payment intent record for traceability
     const intentId = randomUUID();
@@ -269,11 +319,11 @@ router.post(
     const updated = await InvoiceModel.findByIdAndUpdate(
       invoice._id,
       { status: 'paid', paidAt: new Date(), paidTxHash: txHash, paymentIntentId: intentId },
-      { new: true },
+      { new: true }
     );
 
     return res.json({ status: 'success', data: updated });
-  }),
+  })
 );
 
 export const invoiceRoutes = router;

--- a/apps/api/src/modules/lab-results/lab-results.controller.ts
+++ b/apps/api/src/modules/lab-results/lab-results.controller.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { LabResultModel } from './lab-result.model';
 import { toLabResultResponse } from './lab-results.transformer';
 import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
+import { validateRequest } from '@api/middlewares/validate.middleware';
 import { asyncHandler } from '../../utils/asyncHandler';
 import { paginate, parsePagination } from '../../utils/paginate';
 import { detectCriticalValues } from './critical-value.service';
@@ -41,8 +42,10 @@ router.post(
       status: 'ordered',
       orderedAt: new Date(),
     });
-    return res.status(201).json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
-  }),
+    return res
+      .status(201)
+      .json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
+  })
 );
 
 // GET /api/v1/lab-results — List lab results (filter by patient, status, date)
@@ -61,12 +64,18 @@ router.get(
     }
     const pagination = parsePagination(req.query as Record<string, any>);
     if (!pagination) {
-      return res.status(400).json({ error: 'ValidationError', message: 'limit must not exceed 100' });
+      return res
+        .status(400)
+        .json({ error: 'ValidationError', message: 'limit must not exceed 100' });
     }
     const { page, limit } = pagination;
     const result = await paginate(LabResultModel, filter, page, limit, { orderedAt: -1 });
-    return res.json({ status: 'success', data: result.data.map((d: any) => toLabResultResponse(d, req.user!.role)), meta: result.meta });
-  }),
+    return res.json({
+      status: 'success',
+      data: result.data.map((d: any) => toLabResultResponse(d, req.user!.role)),
+      meta: result.meta,
+    });
+  })
 );
 
 // GET /api/v1/lab-results/critical — Get pending critical value acknowledgments
@@ -81,8 +90,11 @@ router.get(
       .populate('patientId', 'firstName lastName')
       .populate('orderedBy', 'firstName lastName')
       .sort({ resultedAt: -1 });
-    return res.json({ status: 'success', data: docs.map((d) => toLabResultResponse(d, req.user!.role)) });
-  }),
+    return res.json({
+      status: 'success',
+      data: docs.map((d) => toLabResultResponse(d, req.user!.role)),
+    });
+  })
 );
 
 // GET /api/v1/lab-results/:id — Get lab result details
@@ -93,7 +105,7 @@ router.get(
     const doc = await LabResultModel.findOne({ _id: req.params.id, clinicId: req.user!.clinicId });
     if (!doc) return res.status(404).json({ error: 'NotFound', message: 'Lab result not found' });
     return res.json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
-  }),
+  })
 );
 
 // PUT /api/v1/lab-results/:id/results — Enter lab results (DOCTOR/NURSE)
@@ -118,7 +130,7 @@ router.put(
         isCritical,
         criticalReason: isCritical ? criticalReason : undefined,
       },
-      { new: true, runValidators: true },
+      { new: true, runValidators: true }
     );
 
     if (!doc) return res.status(404).json({ error: 'NotFound', message: 'Lab result not found' });
@@ -175,7 +187,7 @@ router.put(
       data: toLabResultResponse(doc, req.user!.role),
       ...(isCritical && { alert: { critical: true, reason: criticalReason } }),
     });
-  }),
+  })
 );
 
 // POST /api/v1/lab-results/:id/acknowledge — Acknowledge critical value
@@ -190,7 +202,7 @@ router.post(
         criticalAcknowledgedBy: req.user!.userId,
         criticalAcknowledgedAt: new Date(),
       },
-      { new: true },
+      { new: true }
     );
 
     if (!doc) {
@@ -208,7 +220,7 @@ router.post(
     });
 
     return res.json({ status: 'success', data: toLabResultResponse(doc, req.user!.role) });
-  }),
+  })
 );
 
 export const labResultRoutes = router;

--- a/apps/api/src/modules/referrals/referrals.controller.ts
+++ b/apps/api/src/modules/referrals/referrals.controller.ts
@@ -8,6 +8,7 @@ import { AuditLogModel } from '../audit/audit.model';
 import { ClinicModel } from '../clinics/clinic.model';
 import { UserModel } from '../auth/models/user.model';
 import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
+import { validateRequest } from '@api/middlewares/validate.middleware';
 import { asyncHandler } from '@api/utils/asyncHandler';
 import { parsePagination } from '@api/utils/paginate';
 import { sendReferralNotificationEmail } from '@api/lib/email.service';
@@ -34,15 +35,22 @@ router.post(
     const { toClinicId, patientId, reason, urgency, encounterId, sharedData, notes } = req.body;
 
     // Verify patient belongs to the referring clinic and has data_sharing consent
-    const patient = await PatientModel.findOne({ _id: patientId, clinicId: req.user!.clinicId, isActive: true });
+    const patient = await PatientModel.findOne({
+      _id: patientId,
+      clinicId: req.user!.clinicId,
+      isActive: true,
+    });
     if (!patient) return res.status(404).json({ error: 'NotFound', message: 'Patient not found' });
 
     if (!(patient as any).dataSharingConsent) {
-      return res.status(403).json({ error: 'ConsentRequired', message: 'Patient has not given data sharing consent' });
+      return res
+        .status(403)
+        .json({ error: 'ConsentRequired', message: 'Patient has not given data sharing consent' });
     }
 
     const toClinic = await ClinicModel.findById(toClinicId);
-    if (!toClinic) return res.status(404).json({ error: 'NotFound', message: 'Target clinic not found' });
+    if (!toClinic)
+      return res.status(404).json({ error: 'NotFound', message: 'Target clinic not found' });
 
     const referral = await ReferralModel.create({
       fromClinicId: req.user!.clinicId,
@@ -52,7 +60,12 @@ router.post(
       reason,
       urgency,
       encounterId: encounterId || undefined,
-      sharedData: sharedData ?? { demographics: true, encounters: false, labResults: false, prescriptions: false },
+      sharedData: sharedData ?? {
+        demographics: true,
+        encounters: false,
+        labResults: false,
+        prescriptions: false,
+      },
       notes,
     });
 
@@ -78,7 +91,7 @@ router.post(
     });
 
     return res.status(201).json({ status: 'success', data: referral });
-  }),
+  })
 );
 
 // GET /referrals/outgoing — referrals sent by this clinic
@@ -88,7 +101,9 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const pagination = parsePagination(req.query as Record<string, any>);
     if (!pagination) {
-      return res.status(400).json({ error: 'ValidationError', message: 'limit must not exceed 100' });
+      return res
+        .status(400)
+        .json({ error: 'ValidationError', message: 'limit must not exceed 100' });
     }
     const { page, limit } = pagination;
     const filter = { fromClinicId: req.user!.clinicId };
@@ -106,9 +121,16 @@ router.get(
     return res.json({
       status: 'success',
       data,
-      meta: { total, page, limit, totalPages, hasNextPage: page < totalPages, hasPrevPage: page > 1 },
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages,
+        hasNextPage: page < totalPages,
+        hasPrevPage: page > 1,
+      },
     });
-  }),
+  })
 );
 
 // GET /referrals/incoming — referrals received by this clinic
@@ -118,7 +140,9 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const pagination = parsePagination(req.query as Record<string, any>);
     if (!pagination) {
-      return res.status(400).json({ error: 'ValidationError', message: 'limit must not exceed 100' });
+      return res
+        .status(400)
+        .json({ error: 'ValidationError', message: 'limit must not exceed 100' });
     }
     const { page, limit } = pagination;
     const filter = { toClinicId: req.user!.clinicId };
@@ -136,9 +160,16 @@ router.get(
     return res.json({
       status: 'success',
       data,
-      meta: { total, page, limit, totalPages, hasNextPage: page < totalPages, hasPrevPage: page > 1 },
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages,
+        hasNextPage: page < totalPages,
+        hasPrevPage: page > 1,
+      },
     });
-  }),
+  })
 );
 
 // PUT /referrals/:id/accept
@@ -147,8 +178,13 @@ router.put(
   DOCTOR_ROLES,
   validateRequest({ params: idParamSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const referral = await ReferralModel.findOne({ _id: req.params.id, toClinicId: req.user!.clinicId, status: 'pending' });
-    if (!referral) return res.status(404).json({ error: 'NotFound', message: 'Pending referral not found' });
+    const referral = await ReferralModel.findOne({
+      _id: req.params.id,
+      toClinicId: req.user!.clinicId,
+      status: 'pending',
+    });
+    if (!referral)
+      return res.status(404).json({ error: 'NotFound', message: 'Pending referral not found' });
 
     referral.status = 'accepted';
     referral.acceptedBy = new Types.ObjectId(req.user!.userId);
@@ -166,7 +202,7 @@ router.put(
     });
 
     return res.json({ status: 'success', data: referral });
-  }),
+  })
 );
 
 // PUT /referrals/:id/decline
@@ -176,15 +212,20 @@ router.put(
   validateRequest({ params: idParamSchema, body: declineBodySchema }),
   asyncHandler(async (req: Request, res: Response) => {
     const { declinedReason } = req.body;
-    const referral = await ReferralModel.findOne({ _id: req.params.id, toClinicId: req.user!.clinicId, status: 'pending' });
-    if (!referral) return res.status(404).json({ error: 'NotFound', message: 'Pending referral not found' });
+    const referral = await ReferralModel.findOne({
+      _id: req.params.id,
+      toClinicId: req.user!.clinicId,
+      status: 'pending',
+    });
+    if (!referral)
+      return res.status(404).json({ error: 'NotFound', message: 'Pending referral not found' });
 
     referral.status = 'declined';
     referral.declinedReason = declinedReason;
     await referral.save();
 
     return res.json({ status: 'success', data: referral });
-  }),
+  })
 );
 
 // GET /referrals/:id/patient-data — access shared patient data (accepted referrals only)
@@ -197,7 +238,8 @@ router.get(
       toClinicId: req.user!.clinicId,
       status: 'accepted',
     });
-    if (!referral) return res.status(404).json({ error: 'NotFound', message: 'Accepted referral not found' });
+    if (!referral)
+      return res.status(404).json({ error: 'NotFound', message: 'Accepted referral not found' });
 
     const { sharedData, patientId } = referral;
     const result: Record<string, unknown> = {};
@@ -206,13 +248,19 @@ router.get(
       result.demographics = await PatientModel.findById(patientId).lean();
     }
     if (sharedData.encounters) {
-      result.encounters = await EncounterModel.find({ patientId, isActive: true }).sort({ createdAt: -1 }).lean();
+      result.encounters = await EncounterModel.find({ patientId, isActive: true })
+        .sort({ createdAt: -1 })
+        .lean();
     }
     if (sharedData.labResults) {
       result.labResults = await LabResultModel.find({ patientId }).sort({ orderedAt: -1 }).lean();
     }
     if (sharedData.prescriptions) {
-      const encounters = await EncounterModel.find({ patientId, isActive: true, prescriptions: { $exists: true, $ne: [] } }).lean();
+      const encounters = await EncounterModel.find({
+        patientId,
+        isActive: true,
+        prescriptions: { $exists: true, $ne: [] },
+      }).lean();
       result.prescriptions = encounters.flatMap((e: any) => e.prescriptions ?? []);
     }
 
@@ -229,7 +277,7 @@ router.get(
     });
 
     return res.json({ status: 'success', data: result });
-  }),
+  })
 );
 
 // PATCH /referrals/:id/outcome — record referral outcome
@@ -249,7 +297,8 @@ router.patch(
       toClinicId: req.user!.clinicId,
       status: 'accepted',
     });
-    if (!referral) return res.status(404).json({ error: 'NotFound', message: 'Accepted referral not found' });
+    if (!referral)
+      return res.status(404).json({ error: 'NotFound', message: 'Accepted referral not found' });
 
     referral.outcome = outcome as any;
     referral.outcomeDate = new Date();
@@ -282,7 +331,7 @@ router.patch(
     });
 
     return res.json({ status: 'success', data: referral });
-  }),
+  })
 );
 
 // GET /referrals/analytics — referral analytics and metrics
@@ -333,7 +382,7 @@ router.get(
         })),
       },
     });
-  }),
+  })
 );
 
 export const referralRoutes = router;

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -8,6 +8,7 @@ import { UserModel } from '../auth/models/user.model';
 import { ClinicModel } from '../clinics/clinic.model';
 import { totpService } from '../auth/totp.service';
 import { addToDenylist } from '@api/services/token-denylist.service';
+import { passwordSchema } from '../auth/auth.validation';
 
 const updateProfileSchema = z.object({
   fullName: z.string().min(1, 'Full name is required').max(100),
@@ -143,7 +144,7 @@ router.patch(
 
 const changePasswordSchema = z.object({
   currentPassword: z.string().min(1, 'Current password is required'),
-  newPassword: z.string().min(8, 'Password must be at least 8 characters'),
+  newPassword: passwordSchema,
 });
 
 /**

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -15,7 +15,7 @@ const resetPasswordSchema = z
   .object({
     password: z
       .string()
-      .min(12, 'At least 12 characters')
+      .min(8, 'At least 8 characters')
       .regex(/[A-Z]/, 'One uppercase letter required')
       .regex(/[a-z]/, 'One lowercase letter required')
       .regex(/[0-9]/, 'One digit required')

--- a/apps/web/src/components/ui/PasswordStrengthIndicator.tsx
+++ b/apps/web/src/components/ui/PasswordStrengthIndicator.tsx
@@ -6,7 +6,7 @@ interface Rule {
 }
 
 const RULES: Rule[] = [
-  { label: 'At least 12 characters', test: (p) => p.length >= 12 },
+  { label: 'At least 8 characters', test: (p) => p.length >= 8 },
   { label: 'One uppercase letter (A–Z)', test: (p) => /[A-Z]/.test(p) },
   { label: 'One lowercase letter (a–z)', test: (p) => /[a-z]/.test(p) },
   { label: 'One digit (0–9)', test: (p) => /[0-9]/.test(p) },

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -77,11 +77,34 @@
 - Automatic session expiration
 - Rotate service credentials regularly
 - Secrets management (AWS Secrets Manager)
+- Account lockout after repeated failed attempts
 
 **Detection:**
 - Alert on failed login spikes
 - Monitor geographic anomalies
 - Track privilege escalation attempts
+
+**Password Complexity Requirements**
+
+Enforced server-side (`apps/api/src/modules/auth/auth.validation.ts`, `passwordSchema`) on registration, password reset, and change-password, and mirrored in the web client UI:
+
+- Minimum 8 characters
+- At least one uppercase letter (A-Z)
+- At least one lowercase letter (a-z)
+- At least one digit (0-9)
+- At least one special character (non-alphanumeric)
+- Must not match a list of common/breached passwords
+
+**Account Lockout**
+
+Enforced server-side in `apps/api/src/modules/auth/auth.controller.ts`:
+
+- After 5 consecutive failed login attempts (`failedLoginAttempts`), the account is locked for 15 minutes (`lockedUntil`).
+- The same threshold and duration apply separately to failed MFA challenge attempts (`failedMfaAttempts`).
+- While locked, login/MFA-challenge requests return `423 Locked` with a `Retry-After` header.
+- A `SUPER_ADMIN` can manually unlock an account via `POST /auth/unlock`, which resets the failed-attempt counter.
+- The account holder receives an email notification when their account is locked.
+- Successful authentication resets the failed-attempt counters.
 
 #### Injection Attacks
 
@@ -230,23 +253,34 @@ async function canAccessPatient(userId: string, patientId: string) {
 
 **Database:**
 - MongoDB encryption at rest enabled
-- Separate encryption key per collection
-- Key rotation quarterly
+- Field-level AES-256-GCM encryption for PHI, independent of the database's own encryption at rest
+- Key rotation supported via versioned keys (see below)
 
 **Backups:**
 - Encrypted with separate key
 - Stored in secure S3 bucket
 - Key in AWS Secrets Manager
 
-**Code:**
-```typescript
-// Encrypt PHI before storage
-const encrypted = encryptPHI(patientData, encryptionKey);
-await db.collection('patients').insertOne(encrypted);
+**Field-level encryption (`apps/api/src/lib/encrypt.ts`):**
 
-// Decrypt when needed
-const decrypted = decryptPHI(patient, encryptionKey);
+`encrypt()`/`decrypt()` implement AES-256-GCM with a versioned key prefix (`v<n>:iv:ciphertext:tag`) so old ciphertext keeps decrypting after a key rotation. The active key comes from `FIELD_ENCRYPTION_KEY` (32-byte/64-char hex) with `FIELD_ENCRYPTION_KEY_VERSION`; prior key versions are kept available via `FIELD_ENCRYPTION_KEY_V<n>` for as long as data encrypted under them may still need to be read.
+
+```typescript
+import { encrypt, decrypt } from '@api/lib/encrypt';
+
+// Encrypt a PHI field before storage
+patient.contactNumber = encrypt(rawContactNumber);
+await patient.save();
+
+// Decrypt when read back
+const rawContactNumber = decrypt(patient.contactNumber);
 ```
+
+Currently applied to (`apps/api/src/modules/patients/models/patient.model.ts`, `PHI_FIELDS` / `INSURANCE_PHI_FIELDS`): `contactNumber`, `address`, `dateOfBirth`, `insurance.policyNumber`, `insurance.groupNumber` — encrypted/decrypted transparently via Mongoose hooks. Also used for the MFA TOTP secret (`user.mfaSecret`) in the auth module.
+
+`firstName`/`lastName` and encounter diagnosis fields are not currently in this list — they are used in patient search (`searchName` index) and diagnosis-code filtering (aggregation pipelines), so encrypting them requires a separate, dedicated change (e.g. blind-index/tokenization for searchable PHI) rather than the direct field-swap used above.
+
+Performance of the encryption path is covered by `apps/api/src/lib/encrypt.perf.test.ts`.
 
 #### Encryption in Transit
 


### PR DESCRIPTION
## Summary

Closes #1038 
closes #1039 
closes #1040 

All three security features already had substantial implementations on `main`; this PR closes the specific gaps found in each.

**Account Lockout (#1038)**
- Failed-attempt tracking, 15-min lockout after 5 attempts, manual `SUPER_ADMIN` unlock, and lockout email notification already existed.
- Added: audit log entries (`ACCOUNT_LOCKED` / `ACCOUNT_UNLOCKED`) for both login and MFA-challenge lockouts, and for the `/auth/unlock` endpoint.
- `POST /auth/unlock` now also resets `failedMfaAttempts`, not just `failedLoginAttempts`.
- Added `apps/api/src/modules/auth/account-lockout.test.ts` covering attempt tracking, lockout enforcement (423 + Retry-After), notification, audit logging, and the unlock endpoint (including 401/403/404 cases).
- Documented the concrete lockout policy in `docs/SECURITY_POLICY.md`.

**Password Complexity (#1039)**
- The canonical `passwordSchema` (8+ chars, upper/lower/digit/special, common-password check) was already enforced on registration and password reset.
- Fixed: the authenticated change-password endpoint (`POST /users/me/password`) was using a separate, weaker inline schema (length-only), silently bypassing all complexity/common-password checks for users changing their own password. It now reuses the shared `passwordSchema`.
- Fixed: the web reset-password form and `PasswordStrengthIndicator` required a 12-character minimum, inconsistent with the backend's 8-character minimum — aligned to 8.
- Documented the concrete password rules in `docs/SECURITY_POLICY.md`.
- Added test cases in `change-password.test.ts` covering weak-but-8-char and common passwords being rejected.

**Data Encryption at Rest (#1040)**
- AES-256-GCM field-level encryption with versioned key rotation (`apps/api/src/lib/encrypt.ts`) was already implemented and applied to patient PHI (`contactNumber`, `address`, `dateOfBirth`, insurance policy/group numbers) and the MFA TOTP secret, with an existing performance test.
- Fixed: `SECURITY.md` and `docs/SECURITY_POLICY.md` claimed name/DOB/diagnoses were encrypted and referenced a nonexistent `encryptPHI`/`decryptPHI` API. Docs now match the real `encrypt()`/`decrypt()` implementation and actual field coverage, and explicitly call out that name/diagnosis fields aren't covered yet since they're used in patient search and diagnosis-code aggregation queries that would need a different (e.g. blind-index) approach rather than a direct field swap.

**Incidental fixes (found while getting the test suite to actually run):**
- `apps/api/src/modules/{lab-results,referrals,invoices}/*.controller.ts` were missing the `validateRequest` import, which crashed the entire API at startup.
- The Sentry profiling test mock (`__mocks__/sentry-profiling-node.ts`) returned an object without a `name` field, which crashes `Sentry.init()` under the currently-installed `@sentry/core` version and was breaking every test suite that imports the app.

## Test plan
- [x] `apps/api/src/modules/auth/account-lockout.test.ts` — 13/13 passing (new file)
- [x] `apps/api/src/modules/auth/change-password.test.ts` — 13/13 passing (2 new cases + fixed a pre-existing missing-`jti` bug in the test's token helper that made every case 401 once the suite could actually run)
- [x] `eslint` on all changed files — no new errors/warnings vs. `main`
- [x] `tsc --noEmit` — no new errors vs. `main` (my `validateRequest` fixes actually removed several pre-existing TS2304 errors)
- Note: the broader existing test suite (`auth.routes.test.ts`, `refresh-token-rotation.test.ts`, `token.service.test.ts`, `audit.controller.test.ts`, etc.) has unrelated pre-existing failures on `main` (a broken zod `.partial()` call in `schedules.validation.ts`, a syntax error in `refresh-token-rotation.test.ts`, a missing `tempTokenSecret` in a test's config mock, a missing `cookie-parser` dependency, etc.) that are out of scope for this PR — worth a separate cleanup pass.