### PR TITLE
fix(security): anonymized exports, pentest remediation, API key hardening (#1045, #1046, #1047)

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -16,6 +16,12 @@ const config: Config = {
   moduleNameMapper: {
     '^@api/(.*)$': `${srcRoot}/$1`,
     '^@/(.*)$': `${srcRoot}/$1`,
+    // Resolve the anonymize workspace package explicitly rather than relying on
+    // npm workspace hoisting/symlinks to place it under node_modules.
+    '^@health-watchers/anonymize$': path.resolve(
+      __dirname,
+      '../../packages/anonymize/src/index.ts'
+    ),
     // Mock the rate-limit middleware so tests don't need redis installed.
     // Match both the @api alias and the resolved absolute path.
     '^@api/middlewares/rate-limit\\.middleware$': `${srcRoot}/__mocks__/rate-limit.middleware.ts`,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "@aws-sdk/client-s3": "^3.806.0",
     "@aws-sdk/s3-request-presigner": "^3.806.0",
     "@google/generative-ai": "^0.24.1",
+    "@health-watchers/anonymize": "*",
     "@health-watchers/config": "*",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.77.0",

--- a/apps/api/src/modules/api-keys/api-keys.controller.ts
+++ b/apps/api/src/modules/api-keys/api-keys.controller.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { ApiKeyModel, ALL_SCOPES, ApiKeyScope } from './models/api-key.model';
 import { ApiKeyUsageModel } from './models/api-key-usage.model';
 import { AuditService } from '../audit/audit.service';
+import logger from '@api/utils/logger';
 
 const sha256 = (val: string) => crypto.createHash('sha256').update(val).digest('hex');
 
@@ -10,6 +11,20 @@ const generateRawKey = () => {
   const randomBytes = crypto.randomBytes(32).toString('hex');
   return { rawKey: `hw_${randomBytes}`, prefix: `hw_${randomBytes.slice(0, 8)}` };
 };
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+/**
+ * Log the real error server-side and respond with a generic message in production —
+ * returning err.message directly leaked internal paths/schema details (see PENTEST_FINDINGS FIND-006).
+ */
+function sendServerError(res: Response, err: unknown, action: string) {
+  logger.error({ err }, `API key ${action} failed`);
+  return res.status(500).json({
+    error: 'ServerError',
+    message: isDev && err instanceof Error ? err.message : 'An unexpected error occurred',
+  });
+}
 
 // POST /api/v1/api-keys
 export const createApiKey = async (req: Request, res: Response) => {
@@ -66,7 +81,7 @@ export const createApiKey = async (req: Request, res: Response) => {
       },
     });
   } catch (err: any) {
-    return res.status(500).json({ error: 'ServerError', message: err.message });
+    return sendServerError(res, err, 'create');
   }
 };
 
@@ -77,7 +92,7 @@ export const listApiKeys = async (req: Request, res: Response) => {
     const keys = await ApiKeyModel.find({ clinicId }).lean();
     return res.json({ status: 'success', data: keys });
   } catch (err: any) {
-    return res.status(500).json({ error: 'ServerError', message: err.message });
+    return sendServerError(res, err, 'list');
   }
 };
 
@@ -116,7 +131,7 @@ export const updateApiKey = async (req: Request, res: Response) => {
 
     return res.json({ status: 'success', data: apiKey });
   } catch (err: any) {
-    return res.status(500).json({ error: 'ServerError', message: err.message });
+    return sendServerError(res, err, 'update');
   }
 };
 
@@ -167,7 +182,7 @@ export const rotateApiKey = async (req: Request, res: Response) => {
       },
     });
   } catch (err: any) {
-    return res.status(500).json({ error: 'ServerError', message: err.message });
+    return sendServerError(res, err, 'rotate');
   }
 };
 
@@ -200,7 +215,7 @@ export const revokeApiKey = async (req: Request, res: Response) => {
 
     return res.json({ status: 'success', data: { id: key._id, isActive: key.isActive } });
   } catch (err: any) {
-    return res.status(500).json({ error: 'ServerError', message: err.message });
+    return sendServerError(res, err, 'revoke');
   }
 };
 
@@ -218,6 +233,6 @@ export const getApiKeyUsage = async (req: Request, res: Response) => {
 
     return res.json({ status: 'success', data: usage });
   } catch (err: any) {
-    return res.status(500).json({ error: 'ServerError', message: err.message });
+    return sendServerError(res, err, 'usage lookup');
   }
 };

--- a/apps/api/src/modules/auth/jwt-claim-validator.ts
+++ b/apps/api/src/modules/auth/jwt-claim-validator.ts
@@ -91,6 +91,7 @@ export function validateJwtClaims(
   // Step 7: Verify signature (also re-checks iss, aud, exp via the library)
   try {
     const verified = jwt.verify(token, secret, {
+      algorithms: ['HS256'],
       issuer: expectedIssuer,
       audience: expectedAudience,
     }) as jwt.JwtPayload;

--- a/apps/api/src/modules/auth/token.service.ts
+++ b/apps/api/src/modules/auth/token.service.ts
@@ -77,6 +77,7 @@ export function signTempToken(userId: string): string {
 export function verifyAccessToken(token: string): (TokenPayload & { jti?: string }) | null {
   try {
     const decoded = jwt.verify(token, config.jwt.accessTokenSecret, {
+      algorithms: ['HS256'],
       issuer: JWT_ISSUER,
       audience: JWT_AUDIENCE,
     }) as JwtPayload;
@@ -120,6 +121,7 @@ export interface RefreshTokenPayload extends TokenPayload {
 export function verifyRefreshToken(token: string): RefreshTokenPayload | null {
   try {
     const decoded = jwt.verify(token, config.jwt.refreshTokenSecret, {
+      algorithms: ['HS256'],
       issuer: JWT_ISSUER,
       audience: JWT_AUDIENCE,
     }) as JwtPayload;
@@ -139,6 +141,7 @@ export function verifyRefreshToken(token: string): RefreshTokenPayload | null {
 export function verifyTempToken(token: string): string | null {
   try {
     const decoded = jwt.verify(token, config.jwt.tempTokenSecret, {
+      algorithms: ['HS256'],
       issuer: JWT_ISSUER,
       audience: JWT_AUDIENCE,
     }) as { userId: string };

--- a/apps/api/src/modules/auth/token.service.verify.ts
+++ b/apps/api/src/modules/auth/token.service.verify.ts
@@ -42,6 +42,7 @@ function signAccessToken(payload: TokenPayload): string {
 function verifyAccessToken(token: string): TokenPayload | null {
   try {
     const decoded = jwt.verify(token, mockConfig.jwt.accessTokenSecret, {
+      algorithms: ['HS256'],
       issuer: JWT_ISSUER,
       audience: JWT_AUDIENCE,
     }) as JwtPayload;

--- a/apps/api/src/modules/encounters/template-marketplace.service.ts
+++ b/apps/api/src/modules/encounters/template-marketplace.service.ts
@@ -1,5 +1,6 @@
 import { EncounterTemplateModel } from './encounter-template.model';
 import logger from '@api/utils/logger';
+import { escapeRegex } from '@api/utils/regex';
 
 interface TemplateImportInput {
   templateId: string;
@@ -73,13 +74,14 @@ export class TemplateMarketplaceService {
   }
 
   async searchMarketplace(query: string, tags?: string[], limit: number = 20, offset: number = 0) {
+    const safeQuery = escapeRegex(query);
     const searchQuery: Record<string, unknown> = {
       visibility: 'public',
       isApproved: true,
       $or: [
-        { name: { $regex: query, $options: 'i' } },
-        { description: { $regex: query, $options: 'i' } },
-        { category: { $regex: query, $options: 'i' } },
+        { name: { $regex: safeQuery, $options: 'i' } },
+        { description: { $regex: safeQuery, $options: 'i' } },
+        { category: { $regex: safeQuery, $options: 'i' } },
       ],
     };
 

--- a/apps/api/src/modules/export/export.anonymize.test.ts
+++ b/apps/api/src/modules/export/export.anonymize.test.ts
@@ -1,0 +1,151 @@
+import { PassThrough } from 'stream';
+import type { Response } from 'express';
+import * as anonymizeLib from '@health-watchers/anonymize';
+import { sendPatientJson, sendClinicZip } from './export.service';
+
+jest.mock('@health-watchers/anonymize', () => {
+  const actual = jest.requireActual('@health-watchers/anonymize');
+  return {
+    ...actual,
+    anonymize: jest.fn(actual.anonymize),
+    anonymizeBatch: jest.fn(actual.anonymizeBatch),
+  };
+});
+
+function makeJsonRes(): Response & { setHeader: jest.Mock; json: jest.Mock } {
+  const res: Record<string, unknown> = {};
+  res.setHeader = jest.fn();
+  res.json = jest.fn();
+  return res as unknown as Response & { setHeader: jest.Mock; json: jest.Mock };
+}
+
+const BASE_PATIENT = {
+  _id: 'p1',
+  systemId: 'HW-000001',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  dateOfBirth: '1990-05-15',
+  contactNumber: '555-1234',
+  address: '123 Main St',
+  clinicId: 'clinic1',
+};
+
+describe('export.service — anonymized JSON export (sendPatientJson)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('exports raw (non-anonymized) data by default', () => {
+    const res = makeJsonRes();
+    sendPatientJson(res, { patient: BASE_PATIENT, encounters: [], payments: [] });
+
+    expect(anonymizeLib.anonymize).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.anonymized).toBe(false);
+    expect(payload.data.patient.firstName).toBe('Jane');
+    expect(payload.data.patient.contactNumber).toBe('555-1234');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('HW-000001')
+    );
+  });
+
+  it('anonymizes the patient at the requested level and flags the response', () => {
+    const res = makeJsonRes();
+    sendPatientJson(
+      res,
+      { patient: BASE_PATIENT, encounters: [], payments: [] },
+      'de-identification'
+    );
+
+    expect(anonymizeLib.anonymize).toHaveBeenCalledWith(
+      BASE_PATIENT,
+      expect.objectContaining({ level: 'de-identification', purpose: 'export' })
+    );
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.anonymized).toBe(true);
+    expect(payload.data.patient.firstName).toBeUndefined();
+    expect(payload.data.patient.contactNumber).toBe('[REDACTED]');
+  });
+
+  it('never leaks the real systemId in the filename once anonymization is requested', () => {
+    const res = makeJsonRes();
+    sendPatientJson(
+      res,
+      { patient: BASE_PATIENT, encounters: [], payments: [] },
+      'pseudonymization'
+    );
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('patient-anonymized-export.json')
+    );
+    expect(res.setHeader).not.toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('HW-000001')
+    );
+  });
+
+  it('strips internal/secret fields regardless of anonymization', () => {
+    const res = makeJsonRes();
+    const patientWithSecrets = { ...BASE_PATIENT, password: 'hashed', mfaSecret: 'totp-secret' };
+    sendPatientJson(res, { patient: patientWithSecrets, encounters: [], payments: [] });
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data.patient.password).toBeUndefined();
+    expect(payload.data.patient.mfaSecret).toBeUndefined();
+  });
+});
+
+describe('export.service — anonymized ZIP export (sendClinicZip)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function makeZipRes(): Response & { setHeader: jest.Mock } {
+    const stream = new PassThrough() as PassThrough & { setHeader?: jest.Mock };
+    stream.setHeader = jest.fn();
+    return stream as unknown as Response & { setHeader: jest.Mock };
+  }
+
+  it('does not anonymize when no level is requested', async () => {
+    const res = makeZipRes();
+    const record = { patients: [BASE_PATIENT], encounters: [], payments: [], staff: [] };
+
+    const finished = new Promise((resolve) => res.on('finish', resolve).on('end', resolve));
+    sendClinicZip(res, 'clinic1', record);
+    res.resume();
+    await Promise.race([finished, new Promise((r) => setTimeout(r, 500))]);
+
+    expect(anonymizeLib.anonymizeBatch).not.toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/zip');
+  });
+
+  it('anonymizes the patient batch at the requested level before archiving', async () => {
+    const res = makeZipRes();
+    const record = { patients: [BASE_PATIENT], encounters: [], payments: [], staff: [] };
+
+    const finished = new Promise((resolve) => res.on('finish', resolve).on('end', resolve));
+    sendClinicZip(res, 'clinic1', record, 'de-identification');
+    res.resume();
+    await Promise.race([finished, new Promise((r) => setTimeout(r, 500))]);
+
+    expect(anonymizeLib.anonymizeBatch).toHaveBeenCalledWith(
+      [BASE_PATIENT],
+      expect.objectContaining({ level: 'de-identification', purpose: 'export' })
+    );
+  });
+
+  it('does not crash building the CSV summary once dateOfBirth becomes an age-range string', async () => {
+    // de-identification turns dateOfBirth into e.g. "45-49 years" — buildPatientCsv previously
+    // re-parsed that with `new Date()` and threw RangeError: Invalid time value on .toISOString().
+    const res = makeZipRes();
+    const record = { patients: [BASE_PATIENT], encounters: [], payments: [], staff: [] };
+
+    const errors: Error[] = [];
+    res.on('error', (err: Error) => errors.push(err));
+    const finished = new Promise((resolve) => res.on('finish', resolve).on('end', resolve));
+
+    expect(() => sendClinicZip(res, 'clinic1', record, 'de-identification')).not.toThrow();
+    res.resume();
+    await Promise.race([finished, new Promise((r) => setTimeout(r, 500))]);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/export/export.routes.ts
+++ b/apps/api/src/modules/export/export.routes.ts
@@ -4,6 +4,7 @@ import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
 import { auditLog } from '@api/modules/audit/audit.service';
 import logger from '@api/utils/logger';
 import { bulkExportLimiter } from '@api/middlewares/rate-limit.middleware';
+import { AnonymizationLevel } from '@health-watchers/anonymize';
 import {
   buildPatientRecord,
   sendPatientJson,
@@ -16,6 +17,27 @@ import { buildFhirBundle } from './fhir-mapper';
 
 /** Roles considered "authorized staff" for cross-patient access within a clinic */
 const STAFF_ROLES = ['SUPER_ADMIN', 'CLINIC_ADMIN', 'DOCTOR', 'NURSE', 'ASSISTANT'] as const;
+
+/** Anonymization levels safe to expose as an opt-in export flag (aggregation collapses per-record shape) */
+const EXPORTABLE_ANON_LEVELS = ['de-identification', 'pseudonymization'] as const;
+
+/** Parse and validate the `?anonymize=` query param, or send a 400 and return undefined */
+function parseAnonymizeParam(
+  req: Request,
+  res: Response
+): { ok: true; level: AnonymizationLevel | undefined } | { ok: false } {
+  const raw = (req.query.anonymize as string | undefined)?.toLowerCase();
+  if (!raw) return { ok: true, level: undefined };
+
+  if (!(EXPORTABLE_ANON_LEVELS as readonly string[]).includes(raw)) {
+    res.status(400).json({
+      error: 'BadRequest',
+      message: 'anonymize must be "de-identification" or "pseudonymization"',
+    });
+    return { ok: false };
+  }
+  return { ok: true, level: raw as AnonymizationLevel };
+}
 
 const router = Router();
 
@@ -43,6 +65,16 @@ router.get(
       return res
         .status(400)
         .json({ error: 'BadRequest', message: 'format must be "json" or "pdf"' });
+
+    const anonymizeResult = parseAnonymizeParam(req, res);
+    if (!anonymizeResult.ok) return;
+    const anonymizeLevel = anonymizeResult.level;
+
+    if (anonymizeLevel && format !== 'json')
+      return res.status(400).json({
+        error: 'BadRequest',
+        message: 'anonymize is only supported for format=json',
+      });
 
     try {
       const record = await buildPatientRecord(id);
@@ -80,11 +112,14 @@ router.get(
           resourceId: id,
           userId,
           clinicId,
+          metadata: anonymizeLevel
+            ? { anonymized: true, anonymizationLevel: anonymizeLevel }
+            : undefined,
         },
         req
       ).catch((err) => logger.error({ err }, 'Audit log failed for patient export'));
 
-      if (format === 'json') return sendPatientJson(res, record);
+      if (format === 'json') return sendPatientJson(res, record, anonymizeLevel);
       return sendPatientPdf(res, record);
     } catch (err: any) {
       logger.error({ err }, 'Patient export error');
@@ -113,6 +148,10 @@ router.get(
     if (!Types.ObjectId.isValid(id))
       return res.status(400).json({ error: 'BadRequest', message: 'Invalid clinic ID format' });
 
+    const anonymizeResult = parseAnonymizeParam(req, res);
+    if (!anonymizeResult.ok) return;
+    const anonymizeLevel = anonymizeResult.level;
+
     try {
       const record = await buildClinicRecord(id);
 
@@ -128,11 +167,14 @@ router.get(
           resourceId: id,
           userId: req.user!.userId,
           clinicId: req.user!.clinicId,
+          metadata: anonymizeLevel
+            ? { anonymized: true, anonymizationLevel: anonymizeLevel }
+            : undefined,
         },
         req
       ).catch((err) => logger.error({ err }, 'Audit log failed for clinic export'));
 
-      return sendClinicZip(res, id, record);
+      return sendClinicZip(res, id, record, anonymizeLevel);
     } catch (err: any) {
       logger.error({ err }, 'Clinic export error');
       return res.status(500).json({ error: 'InternalError', message: 'Export failed' });

--- a/apps/api/src/modules/export/export.service.ts
+++ b/apps/api/src/modules/export/export.service.ts
@@ -7,7 +7,7 @@ import { PaymentRecordModel } from '@api/modules/payments/models/payment-record.
 import { UserModel } from '@api/modules/auth/models/user.model';
 import { Types } from 'mongoose';
 import logger from '@api/utils/logger';
-import { anonymizeBatch } from '@health-watchers/anonymize';
+import { anonymize, anonymizeBatch, AnonymizationLevel } from '@health-watchers/anonymize';
 
 // ─── Sanitization ──────────────────────────────────────────────────────────
 
@@ -46,21 +46,34 @@ export async function buildPatientRecord(patientId: string): Promise<any> {
 /** Stream a sanitized JSON response for a patient record */
 export function sendPatientJson(
   res: Response,
-  rawData: NonNullable<Awaited<ReturnType<typeof buildPatientRecord>>>
+  rawData: NonNullable<Awaited<ReturnType<typeof buildPatientRecord>>>,
+  anonymizeLevel?: AnonymizationLevel
 ) {
+  const patientForExport = anonymizeLevel
+    ? anonymize(rawData.patient as any, { level: anonymizeLevel, purpose: 'export' })
+    : rawData.patient;
+
   const data = {
-    patient: sanitize(rawData.patient as any),
+    patient: sanitize(patientForExport as any),
     encounters: sanitizeAll(rawData.encounters as any[]),
     payments: sanitizeAll(rawData.payments as any[]),
   };
 
-  const patientSystemId = (rawData.patient as any).systemId || 'unknown';
+  // Never leak the real systemId in the filename once anonymization was requested
+  const patientSystemId = anonymizeLevel
+    ? 'anonymized'
+    : (rawData.patient as any).systemId || 'unknown';
   res.setHeader('Content-Type', 'application/json');
   res.setHeader(
     'Content-Disposition',
     `attachment; filename="patient-${patientSystemId}-export.json"`
   );
-  res.json({ status: 'success', exportedAt: new Date().toISOString(), data });
+  res.json({
+    status: 'success',
+    exportedAt: new Date().toISOString(),
+    anonymized: !!anonymizeLevel,
+    data,
+  });
 }
 
 /** Stream a PDF response for a patient record */
@@ -176,7 +189,8 @@ export async function buildClinicRecord(clinicId: string): Promise<any> {
 export function sendClinicZip(
   res: Response,
   clinicId: string,
-  record: Awaited<ReturnType<typeof buildClinicRecord>>
+  record: Awaited<ReturnType<typeof buildClinicRecord>>,
+  anonymizeLevel?: AnonymizationLevel
 ) {
   res.setHeader('Content-Type', 'application/zip');
   res.setHeader('Content-Disposition', `attachment; filename="clinic-${clinicId}-export.zip"`);
@@ -190,7 +204,14 @@ export function sendClinicZip(
 
   archive.pipe(res);
 
-  archive.append(JSON.stringify(sanitizeAll(record.patients as any[]), null, 2), {
+  const patientsForExport = anonymizeLevel
+    ? (anonymizeBatch(record.patients as any[], {
+        level: anonymizeLevel,
+        purpose: 'export',
+      }) as any[])
+    : (record.patients as any[]);
+
+  archive.append(JSON.stringify(sanitizeAll(patientsForExport), null, 2), {
     name: 'patients.json',
   });
   archive.append(JSON.stringify(sanitizeAll(record.encounters as any[]), null, 2), {
@@ -202,7 +223,7 @@ export function sendClinicZip(
   archive.append(JSON.stringify(sanitizeAll(record.staff as any[]), null, 2), {
     name: 'staff.json',
   });
-  archive.append(buildPatientCsv(record.patients as any[]), { name: 'patients-summary.csv' });
+  archive.append(buildPatientCsv(patientsForExport), { name: 'patients-summary.csv' });
 
   archive.finalize();
 }
@@ -228,6 +249,19 @@ function field(doc: PDFKit.PDFDocument, label: string, value: string) {
     .text(value);
 }
 
+/**
+ * Format a date field for CSV. Anonymization (e.g. de-identification) can replace
+ * `dateOfBirth` with a non-date string like "45-49 years" — pass those through as-is
+ * instead of feeding them back into `Date()`, which produced `Invalid Date` and threw
+ * on `.toISOString()`.
+ */
+function formatDateField(value: unknown, dateOnly: boolean): string {
+  if (!value) return '';
+  const date = new Date(value as string);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return dateOnly ? date.toISOString().split('T')[0]! : date.toISOString();
+}
+
 function buildPatientCsv(patients: any[]): string {
   const header =
     'systemId,firstName,lastName,dateOfBirth,sex,contactNumber,address,isActive,createdAt';
@@ -236,14 +270,14 @@ function buildPatientCsv(patients: any[]): string {
       p.systemId,
       p.firstName,
       p.lastName,
-      p.dateOfBirth ? new Date(p.dateOfBirth).toISOString().split('T')[0] : '',
+      formatDateField(p.dateOfBirth, true),
       p.sex,
       p.contactNumber || '',
       p.address || '',
       p.isActive,
-      p.createdAt ? new Date(p.createdAt).toISOString() : '',
+      formatDateField(p.createdAt, false),
     ]
-      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .map((v) => `"${(v == null ? '' : String(v)).replace(/"/g, '""')}"`)
       .join(',')
   );
   return [header, ...rows].join('\n');

--- a/apps/api/src/modules/icd10/icd10.controller.ts
+++ b/apps/api/src/modules/icd10/icd10.controller.ts
@@ -4,6 +4,7 @@ import { ICD10Model } from './icd10.model';
 import { authenticate } from '@api/middlewares/auth.middleware';
 import { validateRequest } from '@api/middlewares/validate.middleware';
 import { cacheResponse } from '@api/middlewares/cache.middleware';
+import { escapeRegex } from '@api/utils/regex';
 import {
   listFavorites,
   addFavorite,
@@ -68,7 +69,7 @@ icd10Routes.get(
       let results: ICD10SearchResult[];
       if (isCodeLike) {
         results = await ICD10Model.find({
-          code: { $regex: `^${q.toUpperCase()}`, $options: 'i' },
+          code: { $regex: `^${escapeRegex(q.toUpperCase())}`, $options: 'i' },
           isValid: true,
         })
           .select('code description category chapter')

--- a/apps/api/src/modules/patients/patients.controller.ts
+++ b/apps/api/src/modules/patients/patients.controller.ts
@@ -46,6 +46,7 @@ router.use(authenticate);
 
 const WRITE_ROLES = requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN');
 const ADMIN_ROLES = requireRoles('CLINIC_ADMIN', 'SUPER_ADMIN');
+const requireStaff = requireRoles('DOCTOR', 'CLINIC_ADMIN', 'SUPER_ADMIN', 'NURSE');
 
 const ALLOWED_PATCH_FIELDS = new Set([
   'firstName',
@@ -86,7 +87,12 @@ router.get(
     const page = Math.max(1, parseInt(req.query.page as string) || 1);
     const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
     const filter: Record<string, any> = { isActive: true };
-    if (req.query.clinicId) filter.clinicId = req.query.clinicId;
+    // Only SUPER_ADMIN may cross clinic boundaries; everyone else is scoped to their own clinic
+    // regardless of what the query param says (cross-clinic PHI access — see PENTEST_FINDINGS FIND-004).
+    filter.clinicId =
+      req.user!.role === 'SUPER_ADMIN' && req.query.clinicId
+        ? req.query.clinicId
+        : req.user!.clinicId;
 
     const result = await paginate(PatientModel, filter, page, limit);
     return res.json({
@@ -223,9 +229,11 @@ router.post(
   checkSubscriptionLimit('patients'),
   validateRequest({ body: createPatientSchema }),
   asyncHandler(async (req: Request, res: Response) => {
-    const { firstName, lastName, dateOfBirth, sex, contactNumber, address, clinicId } = req.body;
+    const { firstName, lastName, dateOfBirth, sex, contactNumber, address } = req.body;
     const searchName = `${firstName} ${lastName}`.toLowerCase();
-    const targetClinicId = clinicId || req.user!.clinicId;
+    // Never trust a client-supplied clinicId — always scope creation to the caller's own clinic
+    // (see PENTEST_FINDINGS FIND-004).
+    const targetClinicId = req.user!.clinicId;
     const systemId = await nextSystemId(targetClinicId);
     const doc = await withSpan('patient.create', { 'clinic.id': targetClinicId }, async () =>
       PatientModel.create({
@@ -265,10 +273,14 @@ router.put(
     }
     if (dateOfBirth) update.dateOfBirth = new Date(dateOfBirth);
 
-    const doc = await PatientModel.findByIdAndUpdate(req.params.id, update, { new: true });
+    const clinicId = req.user!.clinicId;
+    // Scope by clinicId so a caller can't update another clinic's patient by guessing its ID
+    // (see PENTEST_FINDINGS FIND-004).
+    const doc = await PatientModel.findOneAndUpdate({ _id: req.params.id, clinicId }, update, {
+      new: true,
+    });
     if (!doc) return res.status(404).json({ error: 'NotFound', message: 'Patient not found' });
 
-    const clinicId = req.user!.clinicId;
     await Promise.all([
       cache.del(`${clinicId}:patient:${req.params.id}`),
       cache.delPattern(`${clinicId}:GET:/dashboard*`),
@@ -331,8 +343,10 @@ router.delete(
   '/:id',
   ADMIN_ROLES,
   asyncHandler(async (req: Request, res: Response) => {
-    const doc = await PatientModel.findByIdAndUpdate(
-      req.params.id,
+    // Scope by clinicId so an admin can't deactivate another clinic's patient by guessing its ID
+    // (see PENTEST_FINDINGS FIND-004).
+    const doc = await PatientModel.findOneAndUpdate(
+      { _id: req.params.id, clinicId: req.user!.clinicId },
       { isActive: false },
       { new: true }
     );

--- a/apps/api/src/modules/portal/portal.controller.ts
+++ b/apps/api/src/modules/portal/portal.controller.ts
@@ -13,6 +13,7 @@ import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
 import { validateRequest } from '@api/middlewares/validate.middleware';
 import { asyncHandler } from '@api/utils/asyncHandler';
 import { paginate, parsePagination } from '@api/utils/paginate';
+import { escapeRegex } from '@api/utils/regex';
 import {
   signAccessToken,
   signRefreshToken,
@@ -406,9 +407,10 @@ router.get(
 
     if (threadId) filter.threadId = new Types.ObjectId(threadId);
     if (q) {
+      const safeQ = escapeRegex(q);
       filter.$or = [
-        { subject: { $regex: q, $options: 'i' } },
-        { body: { $regex: q, $options: 'i' } },
+        { subject: { $regex: safeQ, $options: 'i' } },
+        { body: { $regex: safeQ, $options: 'i' } },
       ];
     }
 

--- a/apps/api/src/modules/webhooks/webhooks.controller.ts
+++ b/apps/api/src/modules/webhooks/webhooks.controller.ts
@@ -5,7 +5,11 @@ import { authenticate, requireRoles } from '@api/middlewares/auth.middleware';
 import { validateRequest } from '@api/middlewares/validate.middleware';
 import logger from '@api/utils/logger';
 import { WebhookModel, WebhookDeliveryModel, WebhookEventLogModel } from './webhook.model';
-import { generateWebhookSecret, verifyWebhookSignature, enqueueWebhookDelivery } from './webhook.service';
+import {
+  generateWebhookSecret,
+  verifyWebhookSignature,
+  enqueueWebhookDelivery,
+} from './webhook.service';
 import {
   registerWebhookSchema,
   updateWebhookSchema,
@@ -73,10 +77,10 @@ router.post(
     const { transactionHash, amount, destination, memo, status } = req.body;
     const payloadString = JSON.stringify(req.body);
 
-    // Find matching webhook by destination (clinic's public key)
-    const webhook = await WebhookModel.findOne({
-      url: { $regex: destination },
-    });
+    // Find matching webhook by destination (clinic's public key).
+    // Exact match — this runs before signature verification, so treating `destination`
+    // (unauthenticated request body input) as a regex would allow ReDoS (see PENTEST_FINDINGS FIND-005).
+    const webhook = await WebhookModel.findOne({ url: destination });
 
     if (!webhook) {
       return res.status(404).json({

--- a/apps/api/src/services/socket.service.ts
+++ b/apps/api/src/services/socket.service.ts
@@ -39,7 +39,9 @@ export class SocketService {
           return next(new Error('Authentication token required'));
         }
 
-        const decoded = jwt.verify(token, process.env.JWT_SECRET!) as any;
+        const decoded = jwt.verify(token, process.env.JWT_SECRET!, {
+          algorithms: ['HS256'],
+        }) as any;
         const user = await UserModel.findById(decoded.userId).select('-password');
 
         if (!user) {

--- a/apps/api/src/utils/regex.test.ts
+++ b/apps/api/src/utils/regex.test.ts
@@ -1,0 +1,22 @@
+import { escapeRegex } from './regex';
+
+describe('escapeRegex', () => {
+  it('escapes regex metacharacters', () => {
+    expect(escapeRegex('a.b*c?d')).toBe('a\\.b\\*c\\?d');
+    expect(escapeRegex('(foo|bar)')).toBe('\\(foo\\|bar\\)');
+    expect(escapeRegex('[a-z]+')).toBe('\\[a-z\\]\\+');
+  });
+
+  it('leaves plain strings untouched', () => {
+    expect(escapeRegex('hello world')).toBe('hello world');
+  });
+
+  it('neutralizes a catastrophic-backtracking ReDoS payload as a literal match', () => {
+    const payload = 'a++++++++++++++++++++++++++++!';
+    const escaped = escapeRegex(payload);
+    const start = Date.now();
+    // eslint-disable-next-line security/detect-non-literal-regexp -- verifying escapeRegex neutralizes the payload
+    new RegExp(escaped, 'i').test('some unrelated text that does not match');
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+});

--- a/apps/api/src/utils/regex.ts
+++ b/apps/api/src/utils/regex.ts
@@ -1,0 +1,8 @@
+/**
+ * Escape regex metacharacters so untrusted input can be embedded in a MongoDB
+ * `$regex` filter as a literal substring match instead of a pattern — prevents
+ * ReDoS (catastrophic backtracking) from attacker-controlled search strings.
+ */
+export function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/docs/PENTEST_FINDINGS.md
+++ b/docs/PENTEST_FINDINGS.md
@@ -11,6 +11,8 @@
 
 Testing identified **9 vulnerabilities** across authentication, API key management, authorization, and data exposure categories. Two are rated Critical, three High, three Medium, and one Low. All findings are based on source code review and dynamic testing of the development environment.
 
+**Update (2026-07-29):** Re-test closed FIND-003, FIND-004, FIND-005, and FIND-006, and confirmed FIND-002 and FIND-008 were already mitigated by existing global middleware. See `PENTEST_REMEDIATION.md` for details. Only FIND-007 (rotation grace period) remains open — it requires a product decision on dual-key overlap vs. hard cutover, not a straightforward code fix.
+
 ---
 
 ## Severity Ratings
@@ -53,7 +55,7 @@ const apiKey = await ApiKeyModel.findOne({ keyHash, isActive: true })
 
 ### FIND-002 — No Rate Limiting on API Key Authentication
 **Severity:** Critical | **CVSS:** 9.1  
-**Status:** 🔴 Open  
+**Status:** 🟡 Mitigated — verified 2026-07-29  
 **Category:** Brute Force
 
 **Description:**  
@@ -74,11 +76,13 @@ done
 
 **Remediation:** Apply `generalLimiter` or a dedicated API key rate limiter before `authenticateApiKey`.
 
+**Verification (2026-07-29):** `generalLimiter` (300 req/15min per IP) is applied globally to `/api/v1` and `/api/v2` in `app.ts` ahead of all route handlers, so it already covers every API-key-authenticated request. The `authenticateApiKey` middleware itself (`middlewares/api-key.middleware.ts`) is not currently mounted on any route — the shipped API key feature only exposes the CRUD lifecycle (`/api/v1/api-keys`), so this attack surface isn't reachable today. Noted for whoever wires key-based request auth into protected routes: mount `authenticateApiKey` behind `generalLimiter` (already the case for anything under `/api/v1`) and consider a dedicated tighter limiter given key auth failures are a stronger brute-force signal than generic traffic.
+
 ---
 
 ### FIND-003 — JWT Algorithm Confusion Risk
 **Severity:** High | **CVSS:** 8.1  
-**Status:** 🟡 Mitigated (verify in config)  
+**Status:** ✅ Fixed — 2026-07-29  
 **Category:** Authentication
 
 **Description:**  
@@ -95,11 +99,13 @@ jwt.verify(token, secret, { algorithms: ['HS256'] })
 
 **Remediation:** Confirm `algorithms: ['HS256']` is explicit in every `jwt.verify()` call.
 
+**Fix (2026-07-29):** None of the 5 `jwt.verify()` call sites pinned `algorithms` — this was a real, live gap, not just a theoretical risk. Added `algorithms: ['HS256']` to all of them: `token.service.ts` (access, refresh, temp token verification), `jwt-claim-validator.ts`, `token.service.verify.ts` (manual verification script), and `socket.service.ts` (Socket.IO auth middleware).
+
 ---
 
 ### FIND-004 — Horizontal Privilege Escalation via clinicId in Body
 **Severity:** High | **CVSS:** 7.5  
-**Status:** 🔴 Open  
+**Status:** ✅ Fixed — 2026-07-29  
 **Category:** Authorization / IDOR
 
 **Description:**  
@@ -120,11 +126,17 @@ const clinicId = req.body.clinicId || req.user.clinicId; // VULNERABLE pattern
 
 **Remediation:** Always derive `clinicId` exclusively from `req.user.clinicId`. Never trust client-supplied `clinicId`.
 
+**Fix (2026-07-29):** Confirmed the vulnerable pattern was live in `patients.controller.ts`, and worse than originally scoped:
+- `GET /patients` had **no clinic filter at all** unless a `clinicId` query param was supplied — any authenticated user of any role could list every patient in the database. Now scoped to `req.user.clinicId` by default; only `SUPER_ADMIN` may override via the query param.
+- `POST /patients` used `clinicId` from the request body if present, letting any DOCTOR/CLINIC_ADMIN create patients under an arbitrary clinic. Now always uses `req.user.clinicId`.
+- `PUT /patients/:id` and `DELETE /patients/:id` used `findByIdAndUpdate(req.params.id, ...)` with no `clinicId` filter, letting staff of one clinic update or deactivate another clinic's patient by guessing/enumerating the ID. Both now filter by `{ _id, clinicId: req.user.clinicId }`.
+- `PATCH /patients/:id` was already correctly scoped and needed no change.
+
 ---
 
 ### FIND-005 — NoSQL Injection in Patient Search
 **Severity:** High | **CVSS:** 7.2  
-**Status:** 🟡 Partially Mitigated  
+**Status:** ✅ Fixed — 2026-07-29  
 **Category:** Injection
 
 **Description:**  
@@ -138,11 +150,15 @@ If this is passed directly to `{ name: { $regex: input } }`, it can cause catast
 
 **Remediation:** Escape regex special characters before use in `$regex` queries, or use `$text` indexes instead.
 
+**Fix (2026-07-29):** The patient search endpoint itself (`GET /patients/search`) already used a `$text` index, not `$regex` — not vulnerable. A repo-wide audit found the real unescaped-regex sites in four other places:
+- `webhooks.controller.ts` — inbound Stellar payment webhook matched `WebhookModel` by `{ url: { $regex: destination } }`, where `destination` is unauthenticated request-body input evaluated *before* signature verification. Changed to an exact match (`url: destination`), which was the intended semantics anyway.
+- `icd10.controller.ts`, `template-marketplace.service.ts`, `portal.controller.ts` — free-text search fields interpolated user input directly into `$regex`. Added a shared `escapeRegex()` helper (`apps/api/src/utils/regex.ts`) and applied it at all three sites so search input is matched literally instead of as a pattern.
+
 ---
 
 ### FIND-006 — Sensitive Data in Error Responses
 **Severity:** Medium | **CVSS:** 5.3  
-**Status:** 🔴 Open  
+**Status:** ✅ Fixed — 2026-07-29  
 **Category:** Information Disclosure
 
 **Description:**  
@@ -157,6 +173,8 @@ return res.status(500).json({ error: 'ServerError', message: err.message });
 **Impact:** Internal paths, library versions, and DB schema details exposed to attackers.
 
 **Remediation:** Return generic messages in production. Log full error internally. Use `errorHandler` middleware consistently.
+
+**Fix (2026-07-29):** The centralized `errorHandler` middleware already redacted correctly (`isDev` gate), but `api-keys.controller.ts` catches its own errors in try/catch blocks and never reaches it. Added a local `sendServerError()` helper that logs the real error via `logger.error` and returns `err.message` only when `NODE_ENV !== 'production'`, otherwise a generic message — applied to all 6 catch blocks (create, list, update, rotate, revoke, usage lookup). The legacy `api-key.controller.ts` (unused, superseded by `api-keys.controller.ts`) already returned generic messages and had no gap.
 
 ---
 
@@ -176,7 +194,7 @@ When `POST /api/v1/api-keys/:id/rotate` is called, the `keyHash` is replaced ato
 
 ### FIND-008 — CSRF Protection Bypassed for API Key Endpoints
 **Severity:** Medium | **CVSS:** 4.8  
-**Status:** 🟡 Requires Verification  
+**Status:** 🟢 Verified — not vulnerable (2026-07-29)  
 **Category:** CSRF
 
 **Description:**  
@@ -185,6 +203,8 @@ When `POST /api/v1/api-keys/:id/rotate` is called, the `keyHash` is replaced ato
 **Impact:** If cookie auth is used without CSRF token for API key management, an attacker can trick an admin into revoking or creating keys.
 
 **Remediation:** Confirm CSRF protection is enforced for any endpoint reachable via browser session, or require `X-Requested-With` header.
+
+**Verification (2026-07-29):** `csrfMiddleware` (double-submit cookie pattern) is registered in `app.ts` before any route is mounted, so it applies to every mutating request including `/api/v1/api-keys/*`. It only exempts `/auth/login`, `/auth/register`, `/csp-report`, and the HMAC-authenticated `/webhooks/stellar-payment` endpoint. No bypass found for API key management routes — closing as verified, no code change needed.
 
 ---
 

--- a/docs/PENTEST_REMEDIATION.md
+++ b/docs/PENTEST_REMEDIATION.md
@@ -8,17 +8,17 @@
 
 ## Remediation Priority Matrix
 
-| Finding | Severity | Effort | Priority | Owner | Target Date |
-|---------|----------|--------|----------|-------|-------------|
-| FIND-001 | Critical | Low | P0 — ✅ Done | API Team | 2026-06-29 |
-| FIND-002 | Critical | Low | P0 | API Team | 2026-07-06 |
-| FIND-003 | High | Low | P1 | Auth Team | 2026-07-06 |
-| FIND-004 | High | Medium | P1 | API Team | 2026-07-13 |
-| FIND-005 | High | Medium | P1 | API Team | 2026-07-13 |
-| FIND-006 | Medium | Low | P2 | API Team | 2026-07-20 |
-| FIND-007 | Medium | Medium | P2 | API Team | 2026-07-20 |
-| FIND-008 | Medium | Low | P2 | Auth Team | 2026-07-20 |
-| FIND-009 | Low | Low | P3 — ✅ Done | API Team | 2026-06-29 |
+| Finding | Severity | Effort | Priority | Owner | Target Date | Status |
+|---------|----------|--------|----------|-------|-------------|--------|
+| FIND-001 | Critical | Low | P0 — ✅ Done | API Team | 2026-06-29 | ✅ Done |
+| FIND-002 | Critical | Low | P0 | API Team | 2026-07-06 | 🟡 Mitigated (generalLimiter) |
+| FIND-003 | High | Low | P1 | Auth Team | 2026-07-06 | ✅ Done 2026-07-29 |
+| FIND-004 | High | Medium | P1 | API Team | 2026-07-13 | ✅ Done 2026-07-29 |
+| FIND-005 | High | Medium | P1 | API Team | 2026-07-13 | ✅ Done 2026-07-29 |
+| FIND-006 | Medium | Low | P2 | API Team | 2026-07-20 | ✅ Done 2026-07-29 |
+| FIND-007 | Medium | Medium | P2 | API Team | 2026-07-20 | 🔴 Open — needs product decision |
+| FIND-008 | Medium | Low | P2 | Auth Team | 2026-07-20 | 🟢 Verified, no gap |
+| FIND-009 | Low | Low | P3 — ✅ Done | API Team | 2026-06-29 | ✅ Done |
 
 ---
 
@@ -44,9 +44,11 @@ const apiKey = await ApiKeyModel.findOne({ keyHash, isActive: true })
 
 ### FIND-002 — Rate Limiting on API Key Authentication
 
-**Status:** Open
+**Status:** 🟡 Mitigated — verified 2026-07-29
 
-**Implementation:**
+`generalLimiter` (300 req/15min per IP) is already applied globally to `/api/v1` and `/api/v2` in `app.ts`, ahead of every route. The `authenticateApiKey` request-auth middleware described in this finding isn't currently wired into any route — only the API key CRUD lifecycle (`/api/v1/api-keys`) is exposed, and that's covered by `generalLimiter` like everything else. No dedicated limiter was added since the specific attack surface (`authenticateApiKey`) isn't reachable yet; when it is wired up, mount it behind `generalLimiter` (automatic under `/api/v1`) and consider a tighter dedicated limiter given key-auth failures are a stronger brute-force signal than generic traffic.
+
+**Implementation (for reference, if a dedicated limiter is added later):**
 
 1. Add a dedicated limiter in `middlewares/rate-limit.middleware.ts`:
 
@@ -68,29 +70,35 @@ export const apiKeyLimiter = rateLimit({
 
 ---
 
-### FIND-003 — JWT Algorithm Confusion
+### FIND-003 — JWT Algorithm Confusion ✅ COMPLETE
 
-**Status:** Verify in code review
+**Status:** Resolved 2026-07-29
 
 **Action:**  
-Audit every `jwt.verify()` call in `apps/api/src/modules/auth/token.service.verify.ts` and confirm:
+Audited every `jwt.verify()` call across `apps/api/src` — all 5 call sites omitted `algorithms`, confirming this was a live gap, not just a theoretical risk:
+- `token.service.ts` — access token, refresh token, and temp token verification (3 calls)
+- `token.service.verify.ts` — standalone manual verification script
+- `jwt-claim-validator.ts` — claim validation helper
+- `socket.service.ts` — Socket.IO connection auth middleware
 
-```typescript
-// Required pattern — algorithms must be explicit
-const payload = jwt.verify(token, secret, { algorithms: ['HS256'] });
-```
+All 5 now pin `{ algorithms: ['HS256'] }`, matching the algorithm used by `jwt.sign()` throughout the codebase.
 
-If any `jwt.verify()` call omits `algorithms`, add it immediately.
-
-**Verification:** Run `grep -r "jwt.verify" apps/api/src` and confirm every call has `algorithms`.
+**Verification:** `grep -r "jwt.verify" apps/api/src` — every call now has `algorithms`.
 
 ---
 
-### FIND-004 — Horizontal Privilege Escalation via clinicId
+### FIND-004 — Horizontal Privilege Escalation via clinicId ✅ COMPLETE
 
-**Status:** Open
+**Status:** Resolved 2026-07-29
 
-**Fix pattern** — apply to all controllers:
+Audited `patients.controller.ts` (the file named in this finding) and found the vulnerability was live and broader than originally scoped:
+- `GET /patients` — no clinic filter applied at all unless a `clinicId` query param was passed; now scoped to `req.user.clinicId` by default, with `SUPER_ADMIN`-only override via query param (matching the existing pattern in `payments/analytics.controller.ts`).
+- `POST /patients` — used `req.body.clinicId` if present; now always uses `req.user.clinicId`.
+- `PUT /patients/:id` and `DELETE /patients/:id` — updated/deactivated by `_id` alone with no clinic filter; both now use `findOneAndUpdate({ _id, clinicId: req.user.clinicId }, ...)`.
+
+`encounters.controller.ts` and `payments/*.controller.ts` were also checked; both already derive `clinicId` exclusively from `req.user.clinicId`.
+
+**Fix pattern applied:**
 
 ```typescript
 // WRONG — never do this
@@ -110,9 +118,15 @@ const clinicId = req.user!.clinicId;
 
 ---
 
-### FIND-005 — ReDoS via Unescaped Regex in Search
+### FIND-005 — ReDoS via Unescaped Regex in Search ✅ COMPLETE
 
-**Status:** Open
+**Status:** Resolved 2026-07-29
+
+The patient search endpoint named in this finding (`GET /patients/search`) already used a `$text` index rather than `$regex` — not vulnerable. A repo-wide `grep -rn '\$regex'` found the real unescaped sites:
+- `webhooks.controller.ts` — inbound webhook matched by `{ url: { $regex: destination } }` using unauthenticated body input, evaluated before signature verification. Changed to an exact-match `{ url: destination }`.
+- `icd10.controller.ts`, `template-marketplace.service.ts`, `portal.controller.ts` — free-text search interpolated user input directly into `$regex`.
+
+Added `apps/api/src/utils/regex.ts` (`escapeRegex()`) and applied it at the three remaining sites so input is matched literally.
 
 **Fix:** Escape regex metacharacters before passing to MongoDB:
 
@@ -130,9 +144,11 @@ Alternatively, use MongoDB `$text` index for full-text search, which does not su
 
 ---
 
-### FIND-006 — Sensitive Data in Error Responses
+### FIND-006 — Sensitive Data in Error Responses ✅ COMPLETE
 
-**Status:** Open
+**Status:** Resolved 2026-07-29
+
+The global `errorHandler` middleware already gated `err.message`/stack behind `isDev` — no change needed there. The gap was `api-keys.controller.ts`, which catches errors locally in try/catch and returns `err.message` directly, bypassing `errorHandler` entirely. Added a `sendServerError()` helper in that file that logs the real error via `logger.error` and returns `err.message` only outside production, applied to all 6 catch blocks. (`api-key.controller.ts`, the older unused module, already used generic messages.)
 
 **Fix:**
 
@@ -193,16 +209,13 @@ Document that integrations must update their key before the next rotation. Add r
 
 ---
 
-### FIND-008 — CSRF on API Key Endpoints
+### FIND-008 — CSRF on API Key Endpoints ✅ VERIFIED, NO GAP
 
-**Status:** Verify
+**Status:** Verified 2026-07-29 — not vulnerable
 
-**Action:**
-1. Confirm `csrfMiddleware` is applied to all mutation routes that could be reached by a browser session.
-2. If API key routes are Bearer-token only (not cookie session), CSRF is not applicable — document this explicitly.
-3. If any portal/web session can reach these endpoints without CSRF, apply the middleware.
+`csrfMiddleware` (double-submit cookie) is registered in `app.ts` before any route is mounted, so it applies globally to every mutating request, including `/api/v1/api-keys/*`. It exempts only `/auth/login`, `/auth/register`, `/csp-report`, and the HMAC-verified `/webhooks/stellar-payment` endpoint. No bypass exists for API key management routes — no code change required.
 
-**Verification:** Attempt a cross-origin POST to `/api/v1/api-keys` without `X-CSRF-Token` header — must return 403.
+**Verification:** Attempt a cross-origin POST to `/api/v1/api-keys` without `X-CSRF-Token` header — returns 403 (confirmed by reading `csrf.middleware.ts`; it validates on every non-safe method except the explicit exemption list above).
 
 ---
 
@@ -216,12 +229,12 @@ All `AuditService.log()` calls in `api-keys.controller.ts` now pass `req` as the
 
 ## Re-test Schedule
 
-| Phase | Findings | Target Date |
-|-------|----------|-------------|
-| Re-test P0 | FIND-001, FIND-009 | 2026-06-29 — Complete |
-| Re-test P1 | FIND-002, FIND-003, FIND-004, FIND-005 | 2026-07-20 |
-| Re-test P2 | FIND-006, FIND-007, FIND-008 | 2026-07-27 |
-| Final sign-off | All findings | 2026-08-03 |
+| Phase | Findings | Target Date | Status |
+|-------|----------|--------------|--------|
+| Re-test P0 | FIND-001, FIND-009 | 2026-06-29 | ✅ Complete |
+| Re-test P1 | FIND-002, FIND-003, FIND-004, FIND-005 | 2026-07-20 | ✅ Complete 2026-07-29 (FIND-002 mitigated by existing middleware, rest fixed) |
+| Re-test P2 | FIND-006, FIND-007, FIND-008 | 2026-07-27 | 🟡 Partial — FIND-006 fixed, FIND-008 verified with no gap, FIND-007 still open |
+| Final sign-off | All findings | 2026-08-03 | Blocked on FIND-007 product decision |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@aws-sdk/client-s3": "^3.806.0",
         "@aws-sdk/s3-request-presigner": "^3.806.0",
         "@google/generative-ai": "^0.24.1",
+        "@health-watchers/anonymize": "*",
         "@health-watchers/config": "*",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.77.0",
@@ -68,6 +69,9 @@
       },
       "devDependencies": {
         "@pact-foundation/pact": "^14.0.0",
+        "@stryker-mutator/core": "^8.7.1",
+        "@stryker-mutator/jest-runner": "^8.7.1",
+        "@stryker-mutator/typescript-checker": "^8.7.1",
         "@types/archiver": "^7.0.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.19",
@@ -93,10 +97,7 @@
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.9.3",
-        "@stryker-mutator/core": "^8.7.1",
-        "@stryker-mutator/jest-runner": "^8.7.1",
-        "@stryker-mutator/typescript-checker": "^8.7.1"
+        "typescript": "^5.9.3"
       }
     },
     "apps/api/node_modules/@apidevtools/json-schema-ref-parser": {
@@ -3809,7 +3810,6 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -4181,7 +4181,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
       "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
@@ -5389,7 +5388,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.3.0.tgz",
       "integrity": "sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
@@ -5436,7 +5434,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
       "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
@@ -26223,7 +26220,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -29614,6 +29611,427 @@
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
       }
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-8.7.1.tgz",
+      "integrity": "sha512-56vxcVxIfW0jxJhr7HB9Zx6Xr5/M95RG9MUK1DtbQhlmQesjpfBBsrPLOPzBJaITPH/vOYykuJ69vgSAMccQyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.3.0",
+        "mutation-testing-report-schema": "3.3.0",
+        "tslib": "~2.7.0",
+        "typed-inject": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/api/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-8.7.1.tgz",
+      "integrity": "sha512-r2AwhHWkHq6yEe5U8mAzPSWewULbv9YMabLHRzLjZnjj+Ipxtg+Zo22rrUc2Zl7mnYvb9w34bdlEzGz6MKgX2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.0",
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/instrumenter": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "ajv": "~8.17.1",
+        "chalk": "~5.3.0",
+        "commander": "~12.1.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.4.0",
+        "execa": "~9.4.0",
+        "file-url": "~4.0.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~9.0.5",
+        "mutation-testing-elements": "3.4.0",
+        "mutation-testing-metrics": "3.3.0",
+        "mutation-testing-report-schema": "3.3.0",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.7.0",
+        "typed-inject": "~4.0.0",
+        "typed-rest-client": "~2.1.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/execa": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.4.1.tgz",
+      "integrity": "sha512-5eo/BRqZm3GYce+1jqX/tJ7duA2AnE39i88fuedNFUV8XxGxUpF3aWkBRfbUcjV49gCkvS/pzc0YrCPhaIewdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-8.7.1.tgz",
+      "integrity": "sha512-HSq4VHXesQCMR3hr6bn41DAeJ0yuP2vp9KSnls2TySNawFVWOCaKXpBX29Skj3zJQh7dnm7HuQg8HuXvJK15oA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.25.2",
+        "@babel/generator": "~7.25.0",
+        "@babel/parser": "~7.25.0",
+        "@babel/plugin-proposal-decorators": "~7.24.7",
+        "@babel/plugin-proposal-explicit-resource-management": "^7.24.7",
+        "@babel/preset-typescript": "~7.24.7",
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "angular-html-parser": "~6.0.2",
+        "semver": "~7.6.3",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.9.tgz",
+      "integrity": "sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helpers": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/generator": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
+      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.9.tgz",
+      "integrity": "sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-8.7.1.tgz",
+      "integrity": "sha512-507jgu9E0yNDwMN56p4J+iFI77+rPDLDV91qYGbBI6fvy5c7rBQ63l64FtAFMTG75f4gCZ6C/Pq3nXTQx6PMjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "semver": "~7.6.3",
+        "tslib": "~2.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "~8.7.0"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@stryker-mutator/typescript-checker": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-8.7.1.tgz",
+      "integrity": "sha512-ZliTju52pOR9Xnh1AjGn4Oet7lTWjbDbi6RfoBGAPzVSZSYcZNnupr3tBtDJX4p2qVYYfYvmhoAKYXbe30dWBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "8.7.1",
+        "@stryker-mutator/util": "8.7.1",
+        "semver": "~7.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "~8.7.0",
+        "typescript": ">=3.6"
+      }
+    },
+    "node_modules/@stryker-mutator/typescript-checker/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-8.7.1.tgz",
+      "integrity": "sha512-Oj/sIHZI1GLfGOHKnud4Gw0ZRufm7ONoQYNnhcaAYEXTWraYVcV7mue/th8fZComTHvDPA8Ge8U16FvWYEb8dg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@svgr/core": {
       "version": "8.1.0",
@@ -55482,7 +55900,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -55501,7 +55919,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -55514,7 +55932,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -61898,7 +62315,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -69684,427 +70101,6 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
-    },
-    "node_modules/@stryker-mutator/api": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-8.7.1.tgz",
-      "integrity": "sha512-56vxcVxIfW0jxJhr7HB9Zx6Xr5/M95RG9MUK1DtbQhlmQesjpfBBsrPLOPzBJaITPH/vOYykuJ69vgSAMccQyw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mutation-testing-metrics": "3.3.0",
-        "mutation-testing-report-schema": "3.3.0",
-        "tslib": "~2.7.0",
-        "typed-inject": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@stryker-mutator/api/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@stryker-mutator/core": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-8.7.1.tgz",
-      "integrity": "sha512-r2AwhHWkHq6yEe5U8mAzPSWewULbv9YMabLHRzLjZnjj+Ipxtg+Zo22rrUc2Zl7mnYvb9w34bdlEzGz6MKgX2g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@inquirer/prompts": "^6.0.0",
-        "@stryker-mutator/api": "8.7.1",
-        "@stryker-mutator/instrumenter": "8.7.1",
-        "@stryker-mutator/util": "8.7.1",
-        "ajv": "~8.17.1",
-        "chalk": "~5.3.0",
-        "commander": "~12.1.0",
-        "diff-match-patch": "1.0.5",
-        "emoji-regex": "~10.4.0",
-        "execa": "~9.4.0",
-        "file-url": "~4.0.0",
-        "lodash.groupby": "~4.6.0",
-        "minimatch": "~9.0.5",
-        "mutation-testing-elements": "3.4.0",
-        "mutation-testing-metrics": "3.3.0",
-        "mutation-testing-report-schema": "3.3.0",
-        "npm-run-path": "~6.0.0",
-        "progress": "~2.0.3",
-        "rxjs": "~7.8.1",
-        "semver": "^7.6.3",
-        "source-map": "~0.7.4",
-        "tree-kill": "~1.2.2",
-        "tslib": "2.7.0",
-        "typed-inject": "~4.0.0",
-        "typed-rest-client": "~2.1.0"
-      },
-      "bin": {
-        "stryker": "bin/stryker.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@stryker-mutator/core/node_modules/execa": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.4.1.tgz",
-      "integrity": "sha512-5eo/BRqZm3GYce+1jqX/tJ7duA2AnE39i88fuedNFUV8XxGxUpF3aWkBRfbUcjV49gCkvS/pzc0YrCPhaIewdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.3",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.0",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@stryker-mutator/core/node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@stryker-mutator/instrumenter": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-8.7.1.tgz",
-      "integrity": "sha512-HSq4VHXesQCMR3hr6bn41DAeJ0yuP2vp9KSnls2TySNawFVWOCaKXpBX29Skj3zJQh7dnm7HuQg8HuXvJK15oA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "~7.25.2",
-        "@babel/generator": "~7.25.0",
-        "@babel/parser": "~7.25.0",
-        "@babel/plugin-proposal-decorators": "~7.24.7",
-        "@babel/plugin-proposal-explicit-resource-management": "^7.24.7",
-        "@babel/preset-typescript": "~7.24.7",
-        "@stryker-mutator/api": "8.7.1",
-        "@stryker-mutator/util": "8.7.1",
-        "angular-html-parser": "~6.0.2",
-        "semver": "~7.6.3",
-        "weapon-regex": "~1.3.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.9.tgz",
-      "integrity": "sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-module-transforms": "^7.25.9",
-        "@babel/helpers": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/generator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
-      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.25.9",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.9.tgz",
-      "integrity": "sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.25.9"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@stryker-mutator/jest-runner": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-8.7.1.tgz",
-      "integrity": "sha512-507jgu9E0yNDwMN56p4J+iFI77+rPDLDV91qYGbBI6fvy5c7rBQ63l64FtAFMTG75f4gCZ6C/Pq3nXTQx6PMjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stryker-mutator/api": "8.7.1",
-        "@stryker-mutator/util": "8.7.1",
-        "semver": "~7.6.3",
-        "tslib": "~2.7.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@stryker-mutator/core": "~8.7.0"
-      }
-    },
-    "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@stryker-mutator/jest-runner/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@stryker-mutator/typescript-checker": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-8.7.1.tgz",
-      "integrity": "sha512-ZliTju52pOR9Xnh1AjGn4Oet7lTWjbDbi6RfoBGAPzVSZSYcZNnupr3tBtDJX4p2qVYYfYvmhoAKYXbe30dWBQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stryker-mutator/api": "8.7.1",
-        "@stryker-mutator/util": "8.7.1",
-        "semver": "~7.6.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@stryker-mutator/core": "~8.7.0",
-        "typescript": ">=3.6"
-      }
-    },
-    "node_modules/@stryker-mutator/typescript-checker/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@stryker-mutator/util": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-8.7.1.tgz",
-      "integrity": "sha512-Oj/sIHZI1GLfGOHKnud4Gw0ZRufm7ONoQYNnhcaAYEXTWraYVcV7mue/th8fZComTHvDPA8Ge8U16FvWYEb8dg==",
-      "dev": true,
-      "license": "Apache-2.0"
     }
   }
 }

--- a/packages/anonymize/src/index.test.ts
+++ b/packages/anonymize/src/index.test.ts
@@ -315,6 +315,26 @@ describe('Level: aggregation (anonymizeBatch)', () => {
   it('throws for unsupported level on single record', () => {
     expect(() => anonymize(BASE_PATIENT, { level: 'aggregation' as AnonymizationLevel })).toThrow();
   });
+
+  it('throws for an unrecognized level string on a single record', () => {
+    expect(() =>
+      anonymize(BASE_PATIENT, { level: 'not-a-real-level' as AnonymizationLevel })
+    ).toThrow();
+  });
+
+  it('propagates the throw when batch de-identifying with an unrecognized level', () => {
+    expect(() =>
+      anonymizeBatch(PATIENTS, { level: 'not-a-real-level' as AnonymizationLevel })
+    ).toThrow();
+  });
+
+  it('handles a completely empty patient object without throwing', () => {
+    expect(() => anonymize({}, DE_ID)).not.toThrow();
+    expect(() => anonymize({}, PSEUDO)).not.toThrow();
+    const r = anonymize({}, DE_ID);
+    expect(r.firstName).toBeUndefined();
+    expect(r.contactNumber).toBe('[REDACTED]');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -385,7 +405,8 @@ describe('Clinical notes — PII stripping', () => {
   });
 
   it('handles undefined clinicalNotes', () => {
-    const r = anonymize({ ...BASE_PATIENT, clinicalNotes: undefined }, DE_ID);
+    const { clinicalNotes: _clinicalNotes, ...withoutNotes } = BASE_PATIENT;
+    const r = anonymize(withoutNotes, DE_ID);
     expect(r.clinicalNotes).toBeUndefined();
   });
 
@@ -439,8 +460,8 @@ describe('Edge cases — names and identifiers', () => {
     const r = anonymize({ dateOfBirth: '1982-01-01' }, DE_ID);
     const match = r.dateOfBirth?.match(/^(\d+)-(\d+) years$/);
     expect(match).not.toBeNull();
-    const low = parseInt(match![1]);
-    const high = parseInt(match![2]);
+    const low = parseInt(match![1]!);
+    const high = parseInt(match![2]!);
     expect(high - low).toBe(4);
     expect(low % 5).toBe(0);
   });
@@ -619,12 +640,13 @@ describe('Property-based tests — PII pattern matching', () => {
   it('age range always matches NNN-NNN years format with 5-year bucket', () => {
     fc.assert(
       fc.property(fc.date({ min: new Date('1920-01-01'), max: new Date('2005-12-31') }), (dob) => {
-        const r = anonymize({ dateOfBirth: dob.toISOString().split('T')[0] }, DE_ID);
+        const dateOfBirth = dob.toISOString().split('T')[0]!;
+        const r = anonymize({ dateOfBirth }, DE_ID);
         if (!r.dateOfBirth) return true;
         const m = r.dateOfBirth.match(/^(\d+)-(\d+) years$/);
         if (!m) return false;
-        const low = parseInt(m[1]);
-        const high = parseInt(m[2]);
+        const low = parseInt(m[1]!);
+        const high = parseInt(m[2]!);
         return high - low === 4 && low % 5 === 0;
       })
     );

--- a/packages/anonymize/src/index.ts
+++ b/packages/anonymize/src/index.ts
@@ -21,14 +21,14 @@ export interface PatientData {
 }
 
 export interface AnonymizedPatientData {
-  firstName?: string;
-  lastName?: string;
-  dateOfBirth?: string;
-  contactNumber?: string;
-  address?: string;
-  email?: string;
-  systemId?: string;
-  clinicalNotes?: string;
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  dateOfBirth?: string | undefined;
+  contactNumber?: string | undefined;
+  address?: string | undefined;
+  email?: string | undefined;
+  systemId?: string | undefined;
+  clinicalNotes?: string | undefined;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

- **closes #1045 — Data Anonymization**: adds an opt-in `?anonymize=de-identification|pseudonymization` export flag for patient (`/patients/:id/export`) and clinic (`/clinics/:id/export`) exports, backed by the existing `packages/anonymize` library. Also fixes a crash where the clinic ZIP's CSV summary re-parsed an already-anonymized `dateOfBirth` (e.g. `"45-49 years"`) with `new Date()`, throwing `RangeError: Invalid time value`.
- **closes #1047 — API Key Management**: verified key generation, rotation, revocation, and audit logging (already implemented in `api-keys.controller.ts`) meet the acceptance criteria and are covered by tests. Hardened error handling so a failure no longer leaks `err.message` (internal paths/schema details) to API clients in production.
- **closes #1046 — Penetration Testing**: re-tested every finding in `docs/PENTEST_FINDINGS.md` / `PENTEST_REMEDIATION.md` against current code and fixed what was still open:
  - **FIND-003** (JWT algorithm confusion): none of the 5 `jwt.verify()` call sites pinned `algorithms` — added `{ algorithms: ['HS256'] }` to all of them.
  - **FIND-004** (cross-clinic IDOR): `patients.controller.ts` let any authenticated user list/create/update/deactivate another clinic's patients via a trusted `clinicId` in the query/body, or by ID alone with no clinic filter. All four routes now scope to `req.user.clinicId` (SUPER_ADMIN may still override the list filter via query param).
  - **FIND-005** (ReDoS): added a shared `escapeRegex()` helper (`apps/api/src/utils/regex.ts`) and applied it to unescaped user input flowing into MongoDB `$regex` (ICD-10 search, encounter template marketplace, portal messages); switched the inbound Stellar webhook lookup to an exact match instead of `$regex`.
  - **FIND-006** (error message leakage): `api-keys.controller.ts` returned `err.message` directly; added a helper that logs the real error server-side and redacts it in production.
  - **FIND-002** (rate limiting) and **FIND-008** (CSRF) were verified as already mitigated by existing global middleware (`generalLimiter`, `csrfMiddleware`) — no code change needed there.
  - **FIND-007** (rotation grace period) remains open — it's a product decision (dual-key overlap vs. hard cutover), not documented here as a straightforward fix.

## Test plan

- [x] `packages/anonymize` unit tests pass (89 tests)
- [x] Added `apps/api/src/modules/export/export.anonymize.test.ts` covering anonymized/raw JSON export and clinic ZIP export, including a regression test for the CSV date-parsing crash
- [x] Added `apps/api/src/utils/regex.test.ts` for `escapeRegex()`, including a ReDoS-payload timing check
- [x] `apps/api/src/modules/api-keys/__tests__/api-key-management.test.ts` (create/rotate/revoke/audit) passes unchanged
- [x] `tsc --noEmit` shows no new type errors introduced (compared against `main` baseline)
- [x] Spot-checked affected suites (auth, patients, export, api-keys, icd10, webhooks) against the `main` baseline to confirm no regressions from these changes

Note: `patients.controller.ts` has pre-existing, unrelated breakage on `main` (undefined `DuplicateController`, missing `merge.service.ts`, ~30 pre-existing TypeScript errors) that predates this PR and is out of scope here — happy to file a separate issue for it.